### PR TITLE
KA10: aux CPU range should be configurable

### DIFF
--- a/PDP10/ka10_auxcpu.c
+++ b/PDP10/ka10_auxcpu.c
@@ -54,12 +54,15 @@
 
 static int pia = 0;
 static int status = 0;
+int auxcpu_base = 03000000;
 
 static t_stat auxcpu_devio(uint32 dev, t_uint64 *data);
 static t_stat auxcpu_svc (UNIT *uptr);
 static t_stat auxcpu_reset (DEVICE *dptr);
 static t_stat auxcpu_attach (UNIT *uptr, CONST char *ptr);
 static t_stat auxcpu_detach (UNIT *uptr);
+static t_stat auxcpu_set_base (UNIT *uptr, int32 val, CONST char *cptr, void *desc);
+static t_stat auxcpu_show_base (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 static t_stat auxcpu_attach_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr);
 static const char *auxcpu_description (DEVICE *dptr);
 
@@ -73,6 +76,8 @@ static REG auxcpu_reg[] = {
 };
 
 static MTAB auxcpu_mod[] = {
+    { MTAB_XTD|MTAB_VDV|MTAB_VALR, 0, "base address", "BASE",
+          &auxcpu_set_base, &auxcpu_show_base },
     { 0 }
 };
 
@@ -387,6 +392,28 @@ t_stat auxcpu_devio(uint32 dev, t_uint64 *data)
         break;
     }
 
+    return SCPE_OK;
+}
+
+static t_stat auxcpu_set_base (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
+{
+    t_stat r;
+    int x;
+
+    if (cptr == NULL || *cptr == 0)
+        return SCPE_ARG;
+
+    x = get_uint (cptr, 8, 03777777, &r);
+    if (r != SCPE_OK)
+        return SCPE_ARG;
+
+    auxcpu_base = x;
+    return SCPE_OK;
+}
+
+static t_stat auxcpu_show_base (FILE *st, UNIT *uptr, int32 val, CONST void *desc)
+{
+    fprintf (st, "Base: %o", auxcpu_base);
     return SCPE_OK;
 }
 #endif

--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -221,7 +221,8 @@ int32   tmxr_poll = 10000;
 /* Physical address range for Rubin 10-11 interface. */
 #define T11RANGE(addr)  ((addr) >= 03040000)
 /* Physical address range for auxiliary PDP-6. */
-#define AUXCPURANGE(addr)  ((addr) >= 03000000 && (addr) < 03040000)
+extern int auxcpu_base;
+#define AUXCPURANGE(addr)  ((addr) >= auxcpu_base && (addr) < (auxcpu_base + 040000))
 
 DEVICE *rh_devs[] = {
 #if (NUM_DEVS_RS > 0)


### PR DESCRIPTION
ITS 724 has the auxiliary CPU at 1,,040000 rather than 3,,000000.

The AUXCPURANGE define in kx10_cpu.c needs to be replaced with a run-time value determined by a CPU modifier.