### PR TITLE
KA10: idling for DPY

### DIFF
--- a/PDP10/kx10_dpy.c
+++ b/PDP10/kx10_dpy.c
@@ -246,6 +246,8 @@ t_stat dpy_devio(uint32 dev, uint64 *data) {
             dpy_update_status( uptr, ty340_reset(&dpy_dev), 1);
         sim_debug(DEBUG_CONO, &dpy_dev, "DPY %03o CONO %06o PC=%06o %06o\n",
                   dev, (uint32)*data, PC, uptr->STAT_REG & ~STAT_VALID);
+        if (!sim_is_active(uptr))
+            sim_activate_after(uptr, DPY_CYCLE_US);
         break;
 
     case DATAO:
@@ -262,6 +264,8 @@ t_stat dpy_devio(uint32 dev, uint64 *data) {
             inst = (uint32)RRZ(*data);
             dpy_update_status(uptr, ty340_instruction(inst), 1);
         }
+        if (!sim_is_active(uptr))
+            sim_activate_after(uptr, DPY_CYCLE_US);
         break;
 
     case DATAI:
@@ -276,7 +280,8 @@ t_stat dpy_devio(uint32 dev, uint64 *data) {
 /* Timer service - */
 t_stat dpy_svc (UNIT *uptr)
 {
-    sim_activate_after(uptr, DPY_CYCLE_US); /* requeue! */
+    if (!display_is_blank() || uptr->INT_COUNTDOWN > 0)
+        sim_activate_after(uptr, DPY_CYCLE_US); /* requeue! */
 
     display_age(DPY_CYCLE_US, 0);       /* age the display */
 

--- a/Visual Studio Projects/PDP10-KA.vcproj
+++ b/Visual Studio Projects/PDP10-KA.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="../PDP10/;../PDP11/;../VAX/;../../windows-build/libSDL/SDL2-2.0.5/include;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/winpcap/Wpdpack/Include;../../windows-build/PCRE/include/;../../windows-build/pthreads;../../windows-build/libSDL/SDL2-2.0.8/include;../../windows-build/libpng-1.6.18"
-				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KA=1;USE_DISPLAY;USE_SIM_VIDEO;HAVE_LIBSDL;USE_SHARED;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC;PTW32_STATIC_LIB;USE_READER_THREAD;SIM_ASYNCH_IO"
+				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KA=1;USE_DISPLAY;USE_SIM_VIDEO;HAVE_LIBSDL;USE_SHARED;HAVE_SLIRP_NETWORK;USE_SIMH_SLIRP_DEBUG;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC;PTW32_STATIC_LIB;USE_READER_THREAD;SIM_ASYNCH_IO"
 				KeepComments="false"
 				BasicRuntimeChecks="0"
 				RuntimeLibrary="1"
@@ -126,7 +126,7 @@
 				OmitFramePointers="true"
 				WholeProgramOptimization="true"
 				AdditionalIncludeDirectories="../PDP10/;../PDP11/;../VAX/;../../windows-build/libSDL/SDL2-2.0.5/include;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/winpcap/Wpdpack/Include;../../windows-build/PCRE/include/;../../windows-build/pthreads;../../windows-build/libSDL/SDL2-2.0.8/include;../../windows-build/libpng-1.6.18"
-				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KA=1;USE_DISPLAY;USE_SIM_VIDEO;HAVE_LIBSDL;USE_SHARED;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC;PTW32_STATIC_LIB;USE_READER_THREAD;SIM_ASYNCH_IO"
+				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KA=1;USE_DISPLAY;USE_SIM_VIDEO;HAVE_LIBSDL;USE_SHARED;HAVE_SLIRP_NETWORK;USE_SIMH_SLIRP_DEBUG;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC;PTW32_STATIC_LIB;USE_READER_THREAD;SIM_ASYNCH_IO"
 				StringPooling="true"
 				RuntimeLibrary="0"
 				EnableFunctionLevelLinking="true"
@@ -193,6 +193,10 @@
 			Name="Source Files"
 			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm"
 			>
+			<File
+				RelativePath="..\PDP10\ka10_ai.c"
+				>
+			</File>
 			<File
 				RelativePath="..\PDP10\ka10_auxcpu.c"
 				>
@@ -425,6 +429,170 @@
 				</File>
 				<File
 					RelativePath="..\display\type340.h"
+					>
+				</File>
+			</Filter>
+			<Filter
+				Name="slirp"
+				>
+				<File
+					RelativePath="..\slirp\arp_table.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\bootp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\bootp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\cksum.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\debug.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\dnssearch.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp_glue\glib_qemu_stubs.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\if.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\if.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_icmp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_icmp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_input.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_output.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\libslirp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\main.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\mbuf.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\mbuf.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\misc.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\misc.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\sbuf.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\sbuf.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp_glue\sim_slirp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp_config.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\socket.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\socket.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_input.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_output.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_subr.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_timer.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_timer.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_var.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcpip.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tftp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tftp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\udp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\udp.h"
 					>
 				</File>
 			</Filter>

--- a/Visual Studio Projects/PDP10-KI.vcproj
+++ b/Visual Studio Projects/PDP10-KI.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="../PDP10/;../PDP11/;../VAX/;../../windows-build/libSDL/SDL2-2.0.5/include;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/winpcap/Wpdpack/Include;../../windows-build/PCRE/include/;../../windows-build/pthreads;../../windows-build/libSDL/SDL2-2.0.8/include;../../windows-build/libpng-1.6.18"
-				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KI=1;USE_SHARED;USE_DISPLAY;DISPLAY_TYPE=DIS_TYPE30;PIX_SCALE=RES_HALF;USE_SIM_VIDEO;HAVE_LIBSDL;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC"
+				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KI=1;USE_SHARED;HAVE_SLIRP_NETWORK;USE_SIMH_SLIRP_DEBUGUSE_DISPLAY;DISPLAY_TYPE=DIS_TYPE30;PIX_SCALE=RES_HALF;USE_SIM_VIDEO;HAVE_LIBSDL;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC"
 				KeepComments="false"
 				BasicRuntimeChecks="0"
 				RuntimeLibrary="1"
@@ -126,7 +126,7 @@
 				OmitFramePointers="true"
 				WholeProgramOptimization="true"
 				AdditionalIncludeDirectories="../PDP10/;../PDP11/;../VAX/;../../windows-build/libSDL/SDL2-2.0.5/include;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/winpcap/Wpdpack/Include;../../windows-build/PCRE/include/;../../windows-build/pthreads;../../windows-build/libSDL/SDL2-2.0.8/include;../../windows-build/libpng-1.6.18"
-				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KI=1;USE_SHARED;USE_DISPLAY;DISPLAY_TYPE=DIS_TYPE30;PIX_SCALE=RES_HALF;USE_SIM_VIDEO;HAVE_LIBSDL;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC"
+				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KI=1;USE_SHARED;HAVE_SLIRP_NETWORK;USE_SIMH_SLIRP_DEBUGUSE_DISPLAY;DISPLAY_TYPE=DIS_TYPE30;PIX_SCALE=RES_HALF;USE_SIM_VIDEO;HAVE_LIBSDL;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC"
 				StringPooling="true"
 				RuntimeLibrary="0"
 				EnableFunctionLevelLinking="true"
@@ -361,6 +361,170 @@
 				</File>
 				<File
 					RelativePath="..\display\type340.h"
+					>
+				</File>
+			</Filter>
+			<Filter
+				Name="slirp"
+				>
+				<File
+					RelativePath="..\slirp\arp_table.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\bootp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\bootp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\cksum.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\debug.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\dnssearch.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp_glue\glib_qemu_stubs.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\if.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\if.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_icmp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_icmp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_input.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_output.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\libslirp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\main.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\mbuf.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\mbuf.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\misc.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\misc.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\sbuf.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\sbuf.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp_glue\sim_slirp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp_config.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\socket.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\socket.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_input.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_output.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_subr.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_timer.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_timer.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_var.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcpip.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tftp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tftp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\udp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\udp.h"
 					>
 				</File>
 			</Filter>

--- a/display/display.c
+++ b/display/display.c
@@ -440,6 +440,15 @@ queue_point(struct point *p)
 }
 
 /*
+ * Return true if the display is blank, i.e. no active points in list.
+ */
+int
+display_is_blank(void)
+{
+    return head->next == head;
+}
+
+/*
  * here to to dynamically adjust interval for examination
  * of elapsed vs. simulated time, and fritter away
  * any extra wall-clock time without eating CPU

--- a/display/display.h
+++ b/display/display.h
@@ -84,6 +84,11 @@ extern int display_scale(void);
 extern int display_age(int,int);
 
 /*
+ * Return true if the display is blank.
+ */
+extern int display_is_blank(void);
+
+/*
  * display intensity levels.
  * always at least 8 (for VT11/VS60) -- may be mapped internally
  */


### PR DESCRIPTION
The current version of the Type 340 display DPY device doesn't do well with idling, causing the host CPU to run at 100%.

The svc routine runs every 50 microseconds.  I tried replacing sim_activate_after with sim_clock_coschedule.  While that was good for idling, it wasn't good for display updates.

If there is no way to reduce host CPU usage with an active display, it should still be possible to have it idling with a blank display.

CC @philbudne, @markpizz 