### PR TITLE
KA10: ITS idling

### DIFF
--- a/PDP10/ka10_auxcpu.c
+++ b/PDP10/ka10_auxcpu.c
@@ -187,7 +187,7 @@ static t_stat auxcpu_svc (UNIT *uptr)
     auxcpu_ldsc.rcve = 1;
     uptr->wait = AUXCPU_POLL;
   }
-  sim_activate (uptr, uptr->wait);
+  sim_clock_coschedule (uptr, uptr->wait);
   return SCPE_OK;
 }
 

--- a/PDP10/ka10_dpk.c
+++ b/PDP10/ka10_dpk.c
@@ -86,7 +86,7 @@ static int dpk_ird = 0;
 static int dpk_iwr = 0;
 
 UNIT                dpk_unit[] = {
-    {UDATA(dpk_svc, TT_MODE_8B|UNIT_ATTABLE|UNIT_DISABLE, 0)},  /* 0 */
+    {UDATA(dpk_svc, TT_MODE_8B|UNIT_IDLE|UNIT_ATTABLE|UNIT_DISABLE, 0)},  /* 0 */
 };
 DIB dpk_dib = {DPK_DEVNUM, 1, &dpk_devio, NULL};
 
@@ -264,7 +264,7 @@ static t_stat dpk_svc (UNIT *uptr)
     int i;
 
     /* 16 ports at 4800 baud, rounded up. */
-    sim_activate_after (uptr, 200);
+    sim_clock_coschedule (uptr, 200);
 
     i = tmxr_poll_conn (&dpk_desc);
     if (i >= 0) {

--- a/PDP10/ka10_mty.c
+++ b/PDP10/ka10_mty.c
@@ -65,7 +65,7 @@ TMXR mty_desc = { MTY_LINES, 0, 0, mty_ldsc };
 static uint64 status = 0;
 
 UNIT                mty_unit[] = {
-    {UDATA(mty_svc, TT_MODE_7B|UNIT_ATTABLE|UNIT_DISABLE, 0)},  /* 0 */
+    {UDATA(mty_svc, TT_MODE_7B|UNIT_IDLE|UNIT_ATTABLE|UNIT_DISABLE, 0)},  /* 0 */
 };
 DIB mty_dib = {MTY_DEVNUM, 1, &mty_devio, NULL};
 
@@ -171,7 +171,7 @@ static t_stat mty_svc (UNIT *uptr)
     int i;
 
     /* High speed device, poll every 0.1 ms. */
-    sim_activate_after (uptr, 100);
+    sim_clock_coschedule (uptr, 100);
 
     i = tmxr_poll_conn (&mty_desc);
     if (i >= 0) {

--- a/PDP10/ka10_ten11.c
+++ b/PDP10/ka10_ten11.c
@@ -184,7 +184,7 @@ static t_stat ten11_svc (UNIT *uptr)
     ten11_ldsc.rcve = 1;
     uptr->wait = TEN11_POLL;
   }
-  sim_activate (uptr, uptr->wait);
+  sim_clock_coschedule (uptr, uptr->wait);
   return SCPE_OK;
 }
 

--- a/PDP10/ka10_tk10.c
+++ b/PDP10/ka10_tk10.c
@@ -69,7 +69,7 @@ TMXR tk10_desc = { TK10_LINES, 0, 0, tk10_ldsc };
 static uint64 status = 0;
 
 UNIT                tk10_unit[] = {
-    {UDATA(tk10_svc, TT_MODE_7B|UNIT_ATTABLE|UNIT_DISABLE, 0)},  /* 0 */
+    {UDATA(tk10_svc, TT_MODE_7B|UNIT_IDLE|UNIT_ATTABLE|UNIT_DISABLE, 0)},  /* 0 */
 };
 DIB tk10_dib = {TK10_DEVNUM, 1, &tk10_devio, NULL};
 
@@ -185,7 +185,7 @@ static t_stat tk10_svc (UNIT *uptr)
     int i;
 
     /* Slow hardware only supported 300 baud teletypes. */
-    sim_activate_after (uptr, 2083);
+    sim_clock_coschedule (uptr, 2083);
 
     i = tmxr_poll_conn (&tk10_desc);
     if (i >= 0) {


### PR DESCRIPTION
The typical ITS configuration runs at 100% host CPU utilization.  How do I fix this?  How do I know which devices are not idling properly?