### PR TITLE
SEL32: Add three missing basemode instructions.

### DIFF
--- a/SEL32/sel32_fltpt.c
+++ b/SEL32/sel32_fltpt.c
@@ -122,7 +122,7 @@ t_uint64 s_nord(t_uint64 reg, uint32 *exp) {
 /* add memory floating point number to register floating point number */
 /* set CC1 if overflow/underflow */
 uint32 s_adfw(uint32 reg, uint32 mem, uint32 *cc) {
-    uint32 mfrac, rfrac, frac, ret, oexp;
+    uint32 mfrac, rfrac, frac, ret=0, oexp;
     uint32 CC, sc, sign, expr, expm, exp;
 
     *cc = 0;                            /* clear the CC'ss */
@@ -402,7 +402,7 @@ t_uint64 s_adfd(t_uint64 reg, t_uint64 mem, uint32 *cc) {
         if (ret & DMSIGN)               /* see if negative */
             /* fraction is negative */
             exp ^= EXMASK;              /* neg fraction, so complement exponent */
-            ret = ret | ((t_uint64)exp << 32);  /* position and insert exponent */
+        ret = ret | ((t_uint64)exp << 32);  /* position and insert exponent */
     }
 
     /* come here to set cc's and return */
@@ -832,6 +832,7 @@ uint32 s_dvfw(uint32 reg, uint32 mem, uint32 *cc) {
 
     if (temp2 >= 0x7fffffc0)            /* check for special rounding */
         goto RRND2;                     /* no special handling */
+    /* FIXME dead code */
     if (temp2 == MSIGN) {               /* check for minux zero */
         temp2 = 0xF8000000;             /* yes, fixup value */
         expr++;                         /* bump exponent */
@@ -854,7 +855,7 @@ RRND1:
     temp2 += 0x40;                      /* round at bit 25 */
 RRND2:
     expr += temp;                       /* add exponent */
-    if (expr < 0) {                     /* test for underflow */
+    if ((int32)expr < 0) {              /* test for underflow */
         goto DUNFLO;                    /* go process underflow */
     }
     if (expr > 0x7f) {                  /* test for overflow */
@@ -981,8 +982,8 @@ t_uint64 s_mpfd(t_uint64 reg, t_uint64 mem, uint32 *cc) {
     temp += expr;                       /* compute final exponent */
     /* if both signs are neg and result sign is positive, overflow */
     /* if both signs are pos and result sign is negative, overflow */
-    if ((temp2 == 3 && (temp & MSIGN) == 0) ||
-        (temp2 == 0 && (temp & MSIGN) != 0)) {
+    if (((temp2 == 3) && ((temp & MSIGN) == 0)) ||
+        ((temp2 == 0) && ((temp & MSIGN) != 0))) {
         /* we have exponent overflow from addition */
         goto DOVFLO;                    /* process overflow */
     }
@@ -1084,8 +1085,8 @@ t_uint64 s_dvfd(t_uint64 reg, t_uint64 mem, uint32 *cc) {
     temp += 0x02000000;                 /* adjust exponent (abr bit 6)*/
     /* if both signs are neg and result sign is positive, overflow */
     /* if both signs are pos and result sign is negative, overflow */
-    if ((temp2 == 3 && (temp & MSIGN) == 0) ||
-        (temp2 == 0 && (temp & MSIGN) != 0)) {
+    if (((temp2 == 3) && ((temp & MSIGN) == 0)) ||
+        ((temp2 == 0) && ((temp & MSIGN) != 0))) {
         /* we have exponent overflow from addition */
         goto DOVFLO;                    /* process overflow */
     }

--- a/SEL32/sel32_iop.c
+++ b/SEL32/sel32_iop.c
@@ -180,9 +180,7 @@ uint8  iop_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
         break;
     }
 
-    if (uptr->u5 & (~(SNS_RDY|SNS_ONLN)))
-        return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;
-    return SNS_CHNEND|SNS_DEVEND;
+    return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;       /* not reachable for now */
 }
 
 /* Handle transfers for other sub-channels on IOP */

--- a/SEL32/sel32_scfi.c
+++ b/SEL32/sel32_scfi.c
@@ -657,7 +657,7 @@ t_stat scfi_srv(UNIT *uptr)
                         data->cyl--;            /* seek 1 cyl */
                         sim_activate(uptr, 200);
                     }
-                    if (data->cyl < 0)          /* test for less than zero */
+                    if ((int32)data->cyl < 0)   /* test for less than zero */
                         data->cyl = 0;          /* make zero */
                 }
                 sim_debug(DEBUG_DETAIL, dptr, "scfi_srv seek next unit=%d %d %d\n", unit, uptr->u4 >> 16,

--- a/SEL32/sel32_sys.c
+++ b/SEL32/sel32_sys.c
@@ -613,7 +613,7 @@ t_opcode  optab[] = {
     {  0x1000,      0xFC0F,   H|TYPE_F,   "CAR", },      /* Compare Arithmetic Register # */
     {  0x1008,      0xFC0F, B|H|TYPE_F,   "SACZ", },     /* Shift and Count Zeros # BR */
     {  0x1400,      0xFC0F,   H|TYPE_F,   "CMR", },      /* Compare masked with register */
-    {  0x1800,      0xFC0C, N|H|TYPE_K,   "SBR", },      /* Set Bit in Register # */
+    {  0x1800,      0xFC0C,   H|TYPE_K,   "SBR", },      /* Set Bit in Register # */
     {  0x1804,      0xFC0C, B|H|TYPE_K,   "ZBR", },      /* Zero Bit In register # BR */
     {  0x1808,      0xFC0C, B|H|TYPE_K,   "ABR", },      /* Add Bit In Register # BR */
     {  0x180C,      0xFC0C, B|H|TYPE_K,   "TBR", },      /* Test Bit in Register # BR */
@@ -634,7 +634,7 @@ t_opcode  optab[] = {
     {  0x2802,      0xFC0F, B|H|TYPE_F,   "XCBR", },     /* Exchange Base Registers # BR Only */
     {  0x2804,      0xFC0F, B|H|TYPE_G,   "TCCR", },     /* Transfer CC to GPR # BR Only */
     {  0x2805,      0xFC0F, B|H|TYPE_G,   "TRCC", },     /* Transfer GPR to CC # BR */
-    {  0x2808,      0xFC0F, B|H|TYPE_F,   "BSUB", },     /* Branch Subroutine # BR Only */
+    {  0x2808,      0xFF8F, B|H|TYPE_F,   "BSUB", },     /* Branch Subroutine # BR Only */
     {  0x2808,      0xFC0F, B|H|TYPE_F,   "CALL", },     /* Procedure Call # BR Only */
     {  0x280C,      0xFC0F, B|H|TYPE_G,   "TPCBR", },    /* Transfer Program Counter to Base # BR Only */
     {  0x280E,      0xFC7F, B|H|TYPE_G,   "RETURN", },   /* Procedure Return # BR Only */
@@ -680,8 +680,8 @@ t_opcode  optab[] = {
     {  0x5800,      0xFC08,   B|TYPE_A,   "SUABR", },    /* Subtract Base Register BR Only */
     {  0x5808,      0xFC08,   B|TYPE_D,   "LABR", },     /* Load Address Base Register BR Only */
     {  0x5C00,      0xFC08,   B|TYPE_A,   "LWBR", },     /* Load Base Register BR Only */
-    {  0x5C08,      0xFC08, B|H|TYPE_A,   "BSUBM", },    /* Branch Subroutine Memory BR Only */
-    {  0x5C08,      0xFC08, B|H|TYPE_A,   "CALLM", },    /* Call Memory BR Only */
+    {  0x5C08,      0xFF88,   B|TYPE_B,   "BSUBM", },    /* Branch Subroutine Memory BR Only */
+    {  0x5C08,      0xFC08,   B|TYPE_B,   "CALLM", },    /* Call Memory BR Only */
     {  0x6000,      0xFC0F, N|H|TYPE_F,   "NOR", },      /* Normalize # NBR Only */
     {  0x6400,      0xFC0F, N|H|TYPE_F,   "NORD", },     /* Normalize Double #  NBR Only */
     {  0x6800,      0xFC0F, N|H|TYPE_F,   "SCZ", },      /* Shift and Count Zeros # */
@@ -805,13 +805,8 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
     t_opcode *tab;
 
 ///    printf("inst %x sw %x\r\n", val, sw);
-#ifdef DO_THIS_UNTIL_FIGURE_IT_OUT
-    if (sw & SWMASK('M'))                           /* Base mode printing */
+    if ((PSD[0] & 0x02000000) || (sw & SWMASK('M'))) /* bit 6 is base mode */
         mode = 1;
-#else
-    if (PSD[0] & 0x02000000)                        /* bit 6 is base mode */
-        mode = 1;
-#endif
     /* loop through the instruction table for an opcode match and get the type */ 
     for (tab = optab; tab->name != NULL; tab++) {
         if (tab->opbase == (inst & tab->mask)) {
@@ -834,6 +829,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
                 /* append B, H, W, D to base instruction using F & C bits */
                 i = (val & 3) | ((inst >> 1) & 04);
                 if (((inst&0xfc00) != 0xdc00) &&
+                    ((inst&0xfc00) != 0xd000) &&
                     ((inst&0xfc00) != 0x5400) &&
                     ((inst&0xfc00) != 0x5800) &&
                     ((inst&0xfc00) != 0x5c00) &&

--- a/SEL32/taptools/mkfmtape.c
+++ b/SEL32/taptools/mkfmtape.c
@@ -104,6 +104,11 @@ char *argv[];
                     case 'U':
                     case 'u':
                         option |= DOUSER;   /* save username for files */
+                        if (*p == '\0')
+                        {
+                            p = *++argv;    /* next parameter */
+                            --argc;         /* one less arg */
+                        };
                         userp = p;
                         while (*p != '\0')
                             p++;
@@ -247,7 +252,7 @@ getout:
         blks = (word/4608);                     /* blocks */
         if ((word%4608) != 0)
             blks++; 
-        printf("handle file %s user %s size %d bytes %d sect %d blocks\n",
+        printf("write SMD %s user %s size %d bytes %d sect %d blocks\n",
             fnp, userp, word, size, blks);
         fclose(fp);
         /* create smd entry for this file */
@@ -305,6 +310,7 @@ getout:
             }
             memset((char *)dir, 0, 4608);       /* zero smd storage */
             filen = 0;                          /* restart count */
+            dirp = (u_int32_t *)dir;            /* get word pointer for smd data */
         }
     }
     /* write out the directory entries for the files to save */
@@ -371,7 +377,7 @@ getout:
             }
             memset((char *)data, 0, 4608);      /* zero data storage */
         }
-        printf("handle file %s user %s (size %d bytes) (%d sect) (%d blocks)\n",
+        printf("write file %s user %s (size %d bytes) (%d sect) (%d blocks)\n",
             fnp, userp, word, size, blks);
         fclose(fp);
     }

--- a/SEL32/taptools/tapdump.c
+++ b/SEL32/taptools/tapdump.c
@@ -48,18 +48,18 @@ int getloi(char *s, int lim)
             if (ln > 0)
             {
                 if (count - lcount > 1)
-                    fprintf(stderr, "file %d: records %d to %d: size %d\n", filen, lcount, count - 1, ln);
+                    fprintf(stderr, "file %d: records %d to %d: size %d (%x)\n", filen, lcount, count-1, ln, ln);
                 else
-                    fprintf(stderr, "file %d: record %d: size %d\n", filen, lcount, ln);
+                    fprintf(stderr, "file %d: record %d: size %d (%x)\n", filen, lcount, ln, ln);
             }
-            fprintf(stderr, "file %d: eof after %d records: %d bytes\n", filen, count, size);
+            fprintf(stderr, "file %d: eof after %d records: %d bytes (%x)\n", filen, count, size, size);
 #endif
             filen++;    /* set next file number */
         }
         else
         {
 #ifndef NOTDUMP
-            fprintf(stderr, "second eof after %d files: %d bytes\n", filen, size);
+            fprintf(stderr, "second eof after %d files: %d bytes (%x)\n", filen, size, size);
 #endif
         }
         count = 0;      /* file record count back to zero */
@@ -77,7 +77,7 @@ int getloi(char *s, int lim)
         /* we have EOM */
         fprintf(stderr, "mpx eot\n");
         /* print out total tape size in bytes */
-        fprintf(stderr, "total length: %ld bytes\n", tsize);
+        fprintf(stderr, "total length: %ld bytes (%x)\n", tsize, tsize);
 #endif
         return -1;      /* at EOM on disk file */
     }
@@ -94,9 +94,9 @@ int getloi(char *s, int lim)
         if (ln > 0)
         {
             if (count - lcount > 1)
-                fprintf(stderr, "file %d: records %d to %d: size %d\n", filen, lcount, count - 1, ln);
+                fprintf(stderr, "file %d: records %d to %d: size %d (%x)\n", filen, lcount, count-1, ln, ln);
             else
-                fprintf(stderr, "file %d: record %d: size %d\n", filen, lcount, ln);
+                fprintf(stderr, "file %d: record %d: size %d (%x)\n", filen, lcount, ln, ln);
         }
 #endif
         ln = n;


### PR DESCRIPTION
SEL32: Handle multiple EOFs on MT.
SEL32: Correct basemode instruction processing and display errors.
SEL32:Fix ex -m to display basemode instructions.