### PR TITLE
KA10: reading 7-track magtapes doesn't check against parity bit

### DIFF
--- a/PDP10/kx10_mt.c
+++ b/PDP10/kx10_mt.c
@@ -616,7 +616,7 @@ t_stat mt_srv(UNIT * uptr)
                 cc = 6 * (5 - uptr->CPOS);
                 ch = mt_buffer[uptr->BPOS];
                 if ((((uptr->CNTRL & ODD_PARITY) ? 0x40 : 0) ^
-                      parity_table[ch & 0x3f]) != 0) {
+                      parity_table[ch & 0x3f]) != (ch & 0x40)) {
                       mt_status |= PARITY_ERR;
                 }
                 mt_df10.buf |= (uint64)(ch & 0x3f) << cc;


### PR DESCRIPTION
Computed parity from 6-bit frame isn't compared against the parity bit.

I looked at the CMP case and copied the code from there.