### PR TITLE
KA10: Fixes for IDIV and MUL.

### DIFF
--- a/PDP10/ka10_cpu.c
+++ b/PDP10/ka10_cpu.c
@@ -4148,6 +4148,21 @@ left:
                   break;              /* Done */
               }
 
+#if !PDP6
+              if (AR == SMASK && BR == 1) {
+                  FLAGS |= OVR|NODIV; /* Overflow and No Divide */
+                  sac_inh=1;          /* Don't touch AC */
+                  check_apr_irq();
+                  break;              /* Done */
+              }
+#else
+              if (AR == SMASK && BR == 1) {
+                  MQ = 0;
+                  AR = 0;
+                  break;              /* Done */
+              }
+#endif
+
               if (AR & SMASK) {
                  AR = (CM(AR) + 1) & FMASK;
                  flag1 = !flag1;

--- a/PDP10/ka10_cpu.c
+++ b/PDP10/ka10_cpu.c
@@ -4128,6 +4128,10 @@ left:
               }
               AR &= FMASK;
               MQ = (MQ & ~SMASK) | (AR & SMASK);
+#if KA
+              if (BR == SMASK && (AR & SMASK))  /* Handle special case */
+                  FLAGS |= OVR;
+#endif
               break;
 
     case 0230:       /* IDIV */


### PR DESCRIPTION
Some quirks on the KA10 and PDP-6 processor.  See #109 and #110.