### PR TITLE
Kx10: idle when UUO handler is 0.

### DIFF
--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -2796,9 +2796,17 @@ st_pi:
 #endif
 
     /* Check if possible idle loop */
-    if (sim_idle_enab && (FLAGS & USER) != 0 && PC < 020 && AB < 020 &&
-           (IR & 0760) == 0340) {
-       sim_idle (TMR_RTC, FALSE);
+    if (sim_idle_enab) {
+        /* Operating system idle loop: AOJA or SOJA in register. */
+        if ((FLAGS & USER) != 0 && PC < 020 && AB < 020 &&
+               (IR & 0760) == 0340)
+            sim_idle (TMR_RTC, FALSE);
+        /* MUUO handler loop.  This typically happens when ITS wants
+           to reset the auxiliary PDP-6.  ITS clear PDP-6 core which
+           makes it execute a 0, which calls the MUUO handler at 41,
+           which is 0, and then we loop. */
+        if ((FLAGS & USER) == 0 && uuo_cycle && IA == 041 && IR == 0)
+            sim_idle (TMR_RTC, FALSE);
     }
 
     /* Update history */

--- a/Visual Studio Projects/PDP10-KA.vcproj
+++ b/Visual Studio Projects/PDP10-KA.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="../PDP10/;../PDP11/;../VAX/;../../windows-build/libSDL/SDL2-2.0.5/include;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/winpcap/Wpdpack/Include;../../windows-build/PCRE/include/;../../windows-build/pthreads;../../windows-build/libSDL/SDL2-2.0.8/include;../../windows-build/libpng-1.6.18"
-				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KA=1;USE_DISPLAY;USE_SIM_VIDEO;HAVE_LIBSDL;USE_SHARED;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC;PTW32_STATIC_LIB;USE_READER_THREAD;SIM_ASYNCH_IO"
+				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KA=1;USE_DISPLAY;USE_SIM_VIDEO;HAVE_LIBSDL;USE_SHARED;HAVE_SLIRP_NETWORK;USE_SIMH_SLIRP_DEBUG;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC;PTW32_STATIC_LIB;USE_READER_THREAD;SIM_ASYNCH_IO"
 				KeepComments="false"
 				BasicRuntimeChecks="0"
 				RuntimeLibrary="1"
@@ -126,7 +126,7 @@
 				OmitFramePointers="true"
 				WholeProgramOptimization="true"
 				AdditionalIncludeDirectories="../PDP10/;../PDP11/;../VAX/;../../windows-build/libSDL/SDL2-2.0.5/include;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/winpcap/Wpdpack/Include;../../windows-build/PCRE/include/;../../windows-build/pthreads;../../windows-build/libSDL/SDL2-2.0.8/include;../../windows-build/libpng-1.6.18"
-				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KA=1;USE_DISPLAY;USE_SIM_VIDEO;HAVE_LIBSDL;USE_SHARED;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC;PTW32_STATIC_LIB;USE_READER_THREAD;SIM_ASYNCH_IO"
+				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KA=1;USE_DISPLAY;USE_SIM_VIDEO;HAVE_LIBSDL;USE_SHARED;HAVE_SLIRP_NETWORK;USE_SIMH_SLIRP_DEBUG;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC;PTW32_STATIC_LIB;USE_READER_THREAD;SIM_ASYNCH_IO"
 				StringPooling="true"
 				RuntimeLibrary="0"
 				EnableFunctionLevelLinking="true"
@@ -193,6 +193,10 @@
 			Name="Source Files"
 			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm"
 			>
+			<File
+				RelativePath="..\PDP10\ka10_ai.c"
+				>
+			</File>
 			<File
 				RelativePath="..\PDP10\ka10_auxcpu.c"
 				>
@@ -425,6 +429,170 @@
 				</File>
 				<File
 					RelativePath="..\display\type340.h"
+					>
+				</File>
+			</Filter>
+			<Filter
+				Name="slirp"
+				>
+				<File
+					RelativePath="..\slirp\arp_table.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\bootp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\bootp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\cksum.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\debug.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\dnssearch.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp_glue\glib_qemu_stubs.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\if.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\if.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_icmp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_icmp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_input.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_output.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\libslirp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\main.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\mbuf.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\mbuf.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\misc.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\misc.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\sbuf.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\sbuf.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp_glue\sim_slirp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp_config.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\socket.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\socket.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_input.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_output.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_subr.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_timer.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_timer.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_var.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcpip.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tftp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tftp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\udp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\udp.h"
 					>
 				</File>
 			</Filter>

--- a/Visual Studio Projects/PDP10-KI.vcproj
+++ b/Visual Studio Projects/PDP10-KI.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="../PDP10/;../PDP11/;../VAX/;../../windows-build/libSDL/SDL2-2.0.5/include;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/winpcap/Wpdpack/Include;../../windows-build/PCRE/include/;../../windows-build/pthreads;../../windows-build/libSDL/SDL2-2.0.8/include;../../windows-build/libpng-1.6.18"
-				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KI=1;USE_SHARED;USE_DISPLAY;DISPLAY_TYPE=DIS_TYPE30;PIX_SCALE=RES_HALF;USE_SIM_VIDEO;HAVE_LIBSDL;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC"
+				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KI=1;USE_SHARED;HAVE_SLIRP_NETWORK;USE_SIMH_SLIRP_DEBUGUSE_DISPLAY;DISPLAY_TYPE=DIS_TYPE30;PIX_SCALE=RES_HALF;USE_SIM_VIDEO;HAVE_LIBSDL;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC"
 				KeepComments="false"
 				BasicRuntimeChecks="0"
 				RuntimeLibrary="1"
@@ -126,7 +126,7 @@
 				OmitFramePointers="true"
 				WholeProgramOptimization="true"
 				AdditionalIncludeDirectories="../PDP10/;../PDP11/;../VAX/;../../windows-build/libSDL/SDL2-2.0.5/include;./;../;../slirp;../slirp_glue;../slirp_glue/qemu;../slirp_glue/qemu/win32/include;../../windows-build/winpcap/Wpdpack/Include;../../windows-build/PCRE/include/;../../windows-build/pthreads;../../windows-build/libSDL/SDL2-2.0.8/include;../../windows-build/libpng-1.6.18"
-				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KI=1;USE_SHARED;USE_DISPLAY;DISPLAY_TYPE=DIS_TYPE30;PIX_SCALE=RES_HALF;USE_SIM_VIDEO;HAVE_LIBSDL;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC"
+				PreprocessorDefinitions="USE_INT64;USE_SIM_CARD;KI=1;USE_SHARED;HAVE_SLIRP_NETWORK;USE_SIMH_SLIRP_DEBUGUSE_DISPLAY;DISPLAY_TYPE=DIS_TYPE30;PIX_SCALE=RES_HALF;USE_SIM_VIDEO;HAVE_LIBSDL;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;SIM_NEED_GIT_COMMIT_ID;HAVE_PCREPOSIX_H;PCRE_STATIC"
 				StringPooling="true"
 				RuntimeLibrary="0"
 				EnableFunctionLevelLinking="true"
@@ -361,6 +361,170 @@
 				</File>
 				<File
 					RelativePath="..\display\type340.h"
+					>
+				</File>
+			</Filter>
+			<Filter
+				Name="slirp"
+				>
+				<File
+					RelativePath="..\slirp\arp_table.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\bootp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\bootp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\cksum.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\debug.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\dnssearch.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp_glue\glib_qemu_stubs.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\if.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\if.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_icmp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_icmp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_input.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\ip_output.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\libslirp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\main.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\mbuf.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\mbuf.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\misc.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\misc.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\sbuf.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\sbuf.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp_glue\sim_slirp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\slirp_config.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\socket.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\socket.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_input.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_output.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_subr.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_timer.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_timer.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcp_var.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tcpip.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tftp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\tftp.h"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\udp.c"
+					>
+				</File>
+				<File
+					RelativePath="..\slirp\udp.h"
 					>
 				</File>
 			</Filter>


### PR DESCRIPTION
As explained in the comment.

A particular use case I have in mind is the auxiliary PDP-6.  For the master PDP-10 to be able to load and start programs, the PDP-6 is started running.  The PDP-10 will then clear the PDP-6, eventually causing the PDP-6 to execute a 0 instruction.  This will cause the UUO handler to be called.  Since location 41 is 0, it will then loop around.  Next the PDP-10 can write a program to PDP-6 core and finally write the start instruction to location 41.