### PR TITLE
KA10: Interface III device with display library.

### DIFF
--- a/PDP10/ka10_iii.c
+++ b/PDP10/ka10_iii.c
@@ -32,6 +32,7 @@
 
 #if NUM_DEVS_III > 0 
 #include "display/display.h"
+#include "display/iii.h"
 
 
 #define III_DEVNUM        0430
@@ -261,6 +262,7 @@ int            iii_sel;         /* Select mask */
 
 t_stat iii_devio(uint32 dev, uint64 *data);
 t_stat iii_svc(UNIT *uptr);
+t_stat iii_reset(DEVICE *dptr);
 static void draw_point(int x, int y, int b);
 static void draw_line(int x1, int y1, int x2, int y2, int b);
 t_stat iii_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr);
@@ -281,7 +283,7 @@ MTAB iii_mod[] = {
 DEVICE iii_dev = {
     "III", iii_unit, NULL, iii_mod,
     2, 10, 31, 1, 8, 8,
-    NULL, NULL, NULL,
+    NULL, NULL, iii_reset,
     NULL, NULL, NULL, &iii_dib, DEV_DEBUG | DEV_DISABLE | DEV_DIS, 0, dev_debug,
     NULL, NULL, &iii_help, NULL, NULL, &iii_description
     };
@@ -348,6 +350,9 @@ iii_svc (UNIT *uptr)
      int       A;
      int       ox, oy, nx, ny, br, sz;
      int       i, j, ch;
+
+     iii_cycle (10, 0);
+
      switch(iii_instr & 017) {
      case 000: /* JMP and HLT */
                if (iii_instr & 020) {
@@ -528,12 +533,24 @@ iii_svc (UNIT *uptr)
 }
 
 
+t_stat iii_reset (DEVICE *dptr)
+{
+    if (dptr->flags & DEV_DIS) {
+        display_close(dptr);
+    } else {
+        display_reset();
+        iii_init(dptr);
+    }
+    return SCPE_OK;
+}
+
+
 /* Draw a point at x,y with intensity b. */
 /* X and Y runs from -512 to 512. */
 static void
 draw_point(int x, int y, int b)
 {
-   display_point(x, y, b, 0);
+   iii_point(x, y, b, 0);
 }
 
 /* Draw a line between two points */

--- a/display/display.c
+++ b/display/display.c
@@ -241,7 +241,13 @@ static struct display displays[] = {
      * 512x512, out of 800x600
      * 0,0 at middle
      */
-    { DIS_NG, "NG Display", &color_p31, NULL, 512, 512 }
+    { DIS_NG, "NG Display", &color_p31, NULL, 512, 512 },
+
+    /*
+     * III display
+     * on PDP-10
+     */
+    { DIS_III, "III Display", &color_p31, NULL, 1024, 1024 }
 };
 
 /*

--- a/display/display.h
+++ b/display/display.h
@@ -47,6 +47,7 @@ enum display_type {
     DIS_VR20 = 20,
     DIS_TYPE30 = 30,
     DIS_VR48 = 48,
+    DIS_III = 111,
     DIS_TYPE340 = 340,
     DIS_NG = 999,
 };

--- a/display/iii.c
+++ b/display/iii.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Lars Brinkhoff
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the names of the authors shall
+ * not be used in advertising or otherwise to promote the sale, use or
+ * other dealings in this Software without prior written authorization
+ * from the authors.
+ */
+
+#include "display.h"                    /* XY plot interface */
+#include "iii.h"
+
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if defined(__cplusplus)
+}
+#endif
+
+int iii_init(void *dev, int debug)
+{
+  return display_init(DIS_III, 1, dev);
+}
+
+int iii_point (int x, int y)
+{
+  display_point(x, y, DISPLAY_INT_MAX, 0);
+}
+
+int iii_cycle(int us, int slowdown)
+{
+  display_age(us, slowdown);
+  return 1;
+}

--- a/display/iii.h
+++ b/display/iii.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Lars Brinkhoff
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the names of the authors shall
+ * not be used in advertising or otherwise to promote the sale, use or
+ * other dealings in this Software without prior written authorization
+ * from the authors.
+ */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+extern int iii_init(void *, int);
+extern int iii_cycle(int, int);
+extern int iii_point(int, int);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/makefile
+++ b/makefile
@@ -587,6 +587,7 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
           DISPLAYVT = ${DISPLAYD}/vt11.c
           DISPLAY340 = ${DISPLAYD}/type340.c
           DISPLAYNG = ${DISPLAYD}/ng.c
+          DISPLAYIII = ${DISPLAYD}/iii.c
           DISPLAY_OPT += -DUSE_DISPLAY $(VIDEO_CCDEFS) $(VIDEO_LDFLAGS)
           $(info using libSDL2: $(call find_include,SDL2/SDL))
           ifeq (Darwin,$(OSTYPE))
@@ -612,6 +613,7 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
             DISPLAYVT = ${DISPLAYD}/vt11.c
             DISPLAY340 = ${DISPLAYD}/type340.c
             DISPLAYNG = ${DISPLAYD}/ng.c
+            DISPLAYIII = ${DISPLAYD}/iii.c
             DISPLAY_OPT += -DUSE_DISPLAY $(VIDEO_CCDEFS) $(VIDEO_LDFLAGS)
             $(info using libSDL: $(call find_include,SDL/SDL))
             ifeq (Darwin,$(OSTYPE))
@@ -976,6 +978,7 @@ else
       DISPLAYVT = ${DISPLAYD}/vt11.c
       DISPLAY340 = ${DISPLAYD}/type340.c
       DISPLAYNG = ${DISPLAYD}/ng.c
+      DISPLAYIII = ${DISPLAYD}/iii.c
       DISPLAY_OPT += -DUSE_DISPLAY $(VIDEO_CCDEFS) $(VIDEO_LDFLAGS)
     else
       $(info ***********************************************************************)
@@ -2029,7 +2032,8 @@ KA10 = ${KA10D}/kx10_cpu.c ${KA10D}/kx10_sys.c ${KA10D}/kx10_df.c \
 	$(KA10D)/ka10_pmp.c ${KA10D}/ka10_dkb.c ${KA10D}/pdp6_dct.c \
 	${KA10D}/pdp6_dtc.c ${KA10D}/pdp6_mtc.c ${KA10D}/pdp6_dsk.c \
 	${KA10D}/pdp6_dcs.c ${KA10D}/ka10_dpk.c ${KA10D}/kx10_dpy.c \
-	${PDP10D}/ka10_ai.c ${KA10D}/ka10_iii.c ${DISPLAYL} ${DISPLAY340}
+	${PDP10D}/ka10_ai.c ${KA10D}/ka10_iii.c ${DISPLAYL} ${DISPLAY340} \
+	$(DISPLAYIII)
 KA10_OPT = -DKA=1 -DUSE_INT64 -I ${KA10D} -DUSE_SIM_CARD ${NETWORK_OPT} ${DISPLAY_OPT} ${KA10_DISPLAY_OPT}
 ifneq (${PANDA_LIGHTS},)
 # ONLY for Panda display.


### PR DESCRIPTION
Something like this.  Draft!  Untested!  Actually, I'm quite sure this will not work 100% but it shows how to tie the device to the display library.

If we are to follow the display library pattern, the main logic should be in iii.c rather than ka10_iii.c.