### PR TITLE
KA10: iii_reset crash

### DIFF
--- a/display/display.c
+++ b/display/display.c
@@ -369,6 +369,7 @@ static long queue_interval;
 #define Y(P) (((P) - points) / xpixels)
 
 static int initialized = 0;
+static void *device = NULL;  /* Current display device. */
 
 /*
  * global set by O/S display level to indicate "light pen tip switch activated"
@@ -979,6 +980,7 @@ display_init(enum display_type type, int sf, void *dptr)
 
     initialized = 1;
     init_failed = 0;            /* hey, we made it! */
+    device = dptr;
     return 1;
 
  failed:
@@ -992,10 +994,14 @@ display_close(void *dptr)
     if (!initialized)
         return;
 
+    if (device != dptr)
+        return;
+
     free (points);
     ws_shutdown();
 
     initialized = 0;
+    device = NULL;
 }
 
 void

--- a/sim_video.c
+++ b/sim_video.c
@@ -564,19 +564,24 @@ static t_stat vid_init_controllers (void)
     vid_gamepad_ok = (ver.major > 2 ||
                       (ver.major == 2 && (ver.minor > 0 || ver.patch >= 4)));
 
-    SDL_InitSubSystem(SDL_INIT_JOYSTICK);
     if (vid_gamepad_ok)
         SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER);
+    else
+        SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 
     if (SDL_JoystickEventState (SDL_ENABLE) < 0) {
-        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        if (vid_gamepad_ok)
+            SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        else
+            SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
         return SCPE_IOERR;
         }
 
     if (vid_gamepad_ok && SDL_GameControllerEventState (SDL_ENABLE) < 0) {
-        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        if (vid_gamepad_ok)
+            SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        else
+            SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
         return SCPE_IOERR;
         }
 
@@ -661,8 +666,10 @@ if (vid_active) {
     vid_gamepad_inited = 0;
     memset (motion_callback, 0, sizeof motion_callback);
     memset (button_callback, 0, sizeof button_callback);
-    SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-    SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+    if (vid_gamepad_ok)
+        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+    else
+        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
 
     vid_active = FALSE;
     if (vid_ready) {


### PR DESCRIPTION
```
Thread 1 "pdp10-ka" received signal SIGSEGV, Segmentation fault.
0x00007ffff7b8f008 in ?? () from /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0
(gdb) bt
#0  0x00007ffff7b8f008 in ?? () from /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0
#1  0x00007ffff7b14eda in ?? () from /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0
#2  0x00007ffff7b151ac in ?? () from /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0
#3  0x00007ffff7add705 in ?? () from /usr/lib/x86_64-linux-gnu/libSDL2-2.0.so.0
#4  0x00000000004bc8e2 in vid_close.part ()
#5  0x00000000004bd5e9 in vid_close ()
#6  0x0000000000440285 in display_close ()
#7  0x000000000043eb3d in iii_reset ()
#8  0x000000000044778e in reset_all.constprop ()
#9  0x000000000045dc3e in sim_run_boot_prep ()
#10 0x0000000000464dd1 in run_cmd ()
#11 0x0000000000462a64 in do_cmd_label ()
#12 0x0000000000406850 in main ()
