### PR TITLE
SEL32: Correct opcode processing errors caught by Gould diagnostics.

### DIFF
--- a/SEL32/sel32_chan.c
+++ b/SEL32/sel32_chan.c
@@ -1268,12 +1268,13 @@ uint32 scan_chan(void) {
     if ((CPUSTATUS & 0x80) == 0) {                  /* are interrupts blocked */
         /* ints not blocked, so look for highest requesting interrupt */
         for (i=0; i<112; i++) {
-            if (INTS[i]&INTS_ACT)                   /* look for level active */
-                break;                              /* this level active, so stop looking */
             if (SPAD[i+0x80] == 0)                  /* not initialize? */
                 continue;                           /* skip this one */
             if (SPAD[i+0x80] == 0xffffffff)         /* not initialize? */
                 continue;                           /* skip this one */
+//          if (INTS[i]&INTS_ACT)                   /* look for level active */
+            if (SPAD[i+0x80] & SINT_ACT)            /* look for level active */
+                break;                              /* this level active, so stop looking */
             /* see if there is pending status for this channel */
             /* if there is and the level is not requesting, do it */
             if ((INTS[i] & INTS_ENAB) && !(INTS[i] & INTS_REQ)) {
@@ -1305,14 +1306,15 @@ uint32 scan_chan(void) {
             /* look for the highest requesting interrupt */
             /* that is enabled */
             if (((INTS[i] & INTS_ENAB) && (INTS[i] & INTS_REQ)) ||
-                ((SPAD[i+0x80] & INTS_ENAB) && (INTS[i] & INTS_REQ))) {
+                ((SPAD[i+0x80] & SINT_ENAB) && (INTS[i] & INTS_REQ))) {
                 /* requesting, make active and turn off request flag */
                 INTS[i] &= ~INTS_REQ;               /* turn off request */
                 INTS[i] |= INTS_ACT;                /* turn on active */
                 SPAD[i+0x80] |= SINT_ACT;           /* show active in SPAD too */
                 /* make sure both enabled too */
-                INTS[i] |= INTS_ENAB;               /* turn on enable */
-                SPAD[i+0x80] |= SINT_ENAB;          /* show enabled in SPAD too */
+   /* should already be enabled */
+//                INTS[i] |= INTS_ENAB;               /* turn on enable */
+//                SPAD[i+0x80] |= SINT_ENAB;          /* show enabled in SPAD too */
                 /* get the address of the interrupt IVL table in main memory */
                 chan_ivl = SPAD[0xf1] + (i<<2);     /* contents of spad f1 points to chan ivl in mem */
                 chan_icba = M[chan_ivl >> 2];       /* get the interrupt context block addr in memory */

--- a/SEL32/sel32_defs.h
+++ b/SEL32/sel32_defs.h
@@ -158,7 +158,7 @@ extern DEVICE lpr_dev;
 
 /* Memory */
 
-#define MAXMEMSIZE  ((16*1024*1024)/4)      /* max memory size */
+#define MAXMEMSIZE  ((16*1024*1024)/4)      /* max memory size in 32bit words */
 #define PAMASK      (MAXMEMSIZE - 1)        /* physical addr mask */
 #define MEMSIZE     (cpu_unit.capac)        /* actual memory size */
 #define MEM_ADDR_OK(x)  (((x)) < MEMSIZE)
@@ -314,6 +314,8 @@ extern DEBTAB dev_debug[];
 #define CONSOLEATN_TRAP 0xB4                /* Console Attention Trap */
 #define PRIVHALT_TRAP   0xB8                /* Privlege Mode Halt Trap */
 #define AEXPCEPT_TRAP   0xBC                /* Arithmetic Exception Trap */
+#define CACHEERR_TRAP   0xC0                /* Cache Error Trap (V9 Only) */
+#define DEMANDPG_TRAP   0xC4                /* Demand Page Fault Trap (V6&V9 Only) */
 
 /* Errors returned from various functions */
 #define ALLOK   0x0000                      /* no error, all is OK */

--- a/SEL32/sel32_disk.c
+++ b/SEL32/sel32_disk.c
@@ -70,7 +70,7 @@ bits 0-7 - Flags
 bits 8-15 - sector count (sectors per track)(F16=16, F20=20)
 bits 16-23 - MHD Head count (number of heads on MHD)
 bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option of
-    mini-module)
+  mini-module)
 */
 
 
@@ -83,89 +83,89 @@ bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option
 #define CMD        u3
 /* u3 */
 /* in u3 is device command code and status */
-#define DSK_CMDMSK       0x00ff   /* Command being run */
-#define DSK_STAR         0x0100   /* STAR value in u4 */
-#define DSK_NU2          0x0200   /*                    */
-#define DSK_READDONE     0x0400   /* Read finished, end channel */
-#define DSK_ENDDSK       0x0800   /* Sensed end of disk */
-#define DSK_SEEKING      0x1000   /* Disk is currently seeking */
-#define DSK_READING      0x2000   /* Disk is reading data */
-#define DSK_WRITING      0x4000   /* Disk is writing data */
-#define DSK_BUSY         0x8000   /* Flag to send a CUE */
+#define DSK_CMDMSK       0x00ff     /* Command being run */
+#define DSK_STAR         0x0100     /* STAR value in u4 */
+#define DSK_NU2          0x0200     /*                    */
+#define DSK_READDONE     0x0400     /* Read finished, end channel */
+#define DSK_ENDDSK       0x0800     /* Sensed end of disk */
+#define DSK_SEEKING      0x1000     /* Disk is currently seeking */
+#define DSK_READING      0x2000     /* Disk is reading data */
+#define DSK_WRITING      0x4000     /* Disk is writing data */
+#define DSK_BUSY         0x8000     /* Flag to send a CUE */
 /* commands */
-#define DSK_INCH           0x00   /* Initialize channel */
-#define DSK_WD             0x01   /* Write data */
-#define DSK_RD             0x02   /* Read data */
-#define DSK_NOP            0x03   /* No operation */
-#define DSK_SNS            0x04   /* Sense */
-#define DSK_SCK            0x07   /* Seek cylinder, track, sector */
-#define DSK_TIC            0x08   /* Transfer in channel */
-#define DSK_FNSK           0x0B   /* Format for no skip */
-#define DSK_LPL            0x13   /* Lock protected label */
-#define DSK_LMR            0x1F   /* Load mode register */
-#define DSK_RES            0x23   /* Reserve */
-#define DSK_WSL            0x31   /* Write sector label */
-#define DSK_RSL            0x32   /* Read sector label */
-#define DSK_REL            0x33   /* Release */
-#define DSK_XEZ            0x37   /* Rezero */
-#define DSK_POR            0x43   /* Priority Override */
-#define DSK_IHA            0x47   /* Increment head address */
-#define DSK_SRM            0x4F   /* Set reserve track mode */
-#define DSK_WTL            0x51   /* Write track label */
-#define DSK_RTL            0x52   /* Read track label */
-#define DSK_XRM            0x5F   /* Reset reserve track mode */
-#define DSK_RAP            0xA2   /* Read angular positions */
-#define DSK_TESS           0xAB   /* Test STAR (subchannel target address register) */
-#define DSK_ICH            0xFF   /* Initialize Controller */
+#define DSK_INCH           0x00     /* Initialize channel */
+#define DSK_WD             0x01     /* Write data */
+#define DSK_RD             0x02     /* Read data */
+#define DSK_NOP            0x03     /* No operation */
+#define DSK_SNS            0x04     /* Sense */
+#define DSK_SCK            0x07     /* Seek cylinder, track, sector */
+#define DSK_TIC            0x08     /* Transfer in channel */
+#define DSK_FNSK           0x0B     /* Format for no skip */
+#define DSK_LPL            0x13     /* Lock protected label */
+#define DSK_LMR            0x1F     /* Load mode register */
+#define DSK_RES            0x23     /* Reserve */
+#define DSK_WSL            0x31     /* Write sector label */
+#define DSK_RSL            0x32     /* Read sector label */
+#define DSK_REL            0x33     /* Release */
+#define DSK_XEZ            0x37     /* Rezero */
+#define DSK_POR            0x43     /* Priority Override */
+#define DSK_IHA            0x47     /* Increment head address */
+#define DSK_SRM            0x4F     /* Set reserve track mode */
+#define DSK_WTL            0x51     /* Write track label */
+#define DSK_RTL            0x52     /* Read track label */
+#define DSK_XRM            0x5F     /* Reset reserve track mode */
+#define DSK_RAP            0xA2     /* Read angular positions */
+#define DSK_TESS           0xAB     /* Test STAR (subchannel target address register) */
+#define DSK_ICH            0xFF     /* Initialize Controller */
 
 #define STAR      u4
 /* u4 - sector target address register (STAR) */
 /* Holds the current cylinder, head(track), sector */
-#define DISK_CYL     0xFFFF0000   /* cylinder mask */
-#define DISK_TRACK   0x0000FF00   /* track mask */
-#define DISK_SECTOR  0x000000ff   /* sector mask */
+#define DISK_CYL     0xFFFF0000     /* cylinder mask */
+#define DISK_TRACK   0x0000FF00     /* track mask */
+#define DISK_SECTOR  0x000000ff     /* sector mask */
 
 #define SNS       u5
 /* u5 */
 /* Sense byte 0  - mode register */
-#define SNS_DROFF    0x80000000   /* Drive Carriage will be offset */
-#define SNS_TRKOFF   0x40000000   /* Track offset: 0=positive, 1=negative */
-#define SNS_RDTMOFF  0x20000000   /* Read timing offset = 1 */
-#define SNS_RDSTRBT  0x10000000   /* Read strobe timing: 1=positive, 0=negative */
-#define SNS_DIAGMOD  0x08000000   /* Diagnostic Mode ECC Code generation and checking */
-#define SNS_RSVTRK   0x04000000   /* Reserve Track mode: 1=OK to write, 0=read only */
-#define SNS_FHDOPT   0x02000000   /* FHD or FHD option = 1 */
-#define SNS_RESERV   0x01000000   /* Reserved */
+#define SNS_DROFF      0x80000000   /* Drive Carriage will be offset */
+#define SNS_TRKOFF     0x40000000   /* Track offset: 0=positive, 1=negative */
+#define SNS_RDTMOFF    0x20000000   /* Read timing offset = 1 */
+#define SNS_RDSTRBT    0x10000000   /* Read strobe timing: 1=positive, 0=negative */
+#define SNS_DIAGMOD    0x08000000   /* Diagnostic Mode ECC Code generation and checking */
+#define SNS_RSVTRK     0x04000000   /* Reserve Track mode: 1=OK to write, 0=read only */
+#define SNS_FHDOPT     0x02000000   /* FHD or FHD option = 1 */
+#define SNS_RESERV     0x01000000   /* Reserved */
 
 /* Sense byte 1 */
-#define SNS_CMDREJ     0x800000   /* Command reject */
-#define SNS_INTVENT    0x400000   /* Unit intervention required */
-#define SNS_SPARE1     0x200000   /* Spare */
-#define SNS_EQUCHK     0x100000   /* Equipment check */
-#define SNS_DATCHK     0x080000   /* Data Check */
-#define SNS_OVRRUN     0x040000   /* Data overrun/underrun */
-#define SNS_DSKFERR    0x020000   /* Disk format error */
-#define SNS_DEFTRK     0x010000   /* Defective track encountered */
+#define SNS_CMDREJ     0x800000     /* Command reject */
+#define SNS_INTVENT    0x400000     /* Unit intervention required */
+#define SNS_SPARE1     0x200000     /* Spare */
+#define SNS_EQUCHK     0x100000     /* Equipment check */
+#define SNS_DATCHK     0x080000     /* Data Check */
+#define SNS_OVRRUN     0x040000     /* Data overrun/underrun */
+#define SNS_DSKFERR    0x020000     /* Disk format error */
+#define SNS_DEFTRK     0x010000     /* Defective track encountered */
 
 /* Sense byte 2 */
-#define SNS_LAST         0x8000   /* Last track flag encountered */
-#define SNS_AATT         0x4000   /* At Alternate track */
-#define SNS_WPER         0x2000   /* Write protection error */
-#define SNS_WRL          0x1000   /* Write lock error */
-#define SNS_MOCK         0x0800   /* Mode check */
-#define SNS_INAD         0x0400   /* Invalid memory address */
-#define SNS_RELF         0x0200   /* Release fault */
-#define SNS_CHER         0x0100   /* Chaining error */
+#define SNS_LAST       0x8000       /* Last track flag encountered */
+#define SNS_AATT       0x4000       /* At Alternate track */
+#define SNS_WPER       0x2000       /* Write protection error */
+#define SNS_WRL        0x1000       /* Write lock error */
+#define SNS_MOCK       0x0800       /* Mode check */
+#define SNS_INAD       0x0400       /* Invalid memory address */
+#define SNS_RELF       0x0200       /* Release fault */
+#define SNS_CHER       0x0100       /* Chaining error */
 
 /* Sense byte 3 */
-#define SNS_REVL           0x80   /* Revolution lost */
-#define SNS_DADE           0x40   /* Disc addressing or seek error */
-#define SNS_BUCK           0x20   /* Buffer check */
-#define SNS_ECCS           0x10   /* ECC error in sector label */
-#define SNS_ECCD           0x08   /* ECC error iin data */
-#define SNS_ECCT           0x04   /* ECC error in track label */
-#define SNS_RTAE           0x02   /* Reserve track access error */
-#define SNS_UESS           0x01   /* Uncorrectable ECC error */
+#define SNS_REVL       0x80         /* Revolution lost */
+#define SNS_DADE       0x40         /* Disc addressing or seek error */
+#define SNS_BUCK       0x20         /* Buffer check */
+#define SNS_ECCS       0x10         /* ECC error in sector label */
+#define SNS_ECCD       0x08         /* ECC error iin data */
+#define SNS_ECCT       0x04         /* ECC error in track label */
+#define SNS_RTAE       0x02         /* Reserve track access error */
+#define SNS_UESS       0x01         /* Uncorrectable ECC error */
 
 #define ATTR      u6
 /* u6 */
@@ -405,20 +405,20 @@ uint8  disk_preio(UNIT *uptr, uint16 chan)
     DEVICE         *dptr = find_dev_from_unit(uptr);
     int            unit = (uptr - dptr->units);
 
-    if ((uptr->CMD & 0xff00) != 0) {         /* just return if busy */
+    if ((uptr->CMD & 0xff00) != 0) {        /* just return if busy */
         return SNS_BSY;
     }
 
     sim_debug(DEBUG_CMD, dptr, "dsk_preio unit=%d OK\n", unit);
-    return 0;       /* good to go */
+    return 0;                               /* good to go */
 }
 
 uint8  disk_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
 {
-    uint16         addr = GET_UADDR(uptr->CMD);
-    DEVICE         *dptr = find_dev_from_unit(uptr);
-    int            unit = (uptr - dptr->units);
-    uint8          ch;
+    uint16      addr = GET_UADDR(uptr->CMD);
+    DEVICE      *dptr = find_dev_from_unit(uptr);
+    int         unit = (uptr - dptr->units);
+    uint8       ch;
 
     sim_debug(DEBUG_CMD, dptr, "disk_startcmd unit %d cmd %x CMD %x\n", unit, cmd, uptr->CMD);
     if ((uptr->flags & UNIT_ATT) == 0) {    /* unit attached status */
@@ -592,7 +592,7 @@ t_stat disk_srv(UNIT * uptr)
              unit, cmd, chsa, chsa>>8, chp->ccw_count);
 
     if ((uptr->flags & UNIT_ATT) == 0) {   /* unit attached status */
-        uptr->SNS |= SNS_INTVENT;           /* unit intervention required */
+        uptr->SNS |= SNS_INTVENT;          /* unit intervention required */
         if (cmd != DSK_SNS)                /* we are completed with unit check status */
             return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;
     }

--- a/SEL32/sel32_mt.c
+++ b/SEL32/sel32_mt.c
@@ -119,48 +119,48 @@ OTAB     EQU       $
 
 #define CMD      u3
 /* BTP tape commands */
-#define MT_INCH             0x00       /* Initialize channel command */
-#define MT_WRITE            0x01       /* Write command */
-#define MT_READ             0x02       /* Read command */
-#define MT_NOP              0x03       /* Control command */
-#define MT_SENSE            0x04       /* Sense command */
-#define MT_RDBK             0x0c       /* Read Backward */
-#define MT_RDCMP            0x13       /* Read and compare command */
-#define MT_REW              0x23       /* Rewind command */
-#define MT_RUN              0x33       /* Rewind and unload */
-#define MT_FSR              0x43       /* Advance record */
-#define MT_BSR              0x53       /* Backspace record */
-#define MT_FSF              0x63       /* Advance filemark  */
-#define MT_BSF              0x73       /* Backspace filemark */
-#define MT_SETM             0x83       /* Set Mode command */
-#define MT_WTM              0x93       /* Write Tape filemark */
-#define MT_ERG              0xA3       /* Erase 3.5 of tape */
-#define MT_MODEMSK          0xFF       /* Mode Mask */
+#define MT_INCH             0x00        /* Initialize channel command */
+#define MT_WRITE            0x01        /* Write command */
+#define MT_READ             0x02        /* Read command */
+#define MT_NOP              0x03        /* Control command */
+#define MT_SENSE            0x04        /* Sense command */
+#define MT_RDBK             0x0c        /* Read Backward */
+#define MT_RDCMP            0x13        /* Read and compare command */
+#define MT_REW              0x23        /* Rewind command */
+#define MT_RUN              0x33        /* Rewind and unload */
+#define MT_FSR              0x43        /* Advance record */
+#define MT_BSR              0x53        /* Backspace record */
+#define MT_FSF              0x63        /* Advance filemark  */
+#define MT_BSF              0x73        /* Backspace filemark */
+#define MT_SETM             0x83        /* Set Mode command */
+#define MT_WTM              0x93        /* Write Tape filemark */
+#define MT_ERG              0xA3        /* Erase 3.5 of tape */
+#define MT_MODEMSK          0xFF        /* Mode Mask */
 
 /* set mode bits for BTP (MT_SETM) */
-#define MT_MODE_AUTO        0x80       /* =0 Perform auto error recodery on read */
-#define MT_MODE_FORCE       0x80       /* =1 Read regardless if error recovery fails */
-#define MT_MDEN_800         0x40       /* =0 select 800 BPI NRZI mode 9 track only */
-#define MT_MDEN_1600        0x40       /* =1 select 1600 BPI PE mode 9 track only */
-#define MT_MDEN_6250        0x20       /* =0 Use mode from bit one for NRZI/PE */
-#define MT_MDEN_6250        0x20       /* =1 6250 BPI GCR mode 9 track only */
-#define MT_MDEN_SCATGR      0x01       /* =1 HSTP scatter/gather mode */
-#define MT_MDEN_MSK         0xc0       /* Density mask */
+#define MT_MODE_AUTO        0x80        /* =0 Perform auto error recodery on read */
+#define MT_MODE_FORCE       0x80        /* =1 Read regardless if error recovery fails */
+#define MT_MDEN_800         0x40        /* =0 select 800 BPI NRZI mode 9 track only */
+#define MT_MDEN_1600        0x40        /* =1 select 1600 BPI PE mode 9 track only */
+#define MT_MDEN_6250        0x20        /* =0 Use mode from bit one for NRZI/PE */
+#define MT_MDEN_6250        0x20        /* =1 6250 BPI GCR mode 9 track only */
+#define MT_MDEN_SCATGR      0x01        /* =1 HSTP scatter/gather mode */
+#define MT_MDEN_MSK         0xc0        /* Density mask */
 
-#define MT_CTL_MSK          0x38       /* Mask for control flags */
-#define MT_CTL_NOP          0x00       /* Nop control mode */
-#define MT_CTL_NRZI         0x08       /* 9 track 800 bpi mode */
-#define MT_CTL_RST          0x10       /* Set density, odd, convert on, trans off */
-#define MT_CTL_NOP2         0x18       /* 9 track 1600 NRZI mode */
+#define MT_CTL_MSK          0x38        /* Mask for control flags */
+#define MT_CTL_NOP          0x00        /* Nop control mode */
+#define MT_CTL_NRZI         0x08        /* 9 track 800 bpi mode */
+#define MT_CTL_RST          0x10        /* Set density, odd, convert on, trans off */
+#define MT_CTL_NOP2         0x18        /* 9 track 1600 NRZI mode */
 
 /* in u3 is device command code and status */
-#define MT_CMDMSK            0x00ff       /* Command being run */
-#define MT_READDONE          0x0400       /* Read finished, end channel */
-#define MT_MARK              0x0800       /* Sensed tape mark in move command */
-#define MT_ODD               0x1000       /* Odd parity */
-#define MT_TRANS             0x2000       /* Translation turned on ignored 9 track  */
-#define MT_CONV              0x4000       /* Data converter on ignored 9 track  */
-#define MT_BUSY              0x8000       /* Flag to send a CUE */
+#define MT_CMDMSK           0x00ff      /* Command being run */
+#define MT_READDONE         0x0400      /* Read finished, end channel */
+#define MT_MARK             0x0800      /* Sensed tape mark in move command */
+#define MT_ODD              0x1000      /* Odd parity */
+#define MT_TRANS            0x2000      /* Translation turned on ignored 9 track  */
+#define MT_CONV             0x4000      /* Data converter on ignored 9 track  */
+#define MT_BUSY             0x8000      /* Flag to send a CUE */
 
 #define POS      u4
 /* in u4 is current buffer position */
@@ -168,14 +168,14 @@ OTAB     EQU       $
 #define SNS      u5
 /* in u5 packs sense byte 0, 1, 2 and 3 */
 /* Sense byte 0 */
-#define SNS_CMDREJ       0x80000000       /* Command reject */
-#define SNS_INTVENT      0x40000000       /* Unit intervention required */
-#define SNS_SPARE1       0x20000000       /* Spare */
-#define SNS_EQUCHK       0x10000000       /* Equipment check */
-#define SNS_DATCHK       0x08000000       /* Data Check */
-#define SNS_OVRRUN       0x04000000       /* Data overrun */
-#define SNS_SPARE2       0x02000000       /* Spare */
-#define SNS_LOOKER       0x01000000       /* lookahead error */
+#define SNS_CMDREJ       0x80000000     /* Command reject */
+#define SNS_INTVENT      0x40000000     /* Unit intervention required */
+#define SNS_SPARE1       0x20000000     /* Spare */
+#define SNS_EQUCHK       0x10000000     /* Equipment check */
+#define SNS_DATCHK       0x08000000     /* Data Check */
+#define SNS_OVRRUN       0x04000000     /* Data overrun */
+#define SNS_SPARE2       0x02000000     /* Spare */
+#define SNS_LOOKER       0x01000000     /* lookahead error */
 
 /* Sense byte 1 */
 #define SNS_PEMODER      0x800000       /* PE tape mode error */
@@ -188,27 +188,27 @@ OTAB     EQU       $
 #define SNS_SPARE3       0x010000       /* Spare */
 
 /* Sense byte 2 mode bits */
-#define SNS_MREG0        0x8000       /* Mode register bit 0 */
-#define SNS_MREG1        0x4000       /* Mode register bit 1 */
-#define SNS_MREG2        0x2000       /* Mode register bit 2 */
-#define SNS_MREG3        0x1000       /* Mode register bit 3 */
-#define SNS_MREG4        0x0800       /* Mode register bit 4 */
-#define SNS_MREG5        0x0400       /* Mode register bit 5 */
-#define SNS_MREG6        0x0200       /* Mode register bit 6 */
-#define SNS_MREG7        0x0100       /* Mode register bit 7 */
+#define SNS_MREG0        0x8000         /* Mode register bit 0 */
+#define SNS_MREG1        0x4000         /* Mode register bit 1 */
+#define SNS_MREG2        0x2000         /* Mode register bit 2 */
+#define SNS_MREG3        0x1000         /* Mode register bit 3 */
+#define SNS_MREG4        0x0800         /* Mode register bit 4 */
+#define SNS_MREG5        0x0400         /* Mode register bit 5 */
+#define SNS_MREG6        0x0200         /* Mode register bit 6 */
+#define SNS_MREG7        0x0100         /* Mode register bit 7 */
 
 /* Sense byte 3 */
-#define SNS_RDY          0x80       /* Drive Ready */
-#define SNS_ONLN         0x40       /* Drive Online */
-#define SNS_WRP          0x20       /* Drive is file protected (write ring missing) */
-#define SNS_NRZI         0x10       /* Drive is NRZI */
-#define SNS_SPARE4       0x08       /* Spare */
-#define SNS_LOAD         0x04       /* Drive is at load point */
-#define SNS_EOT          0x02       /* Drive is at EOT */
-#define SNS_SPARE5       0x01       /* Spare */
+#define SNS_RDY          0x80           /* Drive Ready */
+#define SNS_ONLN         0x40           /* Drive Online */
+#define SNS_WRP          0x20           /* Drive is file protected (write ring missing) */
+#define SNS_NRZI         0x10           /* Drive is NRZI */
+#define SNS_SPARE4       0x08           /* Spare */
+#define SNS_LOAD         0x04           /* Drive is at load point */
+#define SNS_EOT          0x02           /* Drive is at EOT */
+#define SNS_SPARE5       0x01           /* Spare */
 
-#define SNS_BYTE4        0x00       /* Hardware errors not supported */
-#define SNS_BYTE5        0x00       /* Hardware errors not supported */
+#define SNS_BYTE4        0x00           /* Hardware errors not supported */
+#define SNS_BYTE5        0x00           /* Hardware errors not supported */
 
 #define MT_CONV1         0x40
 #define MT_CONV2         0x80
@@ -445,40 +445,40 @@ uint8  mt_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
     sim_debug(DEBUG_EXP, &mta_dev, "mt_startcmd processing unit %x cmd %x\n", unit, cmd);
 
     switch (cmd & 0xF) {
-    case 0x0:                                   /* INCH command */
+    case 0x0:                                       /* INCH command */
         /* POS has INCH buffer address and us9 the count */
         /* just return OK and channel software will use POS as status buffer */
         sim_debug(DEBUG_DETAIL, &mta_dev, "mt_startcmd INCH done unit %x cmd %x\n",
                  unit, cmd);
         /* UTX_needs_interrupt */
-        cmd = MT_CMDMSK;                        /* insert INCH cmd as 0xff */
+        cmd = MT_CMDMSK;                            /* insert INCH cmd as 0xff */
         /* fall through */
-    case 0x3:                                   /* Tape motion commands */
+    case 0x3:                                       /* Tape motion commands */
         /* UTX_needs_interrupt */
         /* fall through */
-    case 0x1:                                   /* Write command */
-    case 0x2:                                   /* Read command */
-    case 0xc:                                   /* Read backward */
-        if (cmd != 0x03)                        /* if this is a nop do not zero status */
-            uptr->SNS = (uptr->SNS & 0x0000ff00); /* clear all but byte 2 */
-        uptr->SNS |= (SNS_RDY|SNS_ONLN);        /* set ready status */
+    case 0x1:                                       /* Write command */
+    case 0x2:                                       /* Read command */
+    case 0xc:                                       /* Read backward */
+        if (cmd != 0x03)                            /* if this is a nop do not zero status */
+            uptr->SNS = (uptr->SNS & 0x0000ff00);   /* clear all but byte 2 */
+        uptr->SNS |= (SNS_RDY|SNS_ONLN);            /* set ready status */
         if (sim_tape_wrp(uptr))
-            uptr->SNS |= (SNS_WRP);             /* write protected */
+            uptr->SNS |= (SNS_WRP);                 /* write protected */
         if (sim_tape_bot(uptr))
-            uptr->SNS |= (SNS_LOAD);            /* tape at load point */
+            uptr->SNS |= (SNS_LOAD);                /* tape at load point */
         if (sim_tape_eot(uptr))
-            uptr->SNS |= (SNS_EOT);             /* tape at EOM */
+            uptr->SNS |= (SNS_EOT);                 /* tape at EOM */
         /* Fall through */
 
     case 0x4:              /* Sense */
-        uptr->CMD &= ~(MT_CMDMSK);               /* clear out last cmd */
-        uptr->CMD |= cmd & MT_CMDMSK;            /* insert new cmd */
-        CLR_BUF(uptr);                          /* buffer is empty */
+        uptr->CMD &= ~(MT_CMDMSK);                  /* clear out last cmd */
+        uptr->CMD |= cmd & MT_CMDMSK;               /* insert new cmd */
+        CLR_BUF(uptr);                              /* buffer is empty */
         /* INCH cmd has iNCH buffer address in POS, so leave it */
         if (cmd != MT_CMDMSK)
-            uptr->POS = 0;                       /* reset buffer position pointer */
-        sim_activate(uptr, 100);                /* Start unit off */
-        mt_busy[GET_DEV_BUF(dptr->flags)] = 1;  /* show we are busy */
+            uptr->POS = 0;                          /* reset buffer position pointer */
+        sim_activate(uptr, 100);                    /* Start unit off */
+        mt_busy[GET_DEV_BUF(dptr->flags)] = 1;      /* show we are busy */
         sim_debug(DEBUG_EXP, &mta_dev, "mt_startcmd sense return 0 chan %x cmd %x\n",
               chan, cmd);
         return 0;
@@ -488,7 +488,7 @@ uint8  mt_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
         uptr->SNS |= SNS_CMDREJ;
         break;
     }
-    if (uptr->SNS & 0xff000000)                      /* errors? */
+    if (uptr->SNS & 0xff000000)                     /* errors? */
         return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;
     sim_debug(DEBUG_EXP, &mta_dev,
               "mt_startcmd ret CHNEND|DEVEND chan %d unit %x cmd %x\n", chan, unit, cmd);
@@ -507,7 +507,7 @@ t_stat mt_error(UNIT *uptr, uint16 addr, t_stat r, DEVICE *dptr)
 
     case MTSE_TMK:                                  /* tape mark */
         sim_debug(DEBUG_CMD, &mta_dev, "FILE MARK\n");
-        uptr->SNS |= SNS_FMRKDT;                     /* file mark detected */
+        uptr->SNS |= SNS_FMRKDT;                    /* file mark detected */
         chan_end(addr, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
         break;
 
@@ -567,38 +567,38 @@ t_stat mt_srv(UNIT *uptr)
     }
 
     switch (cmd) {
-    case MT_CMDMSK:   /* 0x0ff for inch 0x00 */    /* INCH is for channel, nothing for us */
+    case MT_CMDMSK:   /* 0x0ff for inch 0x00 */     /* INCH is for channel, nothing for us */
         /* uptr->POS has INCH buffer address, just leave it */
         sim_debug(DEBUG_CMD, &mta_dev, "mt_srv cmd 0 INCH unit=%d\n", unit);
-        uptr->CMD &= ~MT_CMDMSK;                   /* clear the cmd */
-        mt_busy[bufnum] &= ~1;                     /* make our buffer not busy */
-        chan_end(addr, SNS_CHNEND|SNS_DEVEND);     /* we are done dev|chan end */
+        uptr->CMD &= ~MT_CMDMSK;                    /* clear the cmd */
+        mt_busy[bufnum] &= ~1;                      /* make our buffer not busy */
+        chan_end(addr, SNS_CHNEND|SNS_DEVEND);      /* we are done dev|chan end */
         break;
 
-    case MT_NOP:    /* 0x03 */                     /* NOP motion command */
-        uptr->CMD &= ~MT_CMDMSK;                   /* clear the cmd */
-        mt_busy[bufnum] &= ~1;                     /* make our buffer not busy */
-        chan_end(addr, SNS_CHNEND|SNS_DEVEND);     /* we are done dev|chan end */
+    case MT_NOP:    /* 0x03 */                      /* NOP motion command */
+        uptr->CMD &= ~MT_CMDMSK;                    /* clear the cmd */
+        mt_busy[bufnum] &= ~1;                      /* make our buffer not busy */
+        chan_end(addr, SNS_CHNEND|SNS_DEVEND);      /* we are done dev|chan end */
         break;
 
-    case MT_SENSE:  /* 0x04 */                     /* get sense data */
+    case MT_SENSE:  /* 0x04 */                      /* get sense data */
         sim_debug(DEBUG_CMD, &mta_dev, "mt_srv cmd 4 SENSE unit=%d\n", unit);
-        ch = (uptr->SNS >> 24) & 0xff;             /* get sense byte 0 status */
+        ch = (uptr->SNS >> 24) & 0xff;              /* get sense byte 0 status */
         sim_debug(DEBUG_DETAIL, &mta_dev, "sense unit %d byte 0 %x\n", unit, ch);
-        chan_write_byte(addr, &ch);                /* write byte 0 */
-        ch = (uptr->SNS >> 16) & 0xff;             /* get sense byte 1 status */
+        chan_write_byte(addr, &ch);                 /* write byte 0 */
+        ch = (uptr->SNS >> 16) & 0xff;              /* get sense byte 1 status */
         sim_debug(DEBUG_DETAIL, &mta_dev, "sense unit %d byte 1 %x\n", unit, ch);
-        chan_write_byte(addr, &ch);                /* write byte 1 */
-        ch = (uptr->SNS >> 8) & 0xff;              /* get sense byte 2 status */
+        chan_write_byte(addr, &ch);                 /* write byte 1 */
+        ch = (uptr->SNS >> 8) & 0xff;               /* get sense byte 2 status */
         sim_debug(DEBUG_DETAIL, &mta_dev, "sense unit %d byte 2 %x\n", unit, ch);
-        chan_write_byte(addr, &ch);                /* write byte 2 */
-        ch = (uptr->SNS >> 0) & 0xff;              /* get sense byte 3 status */
+        chan_write_byte(addr, &ch);                 /* write byte 2 */
+        ch = (uptr->SNS >> 0) & 0xff;               /* get sense byte 3 status */
         sim_debug(DEBUG_DETAIL, &mta_dev, "sense unit %d byte 3 %x\n", unit, ch);
-        chan_write_byte(addr, &ch);                /* write byte 3 */
+        chan_write_byte(addr, &ch);                 /* write byte 3 */
         ch = 4;
-        uptr->CMD &= ~MT_CMDMSK;                   /* clear the cmd */
-        mt_busy[bufnum] &= ~1;                     /* make our buffer not busy */
-        chan_end(addr, SNS_CHNEND|SNS_DEVEND);     /* we are done dev|chan end */
+        uptr->CMD &= ~MT_CMDMSK;                    /* clear the cmd */
+        mt_busy[bufnum] &= ~1;                      /* make our buffer not busy */
+        chan_end(addr, SNS_CHNEND|SNS_DEVEND);      /* we are done dev|chan end */
         sim_debug(DEBUG_CMD, &mta_dev, "mt_srv SENSE %x char complete unit=%d\n",
                      uptr->POS, unit);
         break;
@@ -628,8 +628,8 @@ t_stat mt_srv(UNIT *uptr)
                 uptr->CMD &= ~(MT_CMDMSK|MT_READDONE);   /* clear all but readdone & cmd */
                 return mt_error(uptr, addr, r, dptr);   /* process any error & return status */
             }
-            uptr->SNS &= ~(SNS_LOAD|SNS_EOT);        /* reset BOT & EOT */
-            uptr->POS = 0;                           /* reset buffer position */
+            uptr->SNS &= ~(SNS_LOAD|SNS_EOT);       /* reset BOT & EOT */
+            uptr->POS = 0;                          /* reset buffer position */
             uptr->hwmark = reclen;                  /* set buffer chars read in */
             sim_debug(DEBUG_DETAIL, &mta_dev, "mt_srv READ fill buffer complete count %x\n", reclen);
         }
@@ -645,13 +645,13 @@ t_stat mt_srv(UNIT *uptr)
                 chan_write_byte(addr, &ch);         /* write the byte */
                 sim_debug(DEBUG_CMD, &mta_dev, "Read unit %d send dump SLI\n", unit);
                 sim_activate(uptr, (uptr->hwmark-uptr->POS) * 10); /* wait again */
-                uptr->CMD |= MT_READDONE;            /* read is done */
+                uptr->CMD |= MT_READDONE;           /* read is done */
                 break;
             }
             sim_debug(DEBUG_CMD, &mta_dev,
                 "Read data @1 unit %d  cnt %x ch %02x hwm %x\n", unit, uptr->POS,
                          ch, uptr->hwmark);
-            uptr->CMD &= ~MT_CMDMSK;                 /* clear the cmd */
+            uptr->CMD &= ~MT_CMDMSK;                /* clear the cmd */
             mt_busy[bufnum] &= ~1;                  /* set not busy */
             chan_end(addr, SNS_CHNEND|SNS_DEVEND);  /* return end status */
         } else {
@@ -664,11 +664,11 @@ t_stat mt_srv(UNIT *uptr)
                         "Read data out of data unit %d cnt %x ch %02x hwm %x\n",
                         unit, uptr->POS, ch, uptr->hwmark);
 #ifdef UTX_EOF_CHANGE
-                uptr->CMD &= ~MT_CMDMSK;             /* clear the cmd */
+                uptr->CMD &= ~MT_CMDMSK;            /* clear the cmd */
                 mt_busy[bufnum] &= ~1;              /* set not busy */
                 chan_end(addr, SNS_CHNEND|SNS_DEVEND);  /* return end status */
 #else
-                uptr->CMD |= MT_READDONE;            /* read is done */
+                uptr->CMD |= MT_READDONE;           /* read is done */
                 sim_activate(uptr, 20);             /* wait again */
 #endif
             } else
@@ -680,23 +680,23 @@ t_stat mt_srv(UNIT *uptr)
         sim_debug(DEBUG_CMD, &mta_dev, "mt_srv cmd 0x83 SETM unit=%d\n", unit);
         /* Grab data until channel has no more */
         if (chan_read_byte(addr, &ch)) {
-            if (uptr->POS > 0) {                     /* Only if data in record */
+            if (uptr->POS > 0) {                    /* Only if data in record */
                 reclen = uptr->hwmark;              /* set record length */
                 ch = mt_buffer[bufnum][0];          /* get the first byte read */
                 sim_debug(DEBUG_CMD, &mta_dev,
                     "Write mode data done unit %d chars %d char %x\n", unit, reclen, ch);
                 /* put mode bits into byte 2 of SNS */
                 uptr->SNS = (uptr->SNS & 0xffff00ff) | (ch << 8);
-                uptr->POS = 0;                       /* no bytes anymore */
-                uptr->CMD &= ~MT_CMDMSK;             /* no cmd to do */
+                uptr->POS = 0;                      /* no bytes anymore */
+                uptr->CMD &= ~MT_CMDMSK;            /* no cmd to do */
                 mt_busy[bufnum] &= ~1;              /* set not busy */
                 chan_end(addr, SNS_CHNEND|SNS_DEVEND);  /* return end status */
             }
         } else {
-            mt_buffer[bufnum][uptr->POS++] = ch;     /* save the character read in */
+            mt_buffer[bufnum][uptr->POS++] = ch;    /* save the character read in */
             sim_debug(DEBUG_CMD, &mta_dev, "Write mode data in unit %d POS %d ch %0x\n",
                   unit, uptr->POS, ch);
-            uptr->hwmark = uptr->POS;                /* set high water mark */
+            uptr->hwmark = uptr->POS;               /* set high water mark */
             sim_activate(uptr, 20);                 /* wait time */
         }
         break;
@@ -714,7 +714,7 @@ t_stat mt_srv(UNIT *uptr)
 
          /* Grab data until channel has no more */
          if (chan_read_byte(addr, &ch)) {
-             if (uptr->POS > 0) {                    /* Only if data in record */
+             if (uptr->POS > 0) {                   /* Only if data in record */
                  reclen = uptr->hwmark;
                  sim_debug(DEBUG_DETAIL, &mta_dev, "Write unit=%d Block %d chars\n",
                         unit, reclen);
@@ -941,11 +941,11 @@ t_stat mt_srv(UNIT *uptr)
             r = sim_tape_sprecf(uptr, &reclen);
             if (r == MTSE_TMK) {
                 uptr->POS++;
-                uptr->SNS |= SNS_FMRKDT;             /* file mark detected */
+                uptr->SNS |= SNS_FMRKDT;            /* file mark detected */
                 sim_debug(DEBUG_DETAIL, &mta_dev, "FSF MARK\n");
                 sim_activate(uptr, 50);
             } else if (r == MTSE_EOM) {
-                uptr->SNS |= SNS_EOT;                /* set EOT status */
+                uptr->SNS |= SNS_EOT;               /* set EOT status */
                 uptr->POS+= 2;
                 sim_activate(uptr, 50);
             } else {
@@ -1030,10 +1030,10 @@ void mt_ini(UNIT *uptr, t_bool f)
     if (MT_DENS(uptr->dynflags) == 0)
         uptr->dynflags |= MT_DENS_6250 << UNIT_S_DF_TAPE;
 
-    uptr->CMD &= ~0xffff;                     /* clear out the flags but leave ch/sa */
-    uptr->SNS = 0;                            /* clear sense data */
-    uptr->SNS |= (SNS_RDY|SNS_ONLN|SNS_LOAD); /* set initial status */
-    mt_busy[GET_DEV_BUF(dptr->flags)] = 0;    /* set not busy */
+    uptr->CMD &= ~0xffff;                           /* clear out the flags but leave ch/sa */
+    uptr->SNS = 0;                                  /* clear sense data */
+    uptr->SNS |= (SNS_RDY|SNS_ONLN|SNS_LOAD);       /* set initial status */
+    mt_busy[GET_DEV_BUF(dptr->flags)] = 0;          /* set not busy */
     sim_debug(DEBUG_EXP, dptr, "MT init device %s unit %x\n", dptr->name,
                  GET_UADDR(uptr->CMD));
 }
@@ -1055,11 +1055,11 @@ t_stat mt_attach(UNIT *uptr, CONST char *file)
     /* mount the specified file to the MT */
     if ((r = sim_tape_attach(uptr, file)) != SCPE_OK) {
        sim_debug(DEBUG_EXP, &mta_dev, "mt_attach ERROR filename %s status %x\n", file, r);
-       return r;                                        /* report any error */
+       return r;                                    /* report any error */
     }
     sim_debug(DEBUG_EXP, &mta_dev, "mt_attach complete filename %s\n", file);
-    set_devattn(addr, SNS_DEVEND);                      /* ready int???? */
-    return SCPE_OK;                                     /* return good status */
+    set_devattn(addr, SNS_DEVEND);                  /* ready int???? */
+    return SCPE_OK;                                 /* return good status */
 }
 
 /* detach the MT device and unload any tape */
@@ -1073,19 +1073,19 @@ t_stat mt_detach(UNIT *uptr)
 /* boot from the specified tape unit */
 t_stat mt_boot(int32 unit_num, DEVICE *dptr)
 {
-    UNIT    *uptr = &dptr->units[unit_num];       /* find tape unit pointer */
+    UNIT    *uptr = &dptr->units[unit_num];         /* find tape unit pointer */
 
     sim_debug(DEBUG_EXP, &mta_dev, "MT Boot dev/unit %x\n", GET_UADDR(uptr->CMD));
-    if ((uptr->flags & UNIT_ATT) == 0) {          /* Is MT device already attached? */
+    if ((uptr->flags & UNIT_ATT) == 0) {            /* Is MT device already attached? */
         sim_debug(DEBUG_EXP, &mta_dev, "MT Boot attach error dev/unit %x\n",
                GET_UADDR(uptr->CMD));
-        return SCPE_UNATT;                        /* not attached, return error */
+        return SCPE_UNATT;                          /* not attached, return error */
     }
-    SPAD[0xf4] = GET_UADDR(uptr->CMD);            /* put boot device chan/sa into spad */
-    SPAD[0xf8] = 0xF000;                          /* show as F class device */
+    SPAD[0xf4] = GET_UADDR(uptr->CMD);              /* put boot device chan/sa into spad */
+    SPAD[0xf8] = 0xF000;                            /* show as F class device */
 
-    uptr->CMD &= ~0xffff;                         /* clear out old status */
-    return chan_boot(GET_UADDR(uptr->CMD), dptr); /* boot the ch/sa */
+    uptr->CMD &= ~0xffff;                           /* clear out old status */
+    return chan_boot(GET_UADDR(uptr->CMD), dptr);   /* boot the ch/sa */
 }
 
 t_stat mt_help(FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr)

--- a/SEL32/sel32_scfi.c
+++ b/SEL32/sel32_scfi.c
@@ -119,9 +119,9 @@ bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option
 
 /* u4 - sector target address register (STAR) */
 /* Holds the current cylinder, head(track), sector */
-#define DISK_CYL            0xFFFF0000  /* cylinder mask */
-#define DISK_TRACK          0x0000FF00  /* track mask */
-#define DISK_SECTOR         0x000000ff  /* sector mask */
+#define DISK_CYL           0xFFFF0000   /* cylinder mask */
+#define DISK_TRACK         0x0000FF00   /* track mask */
+#define DISK_SECTOR        0x000000ff   /* sector mask */
 
 /* u5 */
 /* Sense byte 0  - mode register */
@@ -318,7 +318,7 @@ CHANP           sda_chp[NUM_UNITS_SCFI] = {0};
 
 MTAB            scfi_mod[] = {
     {MTAB_XTD | MTAB_VUN | MTAB_VALR, 0, "TYPE", "TYPE",
-     &scfi_set_type, &scfi_get_type, NULL, "Type of disk"},
+    &scfi_set_type, &scfi_get_type, NULL, "Type of disk"},
     {MTAB_XTD | MTAB_VUN | MTAB_VALR, 0, "DEV", "DEV", &set_dev_addr,
         &show_dev_addr, NULL, "Device channel address"},
     {0}
@@ -418,7 +418,7 @@ uint8  scfi_preio(UNIT *uptr, uint16 chan)
         return SNS_BSY;
     }
     sim_debug(DEBUG_CMD, dptr, "scfi_preio unit=%d\n", unit);
-    return 0;       /* good to go */
+    return 0;                           /* good to go */
 }
 
 uint8  scfi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd) {
@@ -527,7 +527,11 @@ dosns:
             up++;                           /* next unit for this device */
         }
         sim_debug(DEBUG_CMD, dptr, "scfi_startcmd done inch cmd addr %x\n", addr);
-        return SNS_CHNEND|SNS_DEVEND;
+//      return SNS_CHNEND|SNS_DEVEND;
+//      break;
+        uptr->u3 |= DSK_CMDMSK;             /* use 0xff for inch, just need int */
+        sim_activate(uptr, 20);             /* start things off */
+        return (0);
         break;
     }
 
@@ -542,12 +546,20 @@ dosns:
         sim_debug(DEBUG_CMD, dptr, "scfi_startcmd done with disk seek r/w cmd %x addr %x\n", cmd, addr);
         sim_activate(uptr, 20);     /* start things off */
         return 0;
+        break;
 
     case DSK_NOP:                   /* NOP 0x03 */
-        return SNS_CHNEND|SNS_DEVEND;   /* return OK */
+//      return SNS_CHNEND|SNS_DEVEND;   /* return OK */
+        uptr->u3 |= cmd;            /* save cmd */
+        sim_activate(uptr, 20);     /* start things off */
+        return 0;
+        break;
 
     case DSK_SNS:                   /* Sense 0x04 */
-        goto dosns;                 /* use code above */
+        uptr->u3 |= cmd;            /* save cmd */
+        sim_activate(uptr, 20);     /* start things off */
+        return 0;
+//      goto dosns;                 /* use code above */
         break;
     }
     sim_debug(DEBUG_CMD, dptr, "scfi_startcmd done with scfi_startcmd %x addr %x u5 %x\n", cmd, addr, uptr->u5);
@@ -589,27 +601,35 @@ t_stat scfi_srv(UNIT *uptr)
 
     sim_debug(DEBUG_CMD, dptr, "scfi_srv cmd=%x chsa %04x count %x\n", cmd, chsa, chp->ccw_count);
     switch (cmd) {
-    case 0:                               /* No command, stop disk */
+    case 0:                                     /* No command, stop disk */
          break;
 
+    case DSK_CMDMSK:                            /* use 0xff for inch, just need int */
+    case DSK_NOP:                               /* NOP 0x03 */
+        uptr->u3 &= ~(0xffff);                  /* remove old cmd */
+        sim_debug(DEBUG_CMD, dptr, "disk_srv cmd=%x chsa %04x count %x completed\n", cmd, chsa, chp->ccw_count);
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* return OK */
+        break;
+
+
     case DSK_SNS: /* 0x4 */
-         ch = uptr->u5 & 0xff;
-         sim_debug(DEBUG_DETAIL, dptr, "scfi_srv sense unit=%d 1 %x\n", unit, ch);
-         chan_write_byte(chsa, &ch) ;
-         ch = (uptr->u5 >> 8) & 0xff;
-         sim_debug(DEBUG_DETAIL, dptr, "scfi_srv sense unit=%d 2 %x\n", unit, ch);
-         chan_write_byte(chsa, &ch) ;
-         ch = 0;
-         sim_debug(DEBUG_DETAIL, dptr, "scfi_srv sense unit=%d 3 %x\n", unit, ch);
-         chan_write_byte(chsa, &ch) ;
-         ch = unit;
-         sim_debug(DEBUG_DETAIL, dptr, "scfi_srv sense unit=%d 4 %x\n", unit, ch);
-         chan_write_byte(chsa, &ch) ;
+        ch = uptr->u5 & 0xff;
+        sim_debug(DEBUG_DETAIL, dptr, "scfi_srv sense unit=%d 1 %x\n", unit, ch);
+        chan_write_byte(chsa, &ch) ;
+        ch = (uptr->u5 >> 8) & 0xff;
+        sim_debug(DEBUG_DETAIL, dptr, "scfi_srv sense unit=%d 2 %x\n", unit, ch);
+        chan_write_byte(chsa, &ch) ;
+        ch = 0;
+        sim_debug(DEBUG_DETAIL, dptr, "scfi_srv sense unit=%d 3 %x\n", unit, ch);
+        chan_write_byte(chsa, &ch) ;
+        ch = unit;
+        sim_debug(DEBUG_DETAIL, dptr, "scfi_srv sense unit=%d 4 %x\n", unit, ch);
+        chan_write_byte(chsa, &ch) ;
         ch = 4;
         sim_debug(DEBUG_CMD, dptr, "DISK SENSE %x chars complete %.8x, unit %d\n", ch, uptr->u5, unit);
-         uptr->u3 &= ~(0xff00);
-         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
-         break;
+        uptr->u3 &= ~(0xff00);
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
+        break;
 
     case DSK_SCK:            /* Seek cylinder, track, sector 0x07 */
 

--- a/SEL32/sel32_sys.c
+++ b/SEL32/sel32_sys.c
@@ -843,6 +843,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
             case TYPE_D:                 /* r,[*]o[,x] or r,o[(b)],[,x] */
                 if ((tab->type & 0xF) != TYPE_E) {
                     fputc(' ', of);
+//                    fputc('R', of);
                     /* output the reg or bit number */
                     fputc('0'+((inst>>7) & 07), of);
                     fputc(',', of);
@@ -859,11 +860,14 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
                     fprint_val(of, val&0xffff, 16, 16, PV_LEFT);    /* output 16 bit offset */
                     if (inst & 07) {
                         fputc('(', of);
+//                        fputc('B', of);
                         fputc(('0'+(inst & 07)), of);           /* output the base reg number */
                         fputc(')', of);
                     }
-                    if (inst & 0x70) {
+//                    if (inst & 0x70) {
+                    if ((inst & 0x70) && (tab->type != TYPE_D)) {
                         fputc(',', of);
+//                        fputc('R', of);
                         fputc(('0'+((inst >> 4) & 07)), of);    /* output the index reg number */
                     }
                 } else {
@@ -873,6 +877,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
                     fprint_val(of, val&0x7ffff, 16, 19, PV_LEFT);   /* 19 bit offset */
                     if (inst & 0x60) {
                         fputc(',', of);                         /* register coming */
+//                        fputc('R', of);
                         if (tab->type != TYPE_D)
                             fputc('0'+((inst & 0x60) >> 5), of);    /* output the index reg number */
                         else { 
@@ -886,6 +891,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
             /* immediate or XIO instructions */
             case TYPE_C:                    /* r,v */
                 fputc(' ', of);
+//                fputc('R', of);
                 fputc('0'+((inst>>7) & 07), of);                /* index reg number */
                 fputc(',', of);
                 fprint_val(of, val&0xffff, 16, 16, PV_LEFT);    /* 16 bit imm val or chan/suba */
@@ -894,14 +900,17 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
             /* reg - reg instructions */
             case TYPE_F:                    /* rs,rd */
                 fputc(' ', of);
+//                fputc('R', of);
                 fputc('0'+((inst>>4) & 07), of);                /* src reg */
                 fputc(',', of);
+//                fputc('R', of);
                 fputc('0'+((inst>>7) & 07), of);                /* dest reg */
                 break;
 
             /* single reg instructions */
             case TYPE_G:                    /* op r */
                 fputc(' ', of);
+//                fputc('R', of);
                 fputc('0'+((inst>>7) & 07), of);                /* output src/dest reg  num */
                 break;
 
@@ -912,6 +921,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
             /* reg and bit shift cnt */
             case TYPE_I:                    /* r,b */
                 fputc(' ', of);
+//                fputc('R', of);
                 fputc('0'+((inst>>7) & 07), of);                /* reg number */
                 fputc(',', of);
                 fprint_val(of, inst&0x1f, 10, 5, PV_LEFT);      /* 5 bit shift count */
@@ -920,6 +930,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
             /* register bit operations */
             case TYPE_K:                 /* r,rb */
                 fputc(' ', of);
+//                fputc('R', of);
                 fputc('0'+((inst>>4) & 07), of);                /* register number */
                 fputc(',', of);
                 i = ((inst & 3) << 3) | ((inst >> 7) & 07);


### PR DESCRIPTION
SEL32: Do some code cleanup.

With these changes the restart command now works in MPX.  That allows online restart to a new sysgen'd image.
Also changed the sel32_scfi.c code to force interrupt in response to an INCH command like sel32_disk.c.
Grab it and I will continue with diags and UTX testing.