### PR TITLE
KA10: Add DeCoriolis clock.

### DIFF
--- a/PDP10/ka10_defs.h
+++ b/PDP10/ka10_defs.h
@@ -310,6 +310,7 @@ extern DEVICE   rcb_dev;
 extern DEVICE   dc_dev;
 extern DEVICE   dt_dev;
 extern DEVICE   dk_dev;
+extern DEVICE   pd_dev;
 
 extern t_stat (*dev_tab[128])(uint32 dev, uint64 *data);
 
@@ -362,6 +363,7 @@ int  df10_write(struct df10 *df);
 #define NUM_DEVS_RP     2
 #define NUM_DEVS_RS     0
 #define NUM_DEVS_TU     1
+#define NUM_DEVS_PD     1
 /* Global data */
 
 extern t_bool sim_idle_enab;

--- a/PDP10/ka10_pd.c
+++ b/PDP10/ka10_pd.c
@@ -1,0 +1,120 @@
+/* ka10_pd.c: DeCoriolis clock.
+
+   Copyright (c) 2018, Lars Brinkhoff
+
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and associated documentation files (the "Software"),
+   to deal in the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+   RICHARD CORNWELL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   This is a device which keeps track of the time and date.  An access
+   will return the number of ticks since the beginning of the year.
+   There are 60 ticks per second.  The device was made by Paul
+   DeCoriolis at MIT.
+
+   When used with a KL10, the clock was part of the KL-UDGE board
+   which could also provide a 60 Hz interrupt and set console lights.
+   This is not needed on a KA10, so it's not implemented here.
+
+*/
+
+#include <time.h>
+#include "ka10_defs.h"
+
+#define PD_DEVNUM       0500
+#define PD_OFF          (1 << DEV_V_UF)
+
+t_stat         pd_devio(uint32 dev, uint64 *data);
+const char     *pd_description (DEVICE *dptr);
+t_stat         pd_set_on(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
+t_stat         pd_set_off(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
+t_stat         pd_show_on(FILE *st, UNIT *uptr, int32 val, CONST void *desc);
+
+UNIT                pd_unit[] = {
+    {UDATA(NULL, UNIT_FIX, 0)},  /* 0 */
+};
+DIB pd_dib = {PD_DEVNUM, 1, &pd_devio, NULL};
+
+MTAB pd_mod[] = {
+    { MTAB_VDV, 0, "ON", "ON", pd_set_on, pd_show_on },
+    { MTAB_VDV, PD_OFF, NULL, "OFF", pd_set_off },
+    { 0 }
+    };
+
+DEVICE              pd_dev = {
+    "PD", pd_unit, NULL, pd_mod,
+    1, 8, 0, 1, 8, 36,
+    NULL, NULL, NULL, NULL, NULL, NULL,
+    &pd_dib, DEV_DISABLE | DEV_DEBUG, 0, NULL,
+    NULL, NULL, NULL, NULL, NULL, &pd_description
+};
+
+static uint64 pd_ticks (void)
+{
+    time_t t = time(NULL);
+    struct tm *x = localtime(&t);
+    uint64 seconds;
+    seconds = 86400ULL * x->tm_yday;
+    seconds += 3600ULL * x->tm_hour;
+    seconds +=   60ULL * x->tm_min;
+    seconds +=           x->tm_sec;
+    // We could add individual ticks here, but there's no pressing need.
+    return 60ULL * seconds;
+}
+
+t_stat pd_devio(uint32 dev, uint64 *data)
+{
+    DEVICE *dptr = &pd_dev;
+
+    switch(dev & 07) {
+    case DATAI:
+        if (dptr->flags & PD_OFF)
+            *data = 0;
+        else
+            *data = pd_ticks();
+        break;
+    default:
+        break;
+    }
+
+    return SCPE_OK;
+}
+
+const char *pd_description (DEVICE *dptr)
+{
+    return "Paul DeCoriolis clock";
+}
+
+t_stat pd_set_on(UNIT *uptr, int32 val, CONST char *cptr, void *desc)
+{
+    DEVICE *dptr = &pd_dev;
+    dptr->flags &= ~PD_OFF;    
+    return SCPE_OK;
+}
+
+t_stat pd_set_off(UNIT *uptr, int32 val, CONST char *cptr, void *desc)
+{
+    DEVICE *dptr = &pd_dev;
+    dptr->flags |= PD_OFF;    
+    return SCPE_OK;
+}
+
+t_stat pd_show_on(FILE *st, UNIT *uptr, int32 val, CONST void *desc)
+{
+    DEVICE *dptr = &pd_dev;
+    fprintf (st, "%s", (dptr->flags & PD_OFF) ? "off" : "on");
+    return SCPE_OK;
+}
+

--- a/PDP10/ka10_sys.c
+++ b/PDP10/ka10_sys.c
@@ -126,6 +126,9 @@ DEVICE *sim_devices[] = {
 #if (NUM_DEVS_DK > 0)
     &dk_dev,
 #endif
+#if (NUM_DEVS_PD > 0)
+    &pd_dev,
+#endif
     NULL
     };
 

--- a/makefile
+++ b/makefile
@@ -1100,7 +1100,7 @@ KA10 = ${KA10D}/ka10_cpu.c ${KA10D}/ka10_sys.c ${KA10D}/ka10_df.c \
 	${KA10D}/ka10_lp.c ${KA10D}/ka10_pt.c ${KA10D}/ka10_dc.c \
 	${KA10D}/ka10_rp.c ${KA10D}/ka10_rc.c ${KA10D}/ka10_dt.c \
 	${KA10D}/ka10_dk.c ${KA10D}/ka10_cr.c ${KA10D}/ka10_cp.c \
-	${KA10D}/ka10_tu.c ${KA10D}/ka10_rs.c
+	${KA10D}/ka10_tu.c ${KA10D}/ka10_rs.c ${KA10D}/ka10_pd.c
 KA10_OPT = -DKA=1 -DUSE_INT64 -I $(KA10D) -DUSE_SIM_CARD
 
 


### PR DESCRIPTION
Here's a pull request made against your latest master.

The clock can be turned on or off.  When off, it reads as zero.  This condition is detected by ITS, which will emit a warning.