### PR TITLE
I7000: Fix MT density management

### DIFF
--- a/I7000/i7000_mt.c
+++ b/I7000/i7000_mt.c
@@ -604,12 +604,14 @@ uint32 mt_cmd(UNIT * uptr, uint16 cmd, uint16 dev)
     case IO_SDL:
         uptr->u5 |= MT_RDY;     /* Command is quick */
         uptr->flags |= MTUF_LDN;
+        sim_tape_set_dens (uptr, MT_DENS_200, NULL, NULL);
         sim_debug(DEBUG_CMD, dptr, "SDN unit=%d low\n", unit);
         return SCPE_OK;
 
     case IO_SDH:
         uptr->u5 |= MT_RDY;     /* Command is quick */
         uptr->flags &= ~MTUF_LDN;
+        sim_tape_set_dens (uptr, MT_DENS_556, NULL, NULL);
         sim_debug(DEBUG_CMD, dptr, "SDN unit=%d high\n", unit);
         return SCPE_OK;
 
@@ -1334,21 +1336,13 @@ mt_ini(UNIT * uptr, t_bool f)
 t_stat
 mt_reset(DEVICE * dptr)
 {
-    UNIT        *uptr = dptr->units;
-    uint32       i;
-    for (i = 0; i < dptr->numunits; i++) {
-       sim_tape_set_dens (uptr,
-              ((uptr->flags & MTUF_LDN) ? MT_DENS_200 : MT_DENS_556),
-              NULL, NULL);
-       uptr++;
-    }
     return SCPE_OK;
 }
 
 t_stat
 mt_tape_density(UNIT * uptr, int32 val, CONST char *cptr, void *desc)
 {
-    return SCPE_OK;
+return sim_tape_set_dens(uptr, (val == MTUF_LDN) ? MT_DENS_200 : MT_DENS_556, NULL, NULL);
 }
 
 t_stat
@@ -1361,8 +1355,6 @@ mt_attach(UNIT * uptr, CONST char *file)
     uptr->u3 = 0;
     uptr->u5 |= MT_RDY;
     uptr->flags |= MTUF_ONLINE;
-    uptr->dynflags = MT_556_VALID | MT_200_VALID | 
-                ((uptr->flags & MTUF_LDN) ? MT_DENS_556 : MT_DENS_200); 
     return SCPE_OK;
 }
 


### PR DESCRIPTION
This device supports two densities.  Both can be manually set with a
"SET MTA0 LOW|HIGH" or under program control.

This change seems to allow sim_tape to be aware of the density
that the simulated system is operating under.