### PR TITLE
SEL32: Correct real time clock interrupt processing.

### DIFF
--- a/SEL32/sel32_con.c
+++ b/SEL32/sel32_con.c
@@ -163,7 +163,7 @@ void con_ini(UNIT *uptr, t_bool f) {
     int     unit = (uptr - con_unit);   /* unit 0 */
 //  DEVICE *dptr = get_dev(uptr);
 
-    uptr->u4 = 0;                       /* no input cpunt */
+    uptr->u4 = 0;                       /* no input count */
     con_data[unit].incnt = 0;           /* no input data */
 //  con_data[0].incnt = 0;              /* no input data */
 //  con_data[1].incnt = 0;              /* no output data */
@@ -208,7 +208,6 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         uptr->CMD |= CON_INCH2;         /* save INCH command as 0xf0 */
         uptr->SNS = SNS_RDY|SNS_ONLN;   /* status is online & ready */
         sim_activate(uptr, 20);         /* start us off */
-//WAS   sim_activate(uptr, 10);         /* start us off */
         return 0;                       /* no status change */
         break;
 
@@ -219,7 +218,6 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         uptr->CMD |= (cmd & CON_MSK);   /* save command */
         uptr->SNS = SNS_RDY|SNS_ONLN;   /* status is online & ready */
         sim_activate(uptr, 20);         /* start us off */
-//TRIED sim_activate(uptr, 10);         /* start us off */
         return 0;                       /* no status change */
         break;
 
@@ -245,7 +243,7 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         uptr->CMD |= (cmd & CON_MSK);   /* save command */
 //      uptr->u4 = 0;                   /* no I/O yet */
 //      con_data[unit].incnt = 0;       /* clear any input data */
-        sim_activate(uptr, 10);         /* start us off */
+        sim_activate(uptr, 20);         /* start us off */
         return 0;                       /* no status change */
         break;
 
@@ -254,7 +252,7 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         uptr->SNS = SNS_RDY|SNS_ONLN;   /* status is online & ready */
         uptr->CMD &= LMASK;             /* leave only chsa */
         uptr->CMD |= (cmd & CON_MSK);   /* save command */
-        sim_activate(uptr, 10);         /* start us off */
+        sim_activate(uptr, 20);         /* start us off */
         return 0;                       /* no status change */
         break;
 #endif
@@ -282,19 +280,16 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         break;
 
     default:                            /* invalid command */
-        uptr->SNS |= SNS_CMDREJ;        /* command rejected */
-//      uptr->u4 = 0;                   /* no I/O yet */
-//      con_data[unit].incnt = 0;       /* clear any input data */
-        sim_debug(DEBUG_CMD, &con_dev,
-            "con_startcmd %04x: Invalid command %02x Sense %02x\n",
-            chan, cmd, uptr->SNS);
-        return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* unit check */
         break;
     }
-
-    if (uptr->SNS & (~(SNS_RDY|SNS_ONLN|SNS_DSR)))
-        return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;
-    return SNS_CHNEND|SNS_DEVEND;
+    /* invalid command */
+    uptr->SNS |= SNS_CMDREJ;        /* command rejected */
+//  uptr->u4 = 0;                   /* no I/O yet */
+//  con_data[unit].incnt = 0;       /* clear any input data */
+    sim_debug(DEBUG_CMD, &con_dev,
+        "con_startcmd %04x: Invalid command %02x Sense %02x\n",
+        chan, cmd, uptr->SNS);
+    return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* unit check */
 }
 
 /* Handle output transfers for console */
@@ -317,7 +312,6 @@ t_stat con_srvo(UNIT *uptr) {
             uptr->CMD &= LMASK;                 /* nothing left, command complete */
             sim_debug(DEBUG_CMD, &con_dev,
                 "con_srvo Read to output device chsa %04x cmd = %02x\n", chsa, cmd);
-//DIAG_TUE  chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);    /* unit check */
             chan_end(chsa, SNS_CHNEND|SNS_UNITCHK);    /* unit check */
             return SCPE_OK;
         }
@@ -401,9 +395,8 @@ t_stat con_srvi(UNIT *uptr) {
             uptr->CMD &= LMASK;                 /* nothing left, command complete */
             sim_debug(DEBUG_CMD, &con_dev,
                 "con_srvi Write to input device chsa %04x cmd = %02x\n", chsa, cmd);
-//DIAGTUE   chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);    /* unit check */
             chan_end(chsa, SNS_CHNEND|SNS_UNITCHK);    /* unit check */
-//fall thru return SCPE_OK;
+            // fall thru return SCPE_OK;
         }
     }
 #ifdef JUNK

--- a/SEL32/sel32_cpu.c
+++ b/SEL32/sel32_cpu.c
@@ -172,7 +172,7 @@ uint32          BR[8];                      /* Base registers */
 uint32          PC;                         /* Program counter */
 uint32          CC;                         /* Condition codes, bits 1-4 of PSD1 */
 uint32          SPAD[256];                  /* Scratch pad memory */
-uint32          INTS[128];                  /* Interrupt status flags */
+uint32          INTS[112];                  /* Interrupt status flags */
 uint32          CPUSTATUS;                  /* cpu status word */
 uint32          TRAPSTATUS;                 /* trap status word */
 uint32          CMCR;                       /* Cache Memory Control Register */
@@ -689,7 +689,7 @@ t_stat load_maps(uint32 thepsd[2], uint32 lmap)
     uint32 MAXMAP = MAX2048;                        /* default to 2048 maps */
 
     sim_debug(DEBUG_CMD, &cpu_dev,
-        "Load Maps Entry PSD %08x %08x STATUS %08x lmap %01x CPU Type %2x\n",
+        "Load Maps Entry PSD %08x %08x STATUS %08x lmap %01x CPU Mode %2x\n",
         thepsd[0], thepsd[1], CPUSTATUS, lmap, CPU_MODEL);
 
     /* process 32/7X computers */
@@ -887,19 +887,19 @@ npmem:
         BPIX = 0;                                   /* no os maps loaded */
         CPIXPL = 0;                                 /* no user pages */
         CPIX = cpix;                                /* save user CPIX */
-        if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
+        if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
             TRAPSTATUS |= BIT1;                     /* set bit 1 of trap status */
-        else
-            TRAPSTATUS |= BIT8;                     /* set bit 8 of trap status */
+        } else
+            TRAPSTATUS |= BIT10;                    /* set bit 8 of trap status */
         return NPMEM;                               /* non present memory error */
     }
 
     /* output O/S and User MPX entries */
-    sim_debug(DEBUG_CMD, &cpu_dev,
+    sim_debug(DEBUG_DETAIL, &cpu_dev,
         "#MEMORY %06x MPL %06x MPL[0] %08x %06x MPL[%04x] %08x %06x\n",
         MEMSIZE*4, mpl, RMW(mpl), RMW(mpl+4), cpix,
         RMW(cpix+mpl), RMW(cpix+mpl+4));
-    sim_debug(DEBUG_CMD, &cpu_dev,
+    sim_debug(DEBUG_DETAIL, &cpu_dev,
         "MEMORY2 %06x BPIX %04x cpix %04x CPIX %04x CPIXPL %04x HIWM %04x\n",
         MEMSIZE*4, BPIX, cpix, CPIX, CPIXPL, HIWM);
 
@@ -1068,9 +1068,9 @@ loaduser:
         sim_debug(DEBUG_TRAP, &cpu_dev,
             "load_maps MEM SIZE4 %06x user page list address %06x invalid\n",
             MEMSIZE*4, msdl);
-        if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
+        if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
             TRAPSTATUS |= BIT1;                     /* set bit 1 of trap status */
-        else
+        } else
             TRAPSTATUS |= BIT28;                    /* set bit 28 of trap status */
         return NPMEM;                               /* non present memory error */
     }
@@ -1101,7 +1101,7 @@ loaduser:
     if ((CPU_MODEL == MODEL_27) || (CPU_MODEL == MODEL_87)) {
 
         sim_debug(DEBUG_CMD, &cpu_dev,
-            "load_maps Processing 32/27 & 32/87 Model# %04x\n", CPU_MODEL);
+            "load_maps Processing 32/27 & 32/87 Model# %02x\n", CPU_MODEL);
 
         /* handle non virtual page loading or diag LMAP instruction */
         /* do 32/27 and 32/87 that force load all maps */
@@ -1296,9 +1296,9 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
         if (word >= (MEMSIZE*4)) {                  /* see if address is within our memory */
             if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
                 if (access == MEM_RD)
-                    TRAPSTATUS |= 0x40000000;       /* set bit 1 of trap status */
+                    TRAPSTATUS |= BIT1;             /* set bit 1 of trap status */
                 if (access == MEM_WR)
-                    TRAPSTATUS |= 0x20000000;       /* set bit 2 of trap status */
+                    TRAPSTATUS |= BIT2;             /* set bit 2 of trap status */
             } else {
                 TRAPSTATUS |= BIT10;                /* set bit 10 of trap status */
             }
@@ -1333,6 +1333,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
         if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
             // V9  & 32/97 wants MACHINECHK for test 37/1 in CN.MMM & VM.MMM */
             TRAPSTATUS |= BIT7;                     /* set bit 7 of trap status */
+            TRAPSTATUS |= BIT28;                    /* set bit 28 of trap status */
             return MACHINECHK_TRAP;                 /* diags want machine check error */
         }
     }
@@ -1398,7 +1399,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
         if ((BIT1 >> offset) & raddr) {             /* is 1/4 page write protected */
             *prot = 1;                              /* return memory write protection status */
         }
-        sim_debug(DEBUG_CMD, &cpu_dev,
+        sim_debug(DEBUG_DETAIL, &cpu_dev,
             "RealAddrRa address %08x, TLB %08x MAPC[%03x] %08x wprot %02x prot %02x\n",
             word, TLB[index], index/2, MAPC[index/2], (word>>11)&3, *prot);
         return ALLOK;                               /* all OK, return instruction */
@@ -1419,16 +1420,23 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
                 "RealAddr loadmap 2a non present memory fault addr %08x raddr %08x index %04x\n",
                 addr, raddr, index);
             if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
+#ifndef TRY_AGAIN
                 if (access == MEM_RD)
                     TRAPSTATUS |= BIT1;             /* set bit 1 of trap status */
                 else
                 if (access == MEM_WR)
                     TRAPSTATUS |= BIT2;             /* set bit 2 of trap status */
-                /* returning this error fails test 34/2 of mmm diag */
-/*NEW*///       return MAPFLT;                      /* map fault error on memory access */
-/*NEW*///       return MACHINECHK_TRAP;             /* diags want machine check error */
                 /* returning this error fixes 34/2, but still fails 46/2 */
                 return NPMEM;                       /* none present memory error */
+#else
+                TRAPSTATUS |= BIT7;                 /* set bit 7 of trap status */
+                TRAPSTATUS |= BIT12;                /* set bit 12 of trap status */
+                /* returning this error fails test 34/2 of mmm diag */
+                return MAPFLT;                      /* map fault error on memory access */
+#endif
+/*NEW*///       return MAPFLT;                      /* map fault error on memory access */
+                /* returning this error fails test 34/2 of mmm diag */
+/*NEW*///       return MACHINECHK_TRAP;             /* diags want machine check error */
             } else
                 TRAPSTATUS |= BIT28;                /* set bit 28 of trap status */
             return NPMEM;                           /* none present memory error */
@@ -1449,7 +1457,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
             if ((BIT1 >> offset) & raddr) {         /* is 1/4 page write protected */
                 *prot = 1;                          /* return memory write protection status */
             }
-            sim_debug(DEBUG_CMD, &cpu_dev,
+            sim_debug(DEBUG_DETAIL, &cpu_dev,
                 "RealAddrR address %08x, TLB %08x MAPC[%03x] %08x wprot %02x prot %02x\n",
                 word, TLB[index], index/2, MAPC[index/2], (word>>11)&3, *prot);
             return ALLOK;                           /* all OK, return instruction */
@@ -1463,9 +1471,6 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
         else
             *prot = offset;                         /* return memory write protection status */
 
-//    if (addr != word)
-//sim_debug(DEBUG_EXP, &cpu_dev,
-//"At RealAddr Hit convert %06x to addr %08x\n", addr, word);
         sim_debug(DEBUG_DETAIL, &cpu_dev,
             "RealAddrX address %06x, TLB %06x MAPC[%03x] %08x wprot %02x prot %02x\n",
             word, TLB[index], index/2, MAPC[index/2], (word>>11)&3, *prot);
@@ -1473,7 +1478,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
     }
 
     /* Hit bit is off in TLB, so lets go get some maps */
-    sim_debug(DEBUG_CMD, &cpu_dev,
+    sim_debug(DEBUG_DETAIL, &cpu_dev,
         "$MEMORY %06x HIT MPL %06x MPL[0] %08x %06x MPL[%04x] %08x %06x\n",
         MEMSIZE*4, mpl, RMW(mpl), RMW(mpl+4), CPIX, RMW(CPIX+mpl), RMW(CPIX+mpl+4));
 
@@ -1481,7 +1486,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
     msdl = RMW(mpl+CPIX+4);                     /* get msdl entry for given CPIX */
     if ((msdl & MASK24) >= (MEMSIZE*4)) {       /* check user midl */
         sim_debug(DEBUG_TRAP, &cpu_dev,
-            "RealAddr Non Present Memory User msdl %06x CPIX %04x\n",
+            "RealAddr User CPIX Non Present Memory User msdl %06x CPIX %04x\n",
             msdl, CPIX);
 
         if (CPU_MODEL == MODEL_67) {
@@ -1550,7 +1555,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
     else
         mix = nix-BPIX;                             /* get map index in memory */
     map = RMH(msdl+(mix<<1));                       /* map content from memory */      
-    sim_debug(DEBUG_CMD, &cpu_dev,
+    sim_debug(DEBUG_DETAIL, &cpu_dev,
         "Addr %06x RealAddr %06x Map0[%04x] HIT %04x TLB[%3x] %08x MAPC[%03x] %08x\n",
         addr, word, mix, map, nix, TLB[nix], nix/2, MAPC[nix/2]);
 
@@ -1558,10 +1563,6 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
     if ((map & 0x8000) == 0) {
         /* for V6 & V9 handle demand paging */
         if (CPU_MODEL >= MODEL_V6) {
-#ifdef DO_DYNAMIC_DEBUG
-            /* start debugging */
-            cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ);
-#endif
             /* map is not valid, so we have map fault */
             sim_debug(DEBUG_TRAP, &cpu_dev,
                 "AddrMa %06x RealAddr %06x Map0 HIT %04x, TLB[%3x] %08x MAPC[%03x] %08x\n",
@@ -1589,24 +1590,16 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
     TLB[nix] = ((map & 0x7ff) << 13) | ((map << 16) & 0xf8000000) | 0x04000000;
     word = (TLB[nix] & 0xffe000) | offset;          /* combine map and offset */
     WMR((nix<<1), map);                             /* store the map reg contents into MAPC cache */
-    sim_debug(DEBUG_CMD, &cpu_dev,
+    sim_debug(DEBUG_DETAIL, &cpu_dev,
         "RealAddrm RMH %04x mix %04x TLB[%04x] %08x B+C %04x RMR[nix] %04x\n",
         map, mix, nix, TLB[nix], BPIX+CPIXPL, RMR(nix<<1));
 
-    sim_debug(DEBUG_CMD, &cpu_dev,
+    sim_debug(DEBUG_DETAIL, &cpu_dev,
         "Addr1c %06x RealAddr %06x Map1[%04x] HIT %04x, TLB[%3x] %08x MAPC[%03x] %08x RMR %04x\n",
         addr, word, mix, map, nix, TLB[nix], nix/2, MAPC[nix/2], RMR(nix<<1));
 
-#ifdef DO_DYNAMIC_DEBUG
-/* start debugging */
-    if(word == 0x27000)
-cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ | DEBUG_XIO);
-#endif
     *realaddr = word;                               /* return the real address */
     raddr = TLB[nix];                               /* get the base address & bits */
-//  if (addr != word)
-//sim_debug(DEBUG_EXP, &cpu_dev,
-//"At RealAddr Miss convert %06x to addr %08x\n", addr, word);
 
     if ((CPU_MODEL == MODEL_67) || (CPU_MODEL == MODEL_97)) {
         /* get protection status of map */
@@ -1644,13 +1637,13 @@ cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ | DEBUG_XIO);
         nix -= 1;                                   /* point to last map in MAPC */
     }
 
-    sim_debug(DEBUG_CMD, &cpu_dev,
+    sim_debug(DEBUG_DETAIL, &cpu_dev,
         "RealAddrp mix %04x nix %04x TLB[%04x] %08x B+C %04x RMR[nix] %04x\n",
          mix, nix, nix, TLB[nix], BPIX+CPIXPL, RMR(nix<<1));
 
     /* allow the excess map entry to be loaded, even though bad */
     if (nix <= (BPIX+CPIXPL)) {                     /* needs to be a mapped reg */
-        sim_debug(DEBUG_CMD, &cpu_dev,
+        sim_debug(DEBUG_DETAIL, &cpu_dev,
             "Addr1d BPIX %03x CPIXPL %03x RealAddr %06x TLB[%3x] %08x MAPC[%03x] %08x RMR %04x\n",
             BPIX, CPIXPL, word, nix, TLB[nix], nix/2, MAPC[nix/2], RMR(nix<<1));
 
@@ -1660,7 +1653,7 @@ cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ | DEBUG_XIO);
             /* allow the excess map entry to be loaded, even though bad */
             if (nix <= (BPIX+CPIXPL)) {             /* needs to be a mapped reg */
                 map = RMH(msdl+(mix<<1));           /* map content from memory */      
-                sim_debug(DEBUG_CMD, &cpu_dev,
+                sim_debug(DEBUG_DETAIL, &cpu_dev,
                     "Addr2a %06x MapX[%04x] HIT %04x, TLB[%3x] %08x MAPC[%03x] %08x\n",
                     addr, mix, map, nix, TLB[nix], nix/2, MAPC[nix/2]);
 
@@ -1669,7 +1662,7 @@ cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ | DEBUG_XIO);
                     TLB[nix] = ((map & 0x7ff) << 13) | ((map << 16) & 0xf8000000) | 0x04000000;
                     word = (TLB[nix] & 0xffe000);   /* combine map and offset */
                     WMR((nix<<1), map);             /* store the map reg contents into MAPC cache */
-                    sim_debug(DEBUG_CMD, &cpu_dev,
+                    sim_debug(DEBUG_DETAIL, &cpu_dev,
                         "Addr2b %06x RealAddr %06x Map2[%04x] HIT %04x, TLB[%3x] %08x MAPC[%03x] %08x\n",
                         addr, word, mix, map, nix, TLB[nix], nix/2, MAPC[nix/2]);
                 }
@@ -1784,14 +1777,14 @@ t_stat Mem_read(uint32 addr, uint32 *data)
         sim_debug(DEBUG_EXP, &cpu_dev, "Mem_read error addr %.8x realaddr %.8x data %.8x prot %02x status %04x\n",
             addr, realaddr, *data, prot, status);
         if (status == NPMEM) {                      /* operand nonpresent memory error */
-            if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
+            if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
                 TRAPSTATUS |= BIT1;                 /* set bit 1 of trap status */
-            else
+            } else
                 TRAPSTATUS |= BIT10;                /* set bit 10 of trap status */
         }
         if (status == MAPFLT) {
             if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
-                TRAPSTATUS |= BIT1;                 /* set bit 1 of trap status */
+                TRAPSTATUS |= BIT12;                /* set bit 12 of trap status */
             else
                 TRAPSTATUS |= BIT10;                /* set bit 10 of trap status */
         }
@@ -1892,14 +1885,14 @@ t_stat Mem_write(uint32 addr, uint32 *data)
             "Mem_write error addr %.8x realaddr %.8x data %.8x prot %02x status %04x\n",
             addr, realaddr, *data, prot, status);
         if (status == NPMEM) {                      /* operand nonpresent memory error */
-            if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
+            if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
                 TRAPSTATUS |= BIT2;                 /* set bit 2 of trap status */
-            else
+            } else
                 TRAPSTATUS |= BIT10;                /* set bit 10 of trap status */
         }
         if (status == MAPFLT) {
             if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
-                TRAPSTATUS |= BIT2;                 /* set bit 2 of trap status */
+                TRAPSTATUS |= BIT12;                /* set bit 12 of trap status */
             else
                 TRAPSTATUS |= BIT10;                /* set bit 10 of trap status */
         }
@@ -1999,10 +1992,10 @@ wait_loop:
             PSD1 &= ~1;                         /* clear bit 31, no lr */
             drop_nop = 0;                       /* we dropped the nop */
         }
-redo:
+
         if (skipinstr) {                        /* need to skip interrupt test? */
 #ifdef NOTNOW
-            sim_debug(DEBUG_TRAP, &cpu_dev,
+            sim_debug(DEBUG_IRQ, &cpu_dev,
                 "Skipinstr set to zero PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
                 PSD1, PSD2, CPUSTATUS);
 #endif
@@ -2016,7 +2009,7 @@ redo:
             if (int_icb != 0) {                 /* was ICB returned for an I/O or interrupt */
                 int il = ilev;                  /* get the interrupt level */
                 sim_debug(DEBUG_IRQ, &cpu_dev,
-                    "Normal int scan return icb %08x level %02x irq_pend %02x wait4int %02x\n",
+                    "<>Normal int return icb %06x level %02x irq_pend %01x wait4int %01x\n",
                     int_icb, il, irq_pend, wait4int);
 
                 /* take interrupt, store the PSD, fetch new PSD */
@@ -2029,28 +2022,30 @@ redo:
                 /* set new map mode and interrupt blocking state in CPUSTATUS */
                 modes = PSD1 & 0x87000000;      /* extract bits 0, 5, 6, 7 from PSD 1 */
                 CPUSTATUS &= ~0x87000000;       /* reset bits in CPUSTATUS */
-                CPUSTATUS |= modes;             /* not insert into CPUSTATUS */
+                CPUSTATUS |= modes;             /* now insert into CPUSTATUS */
                 if (PSD2 & MAPBIT) {
-                    CPUSTATUS |= 0x00800000;    /* set bit 8 of cpu status */
+                    CPUSTATUS |= BIT8;          /* set bit 8 of cpu status */
                     modes |= MAPMODE;           /* set mapped mode */
                 } else
                     CPUSTATUS &= 0xff7fffff;    /* reset bit 8 of cpu status */
                 if ((PSD2 & 0x8000) == 0) {     /* is it retain blocking state */
                     if (PSD2 & 0x4000) {        /* no, is it set blocking state */
                         CPUSTATUS |= 0x80;      /* yes, set blk state in cpu status bit 24 */
-                        t = SPAD[il+0x80];      /* get spad entry for interrupt */
+
+                        /* This test fixed the hangs on terminal input for diags & UTX! */
+/*TRY*/                 t = SPAD[il+0x80];      /* get spad entry for interrupt */
                         /* Class F I/O spec says to reset interrupt active if user's */
                         /* interrupt service routine runs with interrupts blocked */
-//                        if ((t & 0x0f000000) == 0x0f000000) { /* if class F clear interrupt */
+/*TRY*/                 if ((t & 0x0f000000) == 0x0f000000) { /* if class F clear interrupt */
                             /* if this is F class I/O interrupt, clear the active level */
                             /* SPAD entries for interrupts begin at 0x80 */
                             INTS[il] &= ~INTS_ACT;      /* deactivate specified int level */
                             SPAD[il+0x80] &= ~SINT_ACT; /* deactivate in SPAD too */
                             irq_pend = 1;               /* scan for interrupts again */
                             sim_debug(DEBUG_IRQ, &cpu_dev,
-                                "Auto-reset interrupt INTS[%02x] %08x SPAD[%03x] %08x\n",
+                                "<>Auto-reset interrupt INTS[%02x] %08x SPAD[%03x] %08x\n",
                                 il, INTS[il], il+0x80, SPAD[il+0x80]);
-//                        }
+/*TRY*/                 }
                     }
                     else
                         CPUSTATUS &= ~0x80;     /* no, reset blk state in cpu status bit 24 */
@@ -2062,20 +2057,25 @@ redo:
                 SPAD[0xf5] = PSD2;              /* save the current PSD2 */
                 SPAD[0xf9] = CPUSTATUS;         /* save the cpu status in SPAD */
                 sim_debug(DEBUG_IRQ, &cpu_dev,
-                    "Inter %03x OPSD1 %08x OPSD2 %08x NPSD1 %08x NPSD2 %08x\n",
+                    "<>Int %03x OPSD1 %08x OPSD2 %08x NPSD1 %08x NPSD2 %08x\n",
                     il, RMW(int_icb), RMW(int_icb+4), PSD1, PSD2);
                 bc = RMW(int_icb+20) & 0xffffff;
                 if (RMW(int_icb+16) == 0)
                     sim_debug(DEBUG_IRQ, &cpu_dev,
-                        "Inter2 %03x ICBA %06x IOCLA %06x\n",
+                        "<>Int2 %03x ICBA %06x IOCLA %06x\n",
                         il, int_icb, RMW(int_icb+16));
                 else
                     sim_debug(DEBUG_IRQ, &cpu_dev,
-                        "Inter2 %03x ICBA %06x IOCLA %06x STAT %08x SW1 %08x SW2 %08x\n",
+                        "<>Int2 %03x ICBA %06x IOCLA %06x STAT %08x SW1 %08x SW2 %08x\n",
                         il, int_icb, RMW(int_icb+16), RMW(int_icb+20), RMW(bc), RMW(bc+4));
                 wait4int = 0;                   /* wait is over for int */
                 irq_pend = 1;                   /* scan for interrupts again */
                 skipinstr = 1;                  /* skip next inter test after this instr */
+#ifdef NOTNOW
+            sim_debug(DEBUG_IRQ, &cpu_dev,
+                "Skipinstr set to one PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                PSD1, PSD2, CPUSTATUS);
+#endif
                 goto skipi;                     /* skip int test */
             }
             /* see if waiting at a wait instruction */
@@ -2094,7 +2094,7 @@ redo:
                     PSD2 = M[4>>2];             /* PSD2 from location 4 */
                     modes = PSD1 & 0x87000000;  /* extract bits 0, 5, 6, 7 from PSD 1 */
                     CPUSTATUS &= ~0x87000000;   /* reset bits in CPUSTATUS */
-                    CPUSTATUS |= modes;         /* not insert into CPUSTATUS */
+                    CPUSTATUS |= modes;         /* now insert into CPUSTATUS */
                     sim_debug(DEBUG_IRQ, &cpu_dev, "Boot Loading PSD1 %.8x PSD2 %.8x\n", PSD1, PSD2);
                     /* set interrupt blocking state in CPUSTATUS */
                     CPUSTATUS |= 0x80;          /* set blocked state in cpu status, bit 24 too */
@@ -2103,6 +2103,11 @@ redo:
                     SPAD[0xf9] = CPUSTATUS;     /* save the cpu status in SPAD */
                     loading = 0;                /* we are done loading */
                     skipinstr = 1;              /* skip next interrupt test only once */
+#ifdef NOTNOW
+            sim_debug(DEBUG_IRQ, &cpu_dev,
+                "Skipinstr set to one PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                PSD1, PSD2, CPUSTATUS);
+#endif
                 }
                 goto wait_loop;                 /* continue waiting */
             }
@@ -2121,12 +2126,17 @@ redo:
             attention_trap = 0;                 /* clear flag */
             sim_debug(DEBUG_XIO, &cpu_dev, "Attention TRAP %04x\n", TRAPME);
             skipinstr = 1;                      /* skip next interrupt test only once */
+#ifdef NOTNOW
+            sim_debug(DEBUG_IRQ, &cpu_dev,
+                "Skipinstr set to one PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                PSD1, PSD2, CPUSTATUS);
+#endif
             goto newpsd;                        /* got process trap */
         }
 
 skipi:
         i_flags = 0;                            /* do not update pc if MF or NPM */
-        skipinstr = 0;                          /* skip only once */
+//XXX   skipinstr = 0;                          /* skip only once */
         TRAPSTATUS = CPUSTATUS & 0x57;          /* clear all trap status except cpu type */
 
         /* fill IR from logical memory address */
@@ -2172,10 +2182,6 @@ skipi:
             if (IR == 0x00020000) {             /* is this a NOP from rt hw? */
                 PSD1 = (PSD1 + 2) | (((PSD1 & 2) >> 1) & 1);    /* skip this instruction */
 //                fprintf(stderr, "RIGHT HW skip NOP instr %x skip nop at %x\n", IR, PSD1);
-                if (skipinstr == 2) {           /* last instr was lf hw and rt NOP, try ints again */
-                    skipinstr = 0;              /* only test this once */
-                    goto redo;                  /* check for ints now */
-                }
                 skipinstr = 0;                  /* only test this once */
                 goto skipi;                     /* go read next instruction */
             }
@@ -2920,9 +2926,11 @@ exec:
                 case 0xB:   /* RPSWT */             /* Read Processor Status Word 2 (PSD2) */
                     if ((GPR[reg] & 0x80000000) && (CPU_MODEL < MODEL_V9)) {
                         /* if bit 0 of reg set, return (default 0) CPU Configuration Word */
-                        sim_debug(DEBUG_CMD, &cpu_dev,
+#ifdef NOTNOW
+                        sim_debug(DEBUG_IRQ, &cpu_dev,
                     "RPSWT READ CCW GPR[%x] %08x CCW %04x SPAD[0xf5] %08x PSD2 %08x CPUSTATUS %08x\n",
                             reg, GPR[reg], CCW, SPAD[0xf5], PSD2, CPUSTATUS);
+#endif
                         dest = CCW;                 /* no cache or shared memory */
 //NO WCS                dest |= 0x0000c000;         /* set SIM bit for DIAGS */
                         /* make sure bit 19 is zero saying IPU not present */
@@ -2940,31 +2948,39 @@ exec:
                         CMSMC |= 0x00000200;        /* bit 22, Access Protection ECO present */
                         CMSMC |= 0x00000010;        /* CPU Firmware Version 1/Rev level 0 */
                         dest = CMSMC;               /* return starus */
-                        sim_debug(DEBUG_CMD, &cpu_dev,
+#ifdef NOTNOW
+                        sim_debug(DEBUG_IRQ, &cpu_dev,
                             "RPSWT READ Cache/Shadow CW GPR[%x] = %08x CMSMC %04x SPAD[0xf5] %x PSD2 %x\n",
                             reg, GPR[reg], CMSMC, SPAD[0xf5], PSD2);
+#endif
                     } else
                     if ((GPR[reg] & 0x40000000) && (CPU_MODEL == MODEL_V9)) {
                         /* if bit 1 of reg set, return CPU Shadow Memory Configuration Word */
                         CSMCW = 0x00000000;         /* no Shadow unit present */
-                        sim_debug(DEBUG_CMD, &cpu_dev,
+#ifdef NOTNOW
+                        sim_debug(DEBUG_IRQ, &cpu_dev,
                             "RPSWT READ V9 CPU Shadow Memory CW GPR[%x] = %08x CSMCW %04x SPAD[0xf5] %x PSD2 %x\n",
                             reg, GPR[reg], CSMCW, SPAD[0xf5], PSD2);
+#endif
                         dest = CSMCW;               /* return starus */
                     } else
                     if ((GPR[reg] & 0x20000000) && (CPU_MODEL ==  MODEL_V9)) {
                         /* if bit 2 of reg set, return Cache Memory Configuration Word */
                         ISMCW = 0x00000000;         /* no Shadow unit present */
-                        sim_debug(DEBUG_CMD, &cpu_dev,
+#ifdef NOTNOW
+                        sim_debug(DEBUG_IRQ, &cpu_dev,
                             "RPSWT READ V9 IPU Shadow Memory CW GPR[%x] = %08x ISMCW %04x SPAD[0xf5] %x PSD2 %x\n",
                             reg, GPR[reg], ISMCW, SPAD[0xf5], PSD2);
+#endif
                         dest = ISMCW;               /* return starus */
                     } else
                     if ((GPR[reg] & BIT0) == 0x00000000) {
                         /* if bit 0 of reg not set, return PSD2 */
-                        sim_debug(DEBUG_CMD, &cpu_dev,
+#ifdef NOTNOW
+                        sim_debug(DEBUG_IRQ, &cpu_dev,
                             "RPSWT READ PSW2 GPR[%x] %08x SPAD[0xf5] %08x PSD2 %08x CPUSTATUS %08x\n",
                             reg, GPR[reg], SPAD[0xf5], PSD2, CPUSTATUS);
+#endif
                         /* make sure bit 49 (block state is current stat */
                         dest = SPAD[0xf5];          /* get PSD2 for user from SPAD 0xf5 */
                         dest &= ~0x0000c000;        /* clear bits 48 & 49 */
@@ -4023,9 +4039,6 @@ skipit:
                             break;
                         }
                         td = (t_int64)dest % (t_int64)source;   /* remainder */
-//                      dbl = !(td >= 0);               /* double reg is neg remainder */
-//                      dbl = ((t_int64)td < 0);        /* double reg is neg remainder */
-                        dbl = (td < 0);                 /* double reg is neg remainder */
                         if (((td & DMSIGN) ^ (dest & DMSIGN)) != 0) /* Fix sign if needed */
                             td = NEGATE32(td);          /* dividend and remainder must be same sign */
                         dest = (t_int64)dest / (t_int64)source; /* now do the divide */
@@ -5906,9 +5919,10 @@ doovr2:
                         goto newpsd;                    /* go execute the trap now */
                     }
                     if ((TRAPME = Mem_read(addr, &temp))) { /* get PSD1 from memory */
-                        if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
+                        if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
                             TRAPSTATUS |= BIT10;        /* set bit 10 of trap status */
-                        else
+                            TRAPSTATUS |= BIT7;         /* set bit 7 of trap status */
+                        } else
                             TRAPSTATUS |= BIT18;        /* set bit 18 of trap status */
                         goto newpsd;                    /* memory read error or map fault */
                     }
@@ -5921,18 +5935,20 @@ doovr2:
 
                     if (opr & 0x0200) {                 /* Was it LPSDCM? */
                         if ((TRAPME = Mem_read(addr+4, &temp2))) {   /* get PSD2 from memory */
-                            if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
+                            if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
                                 TRAPSTATUS |= BIT10;    /* set bit 10 of trap status */
-                            else
+                                TRAPSTATUS |= BIT7;     /* set bit 7 of trap status */
+                            } else
                                 TRAPSTATUS |= BIT18;    /* set bit 18 of trap status */
                             goto newpsd;                /* memory read error or map fault */
                         }
                         PSD2 = temp2;                   /* PSD2 access good, so save it */
                     } else {
                         if ((TRAPME = Mem_read(addr+4, &temp2))) {   /* get PSD2 from memory */
-                            if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
+                            if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
                                 TRAPSTATUS |= BIT10;    /* set bit 10 of trap status */
-                            else
+                                TRAPSTATUS |= BIT7;     /* set bit 7 of trap status */
+                            } else
                                 TRAPSTATUS |= BIT18;    /* set bit 18 of trap status */
                             goto newpsd;                /* memory read error or map fault */
                         }
@@ -6025,7 +6041,7 @@ doovr2:
                             PSD2 &= ~RETMBIT;           /* turn off retain bit in PSD2 */
                             SPAD[0xf5] = PSD2;          /* save the current PSD2 */
                             SPAD[0xf9] = CPUSTATUS;     /* save the cpu status in SPAD */
-                            sim_debug(DEBUG_CMD, &cpu_dev,
+                            sim_debug(DEBUG_DETAIL, &cpu_dev,
                                 "LPSDCM MAPS LOADED TRAPME = %02x PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
                                 TRAPME, PSD1, PSD2, CPUSTATUS);
                         }
@@ -6052,14 +6068,25 @@ doovr2:
                         SPAD[0xf5] = ix;                /* restore the current PSD2 to SPAD */
                         SPAD[0xf9] = CPUSTATUS;         /* save the cpu status in SPAD */
                         irq_pend = reg;                 /* restore intr status */
-                        if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
+                        if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
                             TRAPSTATUS |= BIT10;        /* set bit 10 of trap status */
-                        else
+                            TRAPSTATUS |= BIT7;         /* set bit 7 of trap status */
+                        } else
                             TRAPSTATUS |= BIT18;        /* set bit 18 of trap status */
                         goto newpsd;                    /* go process error */
                     }
                     skipinstr = 1;                      /* do not allow intr on next instruction */
+#ifdef NOTNOW
+                    sim_debug(DEBUG_IRQ, &cpu_dev,
+                        "Skipinstr set to one PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                        PSD1, PSD2, CPUSTATUS);
+#endif
                     drop_nop = 0;                       /* nothing to drop */
+#ifdef NOTNOW
+                    sim_debug(DEBUG_IRQ, &cpu_dev,
+                        "LPSD(CM) Done PSD1 %08x PSD2 %08x CPUSTATUS %08x irq %01x\n",
+                        PSD1, PSD2, CPUSTATUS, irq_pend);
+#endif
                     goto newpsd;                        /* load the new psd, or process error */
                     break;
 
@@ -6128,6 +6155,8 @@ doovr2:
 //                            break;                      /* ignore */
                         if ((t & 0x0f000000) == 0x0f000000) /* if class F ignore instruction */
                             break;                      /* ignore for F class */
+
+                        /* does not effect REQ status */
                         INTS[prior] |= INTS_ENAB;       /* enable specified int level */
                         SPAD[prior+0x80] |= SINT_ENAB;  /* enable in SPAD too */
                         irq_pend = 1;                   /* start scanning interrupts again */
@@ -6143,6 +6172,11 @@ doovr2:
                             sim_debug(DEBUG_IRQ, &cpu_dev, "Intv Timer EI %02x Turn on\n", prior);
                             itm_setup(1, prior);        /* tell timer to start */
                         }
+#ifndef NOTNOW
+            sim_debug(DEBUG_IRQ, &cpu_dev,
+                "EI lev %02x Skipinstr set to one PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                prior, PSD1, PSD2, CPUSTATUS);
+#endif
                         break;
 
                     case 0x1:       /* DI FC01 */
@@ -6155,10 +6189,11 @@ doovr2:
                             break;                      /* ignore */
                         if ((t & 0x0f000000) == 0x0f000000) /* if class F ignore instruction */
                             break;                      /* ignore for F class */
+
                         /* active state is left alone */
                         INTS[prior] &= ~INTS_ENAB;      /* disable specified int level */
-                        INTS[prior] &= ~INTS_REQ;       /* clears any requests also */
                         SPAD[prior+0x80] &= ~SINT_ENAB; /* disable in SPAD too */
+                        INTS[prior] &= ~INTS_REQ;       /* clears any requests also */
 
                         /* test for clock at address 0x7f06 and interrupt level 0x18 */
                         /* the diags want the type to be 0, others want 3, so ignore */
@@ -6171,6 +6206,11 @@ doovr2:
                             itm_setup(0, prior);        /* tell timer to stop */
                             sim_debug(DEBUG_IRQ, &cpu_dev, "Intv Timer DI %02x Turn off\n", prior);
                         }
+#ifndef NOTNOW
+            sim_debug(DEBUG_IRQ, &cpu_dev,
+                "DI lev %02x Skipinstr set to %01x PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                prior, skipinstr, PSD1, PSD2, CPUSTATUS);
+#endif
                         break;
 
                     case 0x2:       /* RI FC02 */
@@ -6185,6 +6225,11 @@ doovr2:
                             break;                      /* ignore for F class */
                         INTS[prior] |= INTS_REQ;        /* set the request flag for this level */
                         irq_pend = 1;                   /* start scanning interrupts again */
+#ifndef NOTNOW
+            sim_debug(DEBUG_IRQ, &cpu_dev,
+                "RI lev %02x Skipinstr set to one PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                prior, PSD1, PSD2, CPUSTATUS);
+#endif
                         break;
 
                     case 0x3:       /* AI FC03 */
@@ -6199,6 +6244,11 @@ doovr2:
                         INTS[prior] |= INTS_ACT;        /* activate specified int level */
                         SPAD[prior+0x80] |= SINT_ACT;   /* activate in SPAD too */
                         irq_pend = 1;                   /* start scanning interrupts again */
+#ifndef NOTNOW
+            sim_debug(DEBUG_IRQ, &cpu_dev,
+                "AI lev %02x Skipinstr set to one PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                prior, PSD1, PSD2, CPUSTATUS);
+#endif
                         break;
 
                     case 0x4:       /* DAI FC04 */
@@ -6217,6 +6267,11 @@ doovr2:
                         /* instruction following a DAI can not be interrupted */
                         /* skip tests for interrupts if this is the case */
                         skipinstr = 1;                  /* skip interrupt test */
+#ifndef NOTNOW
+            sim_debug(DEBUG_IRQ, &cpu_dev,
+                "DAI lev %02x Skipinstr set to one PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                prior, PSD1, PSD2, CPUSTATUS);
+#endif
                         drop_nop = 0;                   /* nothing to drop */
                         break;
 
@@ -6503,15 +6558,17 @@ mcheck:
                         /* SPAD entries for interrupts begin at 0x80 */
                         INTS[ix] &= ~INTS_ACT;          /* deactivate specified int level */
                         SPAD[ix+0x80] &= ~SINT_ACT;     /* deactivate in SPAD too */
-                        irq_pend = 1;                   /* start scanning interrupts again */
-                        skipinstr = 1;                  /* skip interrupt test */
                         if ((TRAPME = checkxio(chsa, &status)))
                             goto newpsd;                /* error returned, trap cpu */
-                        PSD1 = ((PSD1 & 0x87fffffe) | (status & 0x78000000));   /* insert status */
-#ifdef DO_DYNAMIC_DEBUG
-                /* start debugging */
-                cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ);
+                        irq_pend = 1;                   /* start scanning interrupts again */
+                        skipinstr = 1;                  /* skip interrupt test */
+#ifdef NOTNOW
+            sim_debug(DEBUG_IRQ, &cpu_dev,
+                "Skipinstr set to one PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
+                PSD1, PSD2, CPUSTATUS);
 #endif
+/*XXX*/                 drop_nop = 0;                   /* nothing to drop */
+                        PSD1 = ((PSD1 & 0x87fffffe) | (status & 0x78000000));   /* insert status */
                         break;
                 }                   /* end of XIO switch */
                 break;

--- a/SEL32/sel32_defs.h
+++ b/SEL32/sel32_defs.h
@@ -102,6 +102,8 @@
 /* simulator devices configuration */
 #define NUM_DEVS_IOP    1       /* 1 device IOP channel controller */
 #define NUM_UNITS_IOP   1       /* 1 master IOP channel device */
+#define NUM_DEVS_MFP    1       /* 1 device MFP channel controller */
+#define NUM_UNITS_MFP   1       /* 1 master MFP channel device */
 #define NUM_DEVS_COM    2       /* 8-Line async controller */
 #define NUM_UNITS_COM   16      /* 8-Line async units */
 #define NUM_DEVS_CON    1       /* 1 I/O console controller */
@@ -128,6 +130,9 @@ extern DEVICE cpu_dev;      /* cpu device */
 extern UNIT cpu_unit;       /* the cpu unit */
 #ifdef NUM_DEVS_IOP
 extern DEVICE iop_dev;      /* IOP channel controller */
+#endif
+#ifdef NUM_DEVS_MFP
+extern DEVICE mfp_dev;      /* MFP channel controller */
 #endif
 #ifdef NUM_DEVS_RTOM
 extern DEVICE rtc_dev;      /* RTOM rtc */

--- a/SEL32/sel32_fltpt.c
+++ b/SEL32/sel32_fltpt.c
@@ -833,7 +833,7 @@ uint32 s_dvfw(uint32 reg, uint32 mem, uint32 *cc) {
     if (temp2 >= 0x7fffffc0)            /* check for special rounding */
         goto RRND2;                     /* no special handling */
     /* FIXME dead code */
-    if (temp2 == MSIGN) {               /* check for minux zero */
+    if (temp2 == MSIGN) {               /* check for minus zero */
         temp2 = 0xF8000000;             /* yes, fixup value */
         expr++;                         /* bump exponent */
     }
@@ -844,9 +844,11 @@ uint32 s_dvfw(uint32 reg, uint32 mem, uint32 *cc) {
     if ((sign & MSIGN) == 0)
         goto RRND1;                     /* if sign set, don't round yet */
     expr += temp;                       /* add exponent */
-    if (expr < 0)                       /* test for underflow */
+    /* FIX unsigned CMP */
+//  if (expr < 0)                       /* test for underflow */
+    if ((int32)expr < 0)                /* test for underflow */
         goto DUNFLO;                    /* go process underflow */
-    if (expr > 0x7f)                    /* test for overflow */
+    if ((int32)expr > 0x7f)             /* test for overflow */
         goto DOVFLO;                    /* go process overflow */
     expr ^= FMASK;                      /* complement exponent */
     temp2 += 0x40;                      /* round at bit 25 */
@@ -858,7 +860,7 @@ RRND2:
     if ((int32)expr < 0) {              /* test for underflow */
         goto DUNFLO;                    /* go process underflow */
     }
-    if (expr > 0x7f) {                  /* test for overflow */
+    if ((int32)expr > 0x7f) {           /* test for overflow */
         goto DOVFLO;                    /* go process overflow */
     }
     if (sign & MSIGN)                   /* test for negative */

--- a/SEL32/sel32_lpr.c
+++ b/SEL32/sel32_lpr.c
@@ -190,6 +190,7 @@ DEVICE          lpr_dev = {
     "LPR", lpr_unit, NULL, lpr_mod,
     NUM_DEVS_LPR, 8, 15, 1, 8, 8,
     NULL, NULL, NULL, NULL, &lpr_attach, &lpr_detach,
+    /* ctxt is the DIB pointer */
     &lpr_dib, DEV_UADDR | DEV_DISABLE | DEV_DEBUG, 0, dev_debug
 };
 

--- a/SEL32/sel32_mfp.c
+++ b/SEL32/sel32_mfp.c
@@ -1,0 +1,275 @@
+/* sel32_mfp.c: SEL-32 Model 8000/8001/8002 MFP processor controller
+
+   Copyright (c) 2018-2020, James C. Bevier
+
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and associated documentation files (the "Software"),
+   to deal in the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+   JAMES C. BEVIER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   This channel is the interrupt fielder for all of the MFP sub channels.  It's
+   channel address is 7600.  This code handles the INCH command for the MFP
+   devices and controls the status FIFO for the mfp devices on interrupts and
+   TIO instructions..
+
+   Possible devices:
+   The f8iop communication controller (TY76A0), (TY76B0), (TY76C0) 
+   The ctiop console communications controller (CT76FC & CT76FD)
+   The lpiop line printer controller (LP76F8), (LP76F9)
+   The scsi  SCSI disk controller (DM7600), (DM7640)
+
+*/
+
+#include "sel32_defs.h"
+
+#ifdef NUM_DEVS_MFP
+
+extern  t_stat  set_dev_addr(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
+extern  t_stat  show_dev_addr(FILE *st, UNIT * uptr, int32 v, CONST void *desc);
+extern  void    chan_end(uint16 chan, uint8 flags);
+extern  int     chan_read_byte(uint16 chan, uint8 *data);
+extern  int     chan_write_byte(uint16 chan, uint8 *data);
+extern  void    set_devattn(uint16 addr, uint8 flags);
+extern  void    post_extirq(void);
+extern  uint32  attention_trap;             /* set when trap is requested */
+extern  void    set_devwake(uint16 addr, uint8 flags);
+extern  t_stat  set_inch(UNIT *uptr, uint32 inch_addr); /* set channel inch address */
+extern  CHANP  *find_chanp_ptr(uint16 chsa);             /* find chanp pointer */
+
+/* forward definitions */
+uint8   mfp_startcmd(UNIT *uptr, uint16 chan, uint8 cmd);
+void    mfp_ini(UNIT *uptr, t_bool f);
+t_stat  mfp_srv(UNIT *uptr);
+t_stat  mfp_reset(DEVICE *dptr);
+t_stat  mfp_help(FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr);
+const char  *mfp_desc(DEVICE *dptr);
+
+/* Held in u3 is the device command and status */
+#define MFP_INCH    0x00    /* Initialize channel command */
+#define MFP_INCH2   0xf0    /* Initialize channel command after start */
+#define MFP_NOP     0x03    /* NOP command */
+#define MFP_MSK     0xff    /* Command mask */
+
+/* Status held in u3 */
+/* controller/unit address in upper 16 bits */
+#define CON_INPUT   0x100   /* Input ready for unit */
+#define CON_CR      0x200   /* Output at beginning of line */
+#define CON_REQ     0x400   /* Request key pressed */
+#define CON_EKO     0x800   /* Echo input character */
+#define CON_OUTPUT  0x1000  /* Output ready for unit */
+#define CON_READ    0x2000  /* Read mode selected */
+
+/* not used u4 */
+
+/* in u5 packs sense byte 0,1 and 3 */
+/* Sense byte 0 */
+#define SNS_CMDREJ  0x80000000    /* Command reject */
+#define SNS_INTVENT 0x40000000    /* Unit intervention required */
+/* sense byte 3 */
+#define SNS_RDY     0x80        /* device ready */
+#define SNS_ONLN    0x40        /* device online */
+
+/* std devices. data structures
+
+    mfp_dev     Console device descriptor
+    mfp_unit    Console unit descriptor
+    mfp_reg     Console register list
+    mfp_mod     Console modifiers list
+*/
+
+struct _mfp_data
+{
+    uint8       ibuff[145];         /* Input line buffer */
+    uint8       incnt;              /* char count */
+}
+mfp_data[NUM_UNITS_MFP];
+
+/* channel program information */
+CHANP           mfp_chp[NUM_UNITS_MFP] = {0};
+
+MTAB            mfp_mod[] = {
+    {MTAB_XTD | MTAB_VUN | MTAB_VALR, 0, "DEV", "DEV",
+        &set_dev_addr, &show_dev_addr, NULL, "Device address"},
+    {0}
+};
+
+UNIT            mfp_unit[] = {
+    {UDATA(&mfp_srv, UNIT_IDLE, 0), 0, UNIT_ADDR(0x7600)},       /* Channel controller */
+};
+
+//DIB mfp_dib = {NULL, mfp_startcmd, NULL, NULL, NULL, mfp_ini, mfp_unit, mfp_chp, NUM_UNITS_MFP, 0xff, 0x7e00,0,0,0};
+DIB             mfp_dib = {
+    NULL,           /* uint8 (*pre_io)(UNIT *uptr, uint16 chan)*/       /* Start I/O */
+    mfp_startcmd,   /* uint8 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start a command SIO */
+    NULL,           /* uint8 (*halt_io)(UNIT *uptr) */          /* Stop I/O HIO */
+    NULL,           /* uint8 (*test_io)(UNIT *uptr) */          /* Test I/O TIO */
+    NULL,           /* uint8 (*post_io)(UNIT *uptr) */          /* Post I/O */
+    mfp_ini,        /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
+    mfp_unit,       /* UNIT* units */                           /* Pointer to units structure */
+    mfp_chp,        /* CHANP* chan_prg */                       /* Pointer to chan_prg structure */
+    NUM_UNITS_MFP,   /* uint8 numunits */                        /* number of units defined */
+    0xff,           /* uint8 mask */                            /* 16 devices - device mask */
+    0x7e00,         /* uint16 chan_addr */                      /* parent channel address */
+    0,              /* uint32 chan_fifo_in */                   /* fifo input index */
+    0,              /* uint32 chan_fifo_out */                  /* fifo output index */
+    {0}             /* uint32 chan_fifo[FIFO_SIZE] */           /* interrupt status fifo for channel */
+};
+
+DEVICE          mfp_dev = {
+    "MFP", mfp_unit, NULL, mfp_mod,
+    NUM_UNITS_MFP, 8, 15, 1, 8, 8,
+    NULL, NULL, &mfp_reset,         /* examine, deposit, reset */
+    NULL, NULL, NULL,               /* boot, attach, detach */
+    &mfp_dib, DEV_UADDR|DEV_DISABLE|DEV_DEBUG, 0, dev_debug,  /* dib, dev flags, debug flags, debug */
+//  NULL, NULL, &mfp_help,          /* ?, ?, help */
+//  NULL, NULL, &mfp_desc           /* ?, ?, description */
+};
+
+/* MFP controller routines */
+/* initialize the console chan/unit */
+void mfp_ini(UNIT *uptr, t_bool f)
+{
+    int     unit = (uptr - mfp_unit);               /* unit 0 */
+    DEVICE *dptr = &mfp_dev;                        /* one and only dummy device */
+
+    sim_debug(DEBUG_CMD, &mfp_dev,
+        "MFP init device %s controller/device %04x\n",
+        dptr->name, GET_UADDR(uptr->u3));
+    mfp_data[unit].incnt = 0;                       /* no input data */
+    uptr->u5 = SNS_RDY|SNS_ONLN;                    /* status is online & ready */
+}
+
+/* start an I/O operation */
+uint8  mfp_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
+{
+    sim_debug(DEBUG_CMD, &mfp_dev,
+        "MFP startcmd %02x controller/device %04x\n",
+        cmd, GET_UADDR(uptr->u3));
+    if ((uptr->u3 & MFP_MSK) != 0)                  /* is unit busy */
+        return SNS_BSY;                             /* yes, return busy */
+
+    /* process the commands */
+    switch (cmd & 0xFF) {
+    /* UTX uses the INCH cmd to detect the MFP or MFP */
+    /* MFP has INCH cmd of 0, while MFP uses 0x80 */
+    case MFP_INCH:                                  /* INCH command */
+        uptr->u5 = SNS_RDY|SNS_ONLN;                /* status is online & ready */
+        uptr->u3 &= LMASK;                          /* leave only chsa */
+        sim_debug(DEBUG_CMD, &mfp_dev,
+            "mfp_startcmd %04x: Cmd INCH iptr %06x INCHa %06x\n",
+            chan, mfp_chp[0].ccw_addr,              /* set inch buffer addr */
+            mfp_chp[0].chan_inch_addr);             /* set inch buffer addr */
+
+        mfp_chp[0].chan_inch_addr = mfp_chp[0].ccw_addr;   /* set inch buffer addr */
+//      set_inch(uptr, mfp_chp[0].ccw_addr);        /* new address */
+
+        uptr->u3 |= MFP_INCH2;                      /* save INCH command as 0xf0 */
+        sim_activate(uptr, 20);                     /* go on */
+        return 0;                                   /* no status change */
+        break;
+
+    case MFP_NOP:                                   /* NOP command */
+        sim_debug(DEBUG_CMD, &mfp_dev, "mfp_startcmd %04x: Cmd NOP\n", chan);
+        uptr->u5 = SNS_RDY|SNS_ONLN;                /* status is online & ready */
+        uptr->u3 &= LMASK;                          /* leave only chsa */
+        uptr->u3 |= (cmd & MFP_MSK);                /* save NOP command */
+        sim_activate(uptr, 20);                     /* TRY 07-13-19 */
+        return 0;                                   /* no status change */
+        break;
+
+    default:                                        /* invalid command */
+        uptr->u5 |= SNS_CMDREJ;                     /* command rejected */
+        sim_debug(DEBUG_CMD, &mfp_dev, "mfp_startcmd %04x: Cmd Invalid %02x status %02x\n",
+            chan, cmd, uptr->u5);
+        uptr->u3 &= LMASK;                          /* leave only chsa */
+        uptr->u3 |= (cmd & MFP_MSK);                /* save command */
+        sim_activate(uptr, 20);                     /* force interrupt */
+        return 0;                                   /* no status change */
+        break;
+    }
+
+    return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;       /* not reachable for now */
+}
+
+/* Handle transfers for other sub-channels on MFP */
+t_stat mfp_srv(UNIT *uptr)
+{
+    uint16  chsa = GET_UADDR(uptr->u3);
+    int     cmd = uptr->u3 & MFP_MSK;
+//  CHANP   *chp = find_chanp_ptr(chsa);            /* find the chanp pointer */
+    CHANP   *chp = &mfp_chp[0];                     /* find the chanp pointer */
+//  int     i;
+//  int     len = chp->ccw_count;                   /* INCH command count */
+    uint32  mema = chp->ccw_addr;                   /* get inch or buffer addr */
+
+    /* test for NOP or INCH cmds */
+    if ((cmd != MFP_NOP) && (cmd != MFP_INCH2)) {   /* NOP or INCH */
+        uptr->u3 &= LMASK;                          /* nothing left, command complete */
+        sim_debug(DEBUG_CMD, &mfp_dev,
+            "mfp_srv Unknown cmd %02x chan %02x: chnend|devend|unitexp\n", cmd, chsa);
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITEXP);  /* done */
+        return SCPE_OK;
+    } else
+
+    if (cmd == MFP_NOP) {                           /* NOP do nothing */
+        uptr->u3 &= LMASK;                          /* nothing left, command complete */
+        sim_debug(DEBUG_CMD, &mfp_dev, "mfp_srv INCH/NOP chan %02x: chnend|devend\n", chsa);
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);      /* done */
+        return SCPE_OK;
+    } else
+
+    /* test for INCH cmd */
+    if (cmd == MFP_INCH2) {                         /* INCH */
+        sim_debug(DEBUG_CMD, &mfp_dev,
+            "mfp_srv starting INCH %06x cmd, chsa %04x MemBuf %06x cnt %04x\n",
+            mema, chsa, chp->ccw_addr, chp->ccw_count);
+
+        /* the chp->ccw_addr location contains the inch address */
+        /* call set_inch() to setup inch buffer */
+//      i = set_inch(uptr, mema);                   /* new address */
+        set_inch(uptr, mema);                       /* new address */
+//      chp->chan_inch_addr = mema;                 /* set inch buffer addr */
+        uptr->u3 &= LMASK;                          /* clear the cmd */
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);      /* we are done dev|chan end */
+//      chan_end(chsa, SNS_CHNEND);                 /* we are done dev|chan end */
+    }
+    return SCPE_OK;
+}
+
+t_stat mfp_reset(DEVICE *dptr)
+{
+    /* add reset code here */
+    return SCPE_OK;
+}
+
+/* sho help mfp */
+t_stat mfp_help(FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, CONST char *cptr)
+{
+    fprintf(st, "SEL-32 MFP Model 8002 Channel Controller at 0x7600\r\n");
+    fprintf(st, "The MFP fields all interrupts and status posting\r\n");
+    fprintf(st, "for each of the controllers on the system.\r\n");
+    fprintf(st, "Nothing can be configured for this Channel.\r\n");
+//    fprint_set_help(st, dptr);
+//    fprint_show_help(st, dptr);
+    return SCPE_OK;
+}
+
+const char *mfp_desc(DEVICE *dptr)
+{
+    return("SEL-32 MFP Model 8002 Channel Controller @ 0x7600");
+}
+
+#endif
+

--- a/SEL32/sel32_sys.c
+++ b/SEL32/sel32_sys.c
@@ -62,6 +62,9 @@ DEVICE *sim_devices[] = {
 #ifdef NUM_DEVS_IOP
         &iop_dev,                           /* IOP channel controller */
 #endif
+#ifdef NUM_DEVS_MFP
+        &mfp_dev,                           /* MFP channel controller */
+#endif
 #ifdef NUM_DEVS_RTOM
         &rtc_dev,
         &itm_dev,
@@ -532,7 +535,9 @@ t_stat sim_load (FILE *fileref, CONST char *cptr, CONST char *fnam, int flag)
     case FMT_ICL:                       /* icl file image */
         return load_icl(fileref);
 
+#ifdef NO_TAP_FOR_NOW
     case FMT_NONE:                      /* nothing */
+#endif
     default:
         break;
     }

--- a/SEL32/taptools/filelist.c
+++ b/SEL32/taptools/filelist.c
@@ -159,25 +159,21 @@ int main (int argc, char *argv[])
     /* get lines until eof */
     while ((ll=getloi(buf, buf_size)) != EOF)
     {
-        if (ll == 0)
-        {
+        if (ll == 0) {
             /* eof found, process new file */
             skipfile = 0;
             file_byte_count = 0;
             fileaddr = 0;
             printf("\nfile %d:\n", filen);
-        }
-        else
-        {
+        } else {
             int cc = 0;
             buffptr = 0;
             char buff[257];
             int ans;
-
-{
-            /* dump first 2 words */
             int w1, w2, i, j;
             char path[64], command[128];
+        {
+            /* dump first 2 words */
             w1 = (buf[0] & 0xff) << 24 | buf[1] << 16 | buf[2] << 8 | (buf[3] & 0xff);
             w2 = (buf[4] & 0xff) << 24 | buf[5] << 16 | buf[6] << 8 | (buf[7] & 0xff);
             if (filen > 480)

--- a/makefile
+++ b/makefile
@@ -1982,7 +1982,7 @@ SEL32 = ${SEL32D}/sel32_cpu.c ${SEL32D}/sel32_sys.c ${SEL32D}/sel32_chan.c \
 	${SEL32D}/sel32_iop.c ${SEL32D}/sel32_com.c ${SEL32D}/sel32_con.c \
 	${SEL32D}/sel32_clk.c ${SEL32D}/sel32_mt.c ${SEL32D}/sel32_lpr.c \
 	${SEL32D}/sel32_scfi.c ${SEL32D}/sel32_fltpt.c ${SEL32D}/sel32_disk.c \
-	${SEL32D}/sel32_hsdp.c
+	${SEL32D}/sel32_hsdp.c ${SEL32D}/sel32_mfp.c ${SEL32D}/sel32_scsi.c
 SEL32_OPT = -I $(SEL32D) -DSEL32 
 #SEL32_OPT = -I $(SEL32D) -DUSE_INT64 -DSEL32 
 


### PR DESCRIPTION
SEL32: start code cleanup.
SEL32: add mfp and mfp scsi disk intitial support code.
SEL32: add new files sel32_mfp.c and sel32_scsi.c to makefile.
SEL32: modify sel32_mt.c code to define tape as BTP for UTX.