### PR TITLE
SEL32: Add CSW (console switches) and BOOTR (boot regs) variables.

### DIFF
--- a/SEL32/sel32_clk.c
+++ b/SEL32/sel32_clk.c
@@ -111,6 +111,8 @@ DEVICE rtc_dev = {
 t_stat rtc_srv (UNIT *uptr)
 {
     if (rtc_pie) {                                  /* set pulse intr */
+//                            time_t result = time(NULL);
+//                            fprintf(stderr, "Clock int time %x\r\n", (uint32)result);
         INTS[rtc_lvl] |= INTS_REQ;                  /* request the interrupt */
         irq_pend = 1;                               /* make sure we scan for int */
     }
@@ -253,6 +255,8 @@ DEVICE itm_dev = {
 t_stat itm_srv (UNIT *uptr)
 {
     if (itm_pie) {                              /* interrupt enabled? */
+                            time_t result = time(NULL);
+                            fprintf(stderr, "Clock int time %x\r\n", (uint32)result);
         INTS[itm_lvl] |= INTS_REQ;              /* request the interrupt on zero value */
         irq_pend = 1;                           /* make sure we scan for int */
         if (itm_cmd == 0x3d) {
@@ -280,18 +284,20 @@ int32 itm_rdwr(uint32 cmd, int32 cnt, uint32 level)
     itm_cmd = cmd;                                  /* save last cmd */
     switch (cmd) {
     case 0x20:                                      /* stop timer */
+//        fprintf(stderr, "clk kill value %x (%d)\r\n", cnt, cnt);
         sim_cancel (&itm_unit);                     /* cancel itc */
         itm_cnt = 0;                                /* no count reset value */
         return 0;                                   /* does not matter, no value returned  */
     case 0x39:                                      /* load timer with new value and start*/
-        if (cnt < 0)
-            cnt = 26042;                            /* TRY ??*/
+        if (cnt <= 0)
+            cnt = 26042;                            /* 0x65ba TRY 1,000,000/38.4 */
+//        fprintf(stderr, "clk 0x39 init value %x (%d)\r\n", cnt, cnt);
         /* start timer with value from user */
         sim_activate_after_abs_d (&itm_unit, ((double)cnt * itm_tick_size_x_100) / 100.0);
-        sim_cancel (&itm_unit);
         itm_cnt = 0;                                /* no count reset value */
         return 0;                                   /* does not matter, no value returned  */
     case 0x3d:                                      /* load timer with new value and start*/
+//        fprintf(stderr, "clk 0x3d init value %x (%d)\r\n", cnt, cnt);
         /* start timer with value from user, reload on zero time */
         sim_activate_after_abs_d (&itm_unit, ((double)cnt * itm_tick_size_x_100) / 100.0);
         itm_cnt = cnt;                              /* count reset value */
@@ -299,18 +305,23 @@ int32 itm_rdwr(uint32 cmd, int32 cnt, uint32 level)
     case 0x60:                                      /* read and stop timer */
         /* get timer value and stop timer */
         temp = (uint32)(100.0 * sim_activate_time_usecs (&itm_unit) / itm_tick_size_x_100);
+//        fprintf(stderr, "clk 0x60 temp value %x (%d)\r\n", temp, temp);
         sim_cancel (&itm_unit);
         return temp;                                /* return current count value */
     case 0x79:                                      /* read the current timer value */
         /* get timer value, load new value and start timer */
         temp = (uint32)(100.0 * sim_activate_time_usecs (&itm_unit) / itm_tick_size_x_100);
+//        fprintf(stderr, "clk 0x79 temp value %x (%d)\r\n", temp, temp);
+//        fprintf(stderr, "clk 0x79 init value %x (%d)\r\n", cnt, cnt);
         /* start timer to fire after cnt ticks */
         sim_activate_after_abs_d (&itm_unit, ((double)cnt * itm_tick_size_x_100) / 100.0);
         itm_cnt = 0;                                /* no count reset value */
         return temp;                                /* return current count value */
     case 0x40:                                      /* read the current timer value */
         /* return current count value */
-        return (uint32)(100.0 * sim_activate_time_usecs (&itm_unit) / itm_tick_size_x_100);
+        temp = (uint32)(100.0 * sim_activate_time_usecs (&itm_unit) / itm_tick_size_x_100);
+//        fprintf(stderr, "clk 0x40 temp value %x (%d)\r\n", temp, temp);
+        return temp;
         break;
     }
     return 0;                                       /* does not matter, no value returned  */

--- a/SEL32/tests/diag.ini
+++ b/SEL32/tests/diag.ini
@@ -1,9 +1,10 @@
 set debug -n sel.log
+;set CPU 32/27 4M
 set CPU 32/67 4M
+;set CPU 32/87 4M
 ;set CPU 32/97 4M
 ;set CPU V6 4M
 ;set CPU V9 4M
-;set CPU 32/27 2M
 ;set debug stderr
 ;set mta debug=cmd;detail;exp;data
 ;set mta debug=inst;cmd;detail;exp
@@ -18,22 +19,22 @@ set CPU 32/67 4M
 ;set dma debug=cmd;exp;detail;data
 ;set dma debug=cmd;exp;detail;data
 ;
-set coml0 enable
-set coml1 enable
-set coml2 enable
-set coml3 enable
-set coml4 enable
-set coml5 enable
-set coml6 enable
-set coml7 enable
+;set coml0 enable
+;set coml1 enable
+;set coml2 enable
+;set coml3 enable
+;set coml4 enable
+;set coml5 enable
+;set coml6 enable
+;set coml7 enable
 ;
-set comc enable
-at comc 4747
+;set comc enable
+;at comc 4747
 ;
 ;set con debug=CMD
 ;
-set lpr enable
-at lpr lprout
+;set lpr enable
+;at lpr lprout
 ;
 ;at mta0 mpxsdt4.tap
 ;at mta0 mpxsdt5.tap
@@ -42,8 +43,12 @@ at lpr lprout
 ;
 ;at mta0 sim32sdt.tap
 at mta0 diag.tap
-at mta1 temptape.tap
-at mta2 output.tap
+;at mta1 temptape.tap
+;at mta2 output.tap
 ;at dma0 diagdisk
 ;bo dma0
+deposit CSW 0
+;deposit bootr[0] ffffffff
+deposit bootr[1] 0
+deposit bootr[2] 0 
 bo mta0

--- a/SEL32/util/makefile
+++ b/SEL32/util/makefile
@@ -1,0 +1,73 @@
+# Makefile for utils
+SHELL = /bin/sh
+
+# Adapt the flags in the following paragraph to your system
+#  for Linux
+ROOT = .
+OPTC = -O #-m32
+
+#B = $(ROOT)
+#B = $(ROOT)/bin
+B = /system/bin
+#I = $(ROOT)/include
+I =
+#L = $(ROOT)/lib
+#D = $L/mylib.a 
+D =
+
+##CFLAGS= $(OPTC) -I$I
+CFLAGS= $(OPTC) -I$I -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+
+# For Linux
+#LFLAGS= -L$L
+LFLAGS= 
+
+PROGS =			\
+	$(ROOT)/makecode
+
+all:	$(PROGS)
+
+#install	:$(PROGS)
+#	@cp $(@F) $B
+#	@echo $(@F) installed in $B
+#	@echo
+##	@chmod 755 $(@F)
+
+##$(PROGS): $D $$(@F).c
+##	@-$(CC) $(CFLAGS) $(@F).c $(LFLAGS) -o $@
+##$(PROGS): $D $$(@F).c
+##	@chmod 755 $@
+##	@cp $(@F) $B
+##	@echo $(@F) installed in $B
+##	@echo
+
+$B/makecode:	$D makecode.c
+	@-$(CC) $(CFLAGS) $(@F).c $(LFLAGS) -o $@
+	@chmod 755 $@
+	@cp $(@F) $B
+	@echo $(@F) installed in $B
+
+# Some makes don't understand the $$ notation above.  In this case
+# you have to type out the compile paragraph for each PROG.  Sigh.
+# Here's a start, good luck.
+#
+#$B/abshw:	abshw.c
+#	$(CC) $(CFLAGS) $? $(LFLAGS) -o $@
+#	@chmod 751 $@
+#	@echo $(@F) installed in $B
+
+remake	:	clobber
+	@make ROOT=$(ROOT) OPTC=$(OPTC)
+	
+clean	:
+	@-rm -f a.out junk* JUNK* core
+	@-rm -f *.o
+
+clobber	:	clean
+	@-rm -f $(PROGS)
+
+install	: $(PROGS)
+	@cp $(PROGS) $B
+	@echo $(PROGS) installed in $B
+	@echo
+#	@chmod 755 $(@F)


### PR DESCRIPTION
SEL32: Fix sel32_clk.c coding error in interval timer code.
SEL32: Update to latest makecode.c utility and add makefile.
SEL32: Update diag.ini file to show how to set boot regs and CSW values.