### PR TITLE
KA10: Fix bug in ASHC.

### DIFF
--- a/PDP10/ka10_cpu.c
+++ b/PDP10/ka10_cpu.c
@@ -3536,7 +3536,7 @@ fxnorm:
                          FLAGS |= OVR|TRP1;
                          check_apr_irq();
                       }
-                      AR = (AD & SMASK) | ((AR << (SC - 35)) & CMASK);
+                      AR = (AD & SMASK) | ((MQ << (SC - 35)) & CMASK);
                       MQ = (AD & SMASK);
                  } else {
                       if ((((AD & CMASK) << SC) & ~CMASK) != ((AR << SC) & ~CMASK)) {


### PR DESCRIPTION
Wrong accumulator as source operand.