### PR TITLE
KA10: Fix inconsistent address types

### DIFF
--- a/PDP10/ka10_auxcpu.c
+++ b/PDP10/ka10_auxcpu.c
@@ -54,7 +54,7 @@
 
 static int pia = 0;
 static int status = 0;
-t_value auxcpu_base = 03000000;
+t_addr auxcpu_base = 03000000;
 
 static t_stat auxcpu_devio(uint32 dev, t_uint64 *data);
 static t_stat auxcpu_svc (UNIT *uptr);
@@ -407,13 +407,13 @@ static t_stat auxcpu_set_base (UNIT *uptr, int32 val, CONST char *cptr, void *de
     if (r != SCPE_OK)
         return SCPE_ARG;
 
-    auxcpu_base = x;
+    auxcpu_base = (t_addr)x;
     return SCPE_OK;
 }
 
 static t_stat auxcpu_show_base (FILE *st, UNIT *uptr, int32 val, CONST void *desc)
 {
-    fprintf (st, "Base: %llo", auxcpu_base);
+    fprintf (st, "Base: %" T_ADDR_FMT "o", auxcpu_base);
     return SCPE_OK;
 }
 #endif

--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -221,7 +221,7 @@ int32   tmxr_poll = 10000;
 /* Physical address range for Rubin 10-11 interface. */
 #define T11RANGE(addr)  ((addr) >= 03040000)
 /* Physical address range for auxiliary PDP-6. */
-extern int auxcpu_base;
+extern t_addr auxcpu_base;
 #define AUXCPURANGE(addr)  ((addr) >= auxcpu_base && (addr) < (auxcpu_base + 040000))
 
 DEVICE *rh_devs[] = {
@@ -1856,7 +1856,7 @@ fault:
  * Return of 0 if successful, 1 if there was an error.
  */
 int Mem_read_its(int flag, int cur_context, int fetch) {
-    int addr;
+    t_addr addr;
 
     if (AB < 020) {
         if ((xct_flag & 1) != 0 && !cur_context && (FLAGS & USER) == 0) {
@@ -1903,7 +1903,7 @@ int Mem_read_its(int flag, int cur_context, int fetch) {
  * Return of 0 if successful, 1 if there was an error.
  */
 int Mem_write_its(int flag, int cur_context) {
-    int addr;
+    t_addr addr;
 
     if (AB < 020) {
         if ((xct_flag & 2) != 0 && !cur_context && (FLAGS & USER) == 0) {

--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -2534,7 +2534,7 @@ int page_lookup(int addr, int flag, int *loc, int wr, int cur_context, int fetch
 }
 
 int Mem_read(int flag, int cur_context, int fetch) {
-    int addr;
+    t_addr addr;
 
     if (AB < 020) {
         MB = get_reg(AB);
@@ -2542,7 +2542,7 @@ int Mem_read(int flag, int cur_context, int fetch) {
         sim_interval--;
         if (!page_lookup(AB, flag, &addr, 0, cur_context, fetch))
             return 1;
-        if (addr >= (int)MEMSIZE) {
+        if (addr >= MEMSIZE) {
             nxm_flag = 1;
             return 1;
         }
@@ -2560,7 +2560,7 @@ int Mem_read(int flag, int cur_context, int fetch) {
  */
 
 int Mem_write(int flag, int cur_context) {
-    int addr;
+    t_addr addr;
 
     if (AB < 020) {
         set_reg(AB, MB);
@@ -2568,7 +2568,7 @@ int Mem_write(int flag, int cur_context) {
         sim_interval--;
         if (!page_lookup(AB, flag, &addr, 1, cur_context, 0))
             return 1;
-        if (addr >= (int)MEMSIZE) {
+        if (addr >= MEMSIZE) {
             nxm_flag = 1;
             return 1;
         }


### PR DESCRIPTION
auxcpu_base was previously defined as a t_value, while it should have
been a t_addr everywhere.  This then showed where it was referenced
need declaration adjustments to also work with t_addr in expressions.