### PR TITLE
KA10: Stanford keyboard

### DIFF
--- a/PDP10/ka10_defs.h
+++ b/PDP10/ka10_defs.h
@@ -323,6 +323,7 @@ extern DEVICE   pd_dev;
 extern DEVICE   dpy_dev;
 extern DEVICE   imx_dev;
 extern DEVICE   imp_dev;
+extern DEVICE   stk_dev;
 extern DEVICE   tk10_dev;
 extern DEVICE   mty_dev;
 extern DEVICE   wcnsls_dev;             /* MIT Spacewar Consoles */
@@ -395,6 +396,7 @@ extern void ka10_lights_clear_aux (int);
 #define NUM_DEVS_TU     1
 #define NUM_DEVS_PD     ITS
 #define NUM_DEVS_IMX    ITS
+#define NUM_DEVS_STK    ITS
 #define NUM_DEVS_TK10   ITS
 #define NUM_DEVS_MTY    ITS
 #define NUM_DEVS_DPY    USE_DISPLAY

--- a/PDP10/ka10_dpy.c
+++ b/PDP10/ka10_dpy.c
@@ -244,7 +244,7 @@ t_stat dpy_devio(uint32 dev, uint64 *data) {
         uptr->STAT_REG &= ~CONO_MASK;
         uptr->STAT_REG |= *data & CONO_MASK;
         if (*data & CONO_INIT)
-            dpy_update_status( uptr, ty340_reset(), 1);
+            dpy_update_status( uptr, ty340_reset(&dpy_dev), 1);
         sim_debug(DEBUG_CONO, &dpy_dev, "DPY %03o CONO %06o PC=%06o %06o\n",
                   dev, (uint32)*data, PC, uptr->STAT_REG & ~STAT_VALID);
         break;
@@ -298,7 +298,7 @@ t_stat dpy_reset (DEVICE *dptr)
 {
     if (!(dptr->flags & DEV_DIS)) {
         display_reset();
-        ty340_reset();
+        ty340_reset(dptr);
     }
     sim_cancel (&dpy_unit[0]);             /* deactivate unit */
     return SCPE_OK;

--- a/PDP10/ka10_stk.c
+++ b/PDP10/ka10_stk.c
@@ -1,0 +1,152 @@
+/* ka10_stk.c: Stanford keyboard.
+
+   Copyright (c) 2018, Lars Brinkhoff
+
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and associated documentation files (the "Software"),
+   to deal in the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+   RICHARD CORNWELL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   This is a device which interfaces with a Stanford keyboard.  It's
+   specific to the MIT AI lab PDP-10.
+*/
+
+#include <time.h>
+#include "display/display.h"
+#include "ka10_defs.h"
+
+#define STK_DEVNUM      070
+
+/* CONI/O bits. */
+#define STK_PIA         0000007
+#define STK_DONE        0000010
+
+/* Bucky bits. */
+#define SHFT   00100
+#define CTRL   00200
+#define TOP    00400
+#define META   01000
+
+static t_stat      stk_svc (UNIT *uptr);
+static t_stat      stk_devio(uint32 dev, uint64 *data);
+static const char  *stk_description (DEVICE *dptr);
+
+static uint64 status = 0;
+static int key_code = 0;
+
+UNIT                stk_unit[] = {
+    {UDATA(stk_svc, UNIT_DISABLE, 0)},  /* 0 */
+};
+DIB stk_dib = {STK_DEVNUM, 1, &stk_devio, NULL};
+
+MTAB stk_mod[] = {
+    { 0 }
+    };
+
+DEVICE              stk_dev = {
+    "STK", stk_unit, NULL, stk_mod,
+    1, 8, 0, 1, 8, 36,
+    NULL, NULL, NULL, NULL, NULL, NULL,
+    &stk_dib, DEV_DISABLE | DEV_DIS | DEV_DEBUG, 0, NULL,
+    NULL, NULL, NULL, NULL, NULL, &stk_description
+};
+
+/* Special key codes. */
+#define CR    033
+#define BKSL  034
+#define LF    035
+#define TAB   045
+#define FF    046
+#define VT    047
+#define BS    074
+#define ALT   077 /* Not sure if 42, 75, 76, or 77. */
+
+/* This maps ASCII codes to Stanford key codes plus bucky bits. */
+static int translate[] = {
+  0,       CTRL|001,CTRL|002,CTRL|003,CTRL|004,CTRL|005,CTRL|006,CTRL|007,
+  CTRL|010,TAB,     LF,      VT,      FF,      CR,      CTRL|016,CTRL|017,
+  CTRL|020,CTRL|021,CTRL|022,CTRL|023,CTRL|024,CTRL|025,CTRL|026,CTRL|027,
+  CTRL|030,CTRL|031,CTRL|032,ALT,     CTRL|034,CTRL|035,0,       CTRL|037,
+  ' ',     SHFT|',',TOP|031, TOP|022, SHFT|'6',SHFT|'7',TOP|024, TOP|011,
+  '(',     ')',     '*',     '+',     ',',     '-',     '.',     '/',
+  '0',     '1',     '2',     '3',     '4',     '5',     '6',     '7',
+  '8',     '9',     ':',     ';',     TOP|004, TOP|010, TOP|006, TOP|'.',
+  TOP|005, SHFT|001,SHFT|002,SHFT|003,SHFT|004,SHFT|005,SHFT|006,SHFT|007,
+  SHFT|010,SHFT|011,SHFT|012,SHFT|013,SHFT|014,SHFT|015,SHFT|016,SHFT|017,
+  SHFT|020,SHFT|021,SHFT|022,SHFT|023,SHFT|024,SHFT|025,SHFT|026,SHFT|027,
+  SHFT|030,SHFT|031,SHFT|032,TOP|'(', BKSL,    TOP|')', 0,       TOP|'9',
+  TOP|025, 001,     002,     003,     004,     005,     006,     007,
+  010,     011,     012,     013,     014,     015,     016,     017,
+  020,     021,     022,     023,     024,     025,     026,     027,
+  030,     031,     032,     TOP|017, SHFT|'+',TOP|020, SHFT|'8',BS
+};
+
+static t_stat stk_svc (UNIT *uptr)
+{
+  int c = SCPE_OK;
+
+#ifdef USE_DISPLAY
+  if (display_last_char) {
+    c = display_last_char | SCPE_KFLAG;
+    display_last_char = 0;
+  }
+#endif
+
+  if (c & SCPE_KFLAG) {
+    key_code = translate[c & 0177];
+    status |= STK_DONE;
+    set_interrupt(STK_DEVNUM, status & STK_PIA);
+  }
+
+  sim_activate (uptr, 100000);
+
+  if (c & SCPE_KFLAG)
+    return SCPE_OK;
+  else
+    return c;
+}
+
+t_stat stk_devio(uint32 dev, uint64 *data)
+{
+    DEVICE *dptr = &stk_dev;
+
+    switch(dev & 07) {
+    case CONO:
+        status &= ~STK_PIA;
+        status |= *data & STK_PIA;
+        if (status & STK_PIA)
+          sim_activate (stk_unit, 1);
+        else
+          sim_cancel (stk_unit);
+        break;
+    case CONI:
+        *data = status;
+        break;
+    case DATAO:
+        break;
+    case DATAI:
+        status &= ~STK_DONE;
+        clr_interrupt(STK_DEVNUM);
+        *data = key_code;
+        break;
+    }
+
+    return SCPE_OK;
+}
+
+const char *stk_description (DEVICE *dptr)
+{
+    return "Stanford keyboard";
+}

--- a/PDP10/ka10_sys.c
+++ b/PDP10/ka10_sys.c
@@ -141,6 +141,9 @@ DEVICE *sim_devices[] = {
 #if NUM_DEVS_IMX > 0
     &imx_dev,
 #endif
+#if NUM_DEVS_STK > 0
+    &stk_dev,
+#endif
 #if NUM_DEVS_TK10 > 0
     &tk10_dev,
 #endif

--- a/display/type340.c
+++ b/display/type340.c
@@ -144,12 +144,12 @@ ty340_set_dac(ty340word addr)
 #endif
 
 ty340word
-ty340_reset(void)
+ty340_reset(void *dptr)
 {
     struct type340 *u = UNIT(0);
 #ifndef TY340_NODISPLAY
     if (!u->initialized) {
-        display_init(DIS_TYPE340, 1, u); /* XXX check return? */
+        display_init(DIS_TYPE340, 1, dptr); /* XXX check return? */
         u->initialized = 1;
     }
 #endif

--- a/display/type340.h
+++ b/display/type340.h
@@ -46,7 +46,7 @@ typedef unsigned int ty340word;
 /*
  * calls from host into type340.c
  */
-ty340word ty340_reset(void);
+ty340word ty340_reset(void *);
 ty340word ty340_status(void);
 ty340word ty340_instruction(ty340word inst);
 void ty340_set_dac(ty340word addr);

--- a/makefile
+++ b/makefile
@@ -1116,7 +1116,7 @@ KA10 = ${KA10D}/ka10_cpu.c ${KA10D}/ka10_sys.c ${KA10D}/ka10_df.c \
 	${KA10D}/ka10_dk.c ${KA10D}/ka10_cr.c ${KA10D}/ka10_cp.c \
 	${KA10D}/ka10_tu.c ${KA10D}/ka10_rs.c ${KA10D}/ka10_pd.c \
 	${KA10D}/ka10_imx.c ${KA10D}/ka10_tk10.c ${KA10D}/ka10_mty.c \
-	${KA10D}/ka10_imp.c
+	${KA10D}/ka10_imp.c ${KA10D}/ka10_stk.c
 KA10_OPT = -DKA=1 -DUSE_INT64 -I $(KA10D) -DUSE_SIM_CARD ${NETWORK_OPT}
 #	${KA10D}/ka10_imp.c sim_imp.c sim_ncp.c sim_tun.c
 

--- a/makefile
+++ b/makefile
@@ -95,6 +95,10 @@ ifneq (,$(findstring besm6,$(MAKECMDGOALS)))
   VIDEO_USEFUL = true
   BESM6_BUILD = true
 endif
+# building the KA10 needs video support
+ifneq (,$(findstring ka10,$(MAKECMDGOALS)))
+  VIDEO_USEFUL = true
+endif
 # building the pdp11, pdp10, or any vax simulator could use networking support
 ifneq (,$(or $(findstring pdp11,$(MAKECMDGOALS)),$(findstring pdp10,$(MAKECMDGOALS)),$(findstring vax,$(MAKECMDGOALS)),$(findstring pdp10-ka,$(MAKECMDGOALS)),$(findstring pdp10-ki,$(MAKECMDGOALS)),$(findstring all,$(MAKECMDGOALS))))
   NETWORK_USEFUL = true
@@ -1118,10 +1122,10 @@ KA10_OPT = -DKA=1 -DUSE_INT64 -I $(KA10D) -DUSE_SIM_CARD ${NETWORK_OPT}
 
 ifneq ($(TYPE340),)
 # ONLY tested on Ubuntu 16.04, using X11 display support:
-KA10_DPY=-DUSE_DISPLAY \
+KA10_DPY=-DUSE_DISPLAY -DHAVE_LIBSDL -DUSE_SIM_VIDEO `$(SDLX_CONFIG) --cflags` \
 	${KA10D}/ka10_dpy.c display/type340.c  display/display.c \
-	display/x11.c
-KA10_DPY_LDFLAGS =-lm -lX11 -lXt
+	display/sim_ws.c
+KA10_DPY_LDFLAGS =-lm -lX11 -lXt `$(SDLX_CONFIG) --libs`
 endif
 ifneq ($(PANDA_LIGHTS),)
 # ONLY for Panda display.


### PR DESCRIPTION
The MIT AI Lab PDP-6/10 had a Stanford keyboard attached as an I/O bus device.  ITS has support for this.

There was a Datapoint terminal emulator that displayed on the Type 340, and used the Stanford keyboard for input.

With this in mind, it would make sense to take keyboard input from the simulator Type 340 window.

Keyboard layout: http://www.keyboard-layout-editor.com/#/gists/6000ae5d36813107c38e6396a5acd518

![SAIL keyboard](http://xahlee.info/kbd/iold51593/sail_keyboard_8cd7f-s1471x979.jpg)