### PR TITLE
SEL32: Revise channel programming support.

### DIFF
--- a/SEL32/README.md
+++ b/SEL32/README.md
@@ -44,9 +44,10 @@ sim32sdt.tap - MPX 1.5f user SDT install tape.  Uses 300mb disk, IOP 8-line
 Available Level One Diagnostic boot tape:
 diag.ini       command file to start diags. ./sel32 diag.ini
 diag.tap       bootable level one diagnostic tape w/auto testing.  Set cpu type
-               to 32/27, 32/67, 32/87, 32/97, V6 or V9.  32/97 and V9 diags 
-               halt at test 46,subtest 2 in the CN.MMM & VM.MMM diags.  The
-               rest of the machines stop in the CN.COM console diagnostic.
+               to 32/27, 32/67, 32/87, 32/97, V6 or V9.  All cpu models now
+               run all diagnostics except cv.dxp which is used to run level 2
+               diagnostics. The diag stops at random places after a few
+               characters are entered into the console.
 
                CV.CSL - Firmware control diag.  Disabled in auto testing.
                CV.CP1 - CPU diag part 1 runs OK.
@@ -57,11 +58,11 @@ diag.tap       bootable level one diagnostic tape w/auto testing.  Set cpu type
                CV.INT - Interrupt diag runs OK.
                CV.TRP - Traps diag runs OK.
                CV.CMD - Cache/Shadow diag.  Disabled in auto testing.
-               CN.MMM - Non virtual memory diag runs OK, except for 32/97.
-               VM.MMM - virtual memory diag for V6 & V9 runs OK, except for V9.
+               CN.MMM - Non virtual memory diag runs OK.
+               VM.MMM - virtual memory diag for V6 & V9 runs OK.
                CV.IPT - IPU trap diag.  Disabled in auto testing.
                CV.CSD - WCS read/write trap diag.  Disabled in auto testing.
-               CV.CON - Operators Console diag halts at 0x852e for all CPUs.
+               CV.CON - Operators Console runs all tests for all CPUs.
 
                Set GPR[0] = 0xffffffff before booting from tape to disable the
                auto test and go to the Diagnostic Overlay Loader (DOL>) prompt.
@@ -72,20 +73,21 @@ Available UTX-21a install tape for testing:
 utxtape1.ini   command file to start UTX install tape.  ./sel32 utxtape1.ini
 utx21a1.tap    bootable UTX install tape for testing basemode.  The current
                V6 & V9 will boot UTX into single user mode.  You can run a
-               small subset of the commands that on the installation tape.
-               Prep, the disk preparation UTX program, cannot format a disk
-               drive at this time due to unsupport disk commands that are
-               required. All basemode instructions have been tested with
-               the CV.BRD diag.  The virtual memory has been fully tested
-               with the VM.MMM diag.  UTX needs better support for the disk
-               controller before we can move any farther with the installation.
+               small subset of the commands that are on the installation tape.
+               Prep, the disk preparation UTX program, can format a disk
+               drive.  Other files systems can be created, but cause the
+               system to hang at various places during the fsck command.
+               All basemode instructions have been tested with the CV.BRD diag.
+               The virtual memory has been fully tested with the VM.MMM diag.
+               UTX needs better support for the disk controller before we can
+               move any farther with the installation.
 
 Other MPX verion support:
                I am still looking for an MPX 3.X user or master SDT tape.  I have
-               much of the source, but no loadable code to creat a bootable system.
+               much of the source, but no loadable code to create a bootable system.
                Please keep looking for anyone who can provide these tapes or a
                disk image of a bootable system..
 
 James C. Bevier
-01/14/2020 
+03/30/2020 
 

--- a/SEL32/sel32_clk.c
+++ b/SEL32/sel32_clk.c
@@ -53,8 +53,6 @@ extern uint32 M[];                  /* system memory */
 int32 rtc_pie = 0;                  /* rtc pulse ie */
 int32 rtc_tps = 60;                 /* rtc ticks/sec */
 int32 rtc_lvl = 0x18;               /* rtc interrupt level */
-time_t lastcresult = 0;             /* last clock int time for rtc */
-time_t lastiresult = 0;             /* last clock int time for tim */
 
 /* Clock data structures
 
@@ -109,11 +107,8 @@ DEVICE rtc_dev = {
 t_stat rtc_srv (UNIT *uptr)
 {
     if (rtc_pie) {                                  /* set pulse intr */
-        time_t result = time(NULL);
+//      time_t result = time(NULL);
 //      fprintf(stderr, "Clock int time %08x\r\n", (uint32)result);
-        sim_debug(DEBUG_CMD, &rtc_dev, "RT Clock int time %08x diff from last %08x\n",
-            (uint32)result, (uint32)(result-lastcresult));
-//      lastcresult = result;                       /* save last clock time */
         if (((INTS[rtc_lvl] & INTS_ENAB) ||         /* make sure enabled */
             (SPAD[rtc_lvl+0x80] & SINT_ENAB)) &&    /* in spad too */
             (((INTS[rtc_lvl] & INTS_ACT) == 0) ||   /* and not active */
@@ -150,13 +145,12 @@ void rtc_setup(uint32 ss, uint32 level)
         INTS[level] &= ~INTS_ENAB;                  /* make sure disabled */
         SPAD[level+0x80] &= ~SINT_ENAB;             /* in spad too */
 //      INTS[level] &= ~INTS_REQ;                   /* make sure request not requesting */
-        INTS[level] &= ~INTS_ACT;                   /* make sure request not active */
-        SPAD[level+0x80] &= ~SINT_ACT;              /* in spad too */
+/*@41*/ INTS[level] &= ~INTS_ACT;                   /* make sure request not active */
+/*@41*/ SPAD[level+0x80] &= ~SINT_ACT;              /* in spad too */
         sim_debug(DEBUG_CMD, &rtc_dev,
             "RT Clock setup disable int %02x rtc_pie %01x ss %01x\n",
             rtc_lvl, rtc_pie, ss);
     }
-    lastcresult = time(NULL);                       /* save start time */
     rtc_pie = ss;                                   /* set new state */
 }
 
@@ -383,13 +377,12 @@ void itm_setup(uint32 ss, uint32 level)
         INTS[level] &= ~INTS_ENAB;                  /* make sure disabled */
         SPAD[level+0x80] &= ~SINT_ENAB;             /* in spad too */
 //      INTS[level] &= ~INTS_REQ;                   /* make sure request not requesting */
-        INTS[level] &= ~INTS_ACT;                   /* make sure request not active */
-        SPAD[level+0x80] &= ~SINT_ACT;              /* in spad too */
+/*@41*/ INTS[level] &= ~INTS_ACT;                   /* make sure request not active */
+/*@41*/ SPAD[level+0x80] &= ~SINT_ACT;              /* in spad too */
         sim_debug(DEBUG_CMD, &itm_dev,
             "Intv Timer setup disable int %02x value %08x itm_pie %01x ss %01x\n",
             itm_lvl, itm_cnt, itm_pie, ss);
     }
-    lastiresult = time(NULL);                       /* save start time */
     itm_pie = ss;                                   /* set new state */
 }
 

--- a/SEL32/sel32_con.c
+++ b/SEL32/sel32_con.c
@@ -193,8 +193,8 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         uptr->CMD &= LMASK;             /* leave only chsa */
         uptr->CMD |= CON_INCH2;         /* save INCH command as 0xf0 */
         uptr->SNS = SNS_RDY|SNS_ONLN;   /* status is online & ready */
-//@     sim_activate(uptr, 20);         /* start us off */
-        sim_activate(uptr, 40);         /* start us off */
+        sim_activate(uptr, 20);         /* start us off */
+//@41   sim_activate(uptr, 40);         /* start us off */
         return 0;                       /* no status change */
         break;
 
@@ -204,8 +204,9 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         uptr->CMD &= LMASK;             /* leave only chsa */
         uptr->CMD |= (cmd & CON_MSK);   /* save command */
         uptr->SNS = SNS_RDY|SNS_ONLN;   /* status is online & ready */
-//@     sim_activate(uptr, 20);         /* start us off */
-        sim_activate(uptr, 40);         /* start us off */
+        sim_activate(uptr, 20);         /* start us off */
+//@41   sim_activate(uptr, 40);         /* start us off */
+//@41   sim_activate(uptr, 20);         /* start us off */
         return 0;                       /* no status change */
         break;
 
@@ -221,8 +222,9 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         uptr->u4 = 0;                   /* no I/O yet */
         con_data[unit].incnt = 0;       /* clear any input data */
         uptr->SNS = SNS_RDY|SNS_ONLN;   /* status is online & ready */
-//@     sim_activate(uptr, 20);         /* start us off */
-        sim_activate(uptr, 40);         /* start us off */
+        sim_activate(uptr, 20);         /* start us off */
+//@41   sim_activate(uptr, 40);         /* start us off */
+//@41   sim_activate(uptr, 140);        /* start us off */
         return 0;
         break;
 
@@ -232,8 +234,8 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         uptr->CMD |= (cmd & CON_MSK);   /* save command */
 //      uptr->u4 = 0;                   /* no I/O yet */
 //      con_data[unit].incnt = 0;       /* clear any input data */
-//@     sim_activate(uptr, 20);         /* start us off */
-        sim_activate(uptr, 40);         /* start us off */
+        sim_activate(uptr, 20);         /* start us off */
+//@41   sim_activate(uptr, 40);         /* start us off */
         return 0;                       /* no status change */
         break;
 
@@ -242,8 +244,8 @@ uint8  con_startcmd(UNIT *uptr, uint16 chan, uint8 cmd) {
         uptr->SNS = SNS_RDY|SNS_ONLN;   /* status is online & ready */
         uptr->CMD &= LMASK;             /* leave only chsa */
         uptr->CMD |= (cmd & CON_MSK);   /* save command */
-//@     sim_activate(uptr, 20);         /* start us off */
-        sim_activate(uptr, 40);         /* start us off */
+        sim_activate(uptr, 20);         /* start us off */
+//@41   sim_activate(uptr, 40);         /* start us off */
         return 0;                       /* no status change */
         break;
 #endif
@@ -320,6 +322,7 @@ t_stat con_srvo(UNIT *uptr) {
         if (cmd == CON_INCH2) {                 /* Channel end only for INCH */
             int len = chp->ccw_count;           /* INCH command count */
             uint32 mema = chp->ccw_addr;        /* get inch or buffer addr */
+            //FIXME - test error return for error
 //          int i = set_inch(uptr, mema);       /* new address */
             set_inch(uptr, mema);               /* new address */
 
@@ -369,8 +372,9 @@ t_stat con_srvo(UNIT *uptr) {
             sim_putchar(ch);                /* output next char to device */
 //WAS       sim_putchar(cp);                /* output next char to device */
 #endif
-//@         sim_activate(uptr, 20);         /* keep going */
-            sim_activate(uptr, 30);         /* start us off */
+            sim_activate(uptr, 20);         /* keep going */
+//@41       sim_activate(uptr, 30);         /* start us off */
+//@41       sim_activate(uptr, 50);         /* start us off */
         }
     }
     return SCPE_OK;
@@ -419,6 +423,7 @@ t_stat con_srvi(UNIT *uptr) {
         if (cmd == CON_INCH2) {                 /* Channel end only for INCH */
             int len = chp->ccw_count;           /* INCH command count */
             uint32 mema = chp->ccw_addr;        /* get inch or buffer addr */
+            //FIXME add code to test return from set_inch
 //          int i = set_inch(uptr, mema);       /* new address */
             set_inch(uptr, mema);               /* new address */
 

--- a/SEL32/sel32_disk.c
+++ b/SEL32/sel32_disk.c
@@ -307,7 +307,6 @@ MTAB            disk_mod[] = {
 };
 
 UNIT            dda_unit[] = {
-/* SET_TYPE(9) DM300 old */
 /* SET_TYPE(3) DM300 */
     {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0x800)},  /* 0 */
     {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0x802)},  /* 1 */
@@ -358,16 +357,15 @@ DEVICE          dda_dev = {
 CHANP           ddb_chp[NUM_UNITS_DISK] = {0};
 
 UNIT            ddb_unit[] = {
-/* SET_TYPE(9) DM300 old */
 /* SET_TYPE(3) DM300 */
     {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC00)},  /* 0 */
-    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC02)},  /* 1 */
-    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC04)},  /* 2 */
-    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC06)},  /* 3 */
-    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC08)},  /* 4 */
-    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC0a)},  /* 5 */
-    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC0c)},  /* 6 */
-    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC0e)},  /* 7 */
+    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC01)},  /* 1 */
+    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC02)},  /* 2 */
+    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC03)},  /* 3 */
+    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC04)},  /* 4 */
+    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC05)},  /* 5 */
+    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC06)},  /* 6 */
+    {UDATA(&disk_srv, UNIT_DISK|SET_TYPE(3), 0), 0, UNIT_ADDR(0xC07)},  /* 7 */
 };
 
 #ifdef  NOUSED
@@ -467,8 +465,8 @@ uint8  disk_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
             uptr->u4, chsa, chp->ccw_addr, chp->ccw_count);
 
         uptr->CMDu3 |= DSK_INCH2;               /* use 0xf0 for inch, just need int */
-//@     sim_activate(uptr, 20);                 /* start things off */
-        sim_activate(uptr, 40);                 /* start things off */
+        sim_activate(uptr, 20);                 /* start things off */
+//@41   sim_activate(uptr, 40);                 /* start things off */
         return 0;
         break;
 
@@ -482,49 +480,50 @@ uint8  disk_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
         sim_debug(DEBUG_CMD, dptr,
             "disk_startcmd starting disk seek r/w cmd %02x chsa %04x\n",
             cmd, chsa);
-//@     sim_activate(uptr, 20);                 /* start things off */
-        sim_activate(uptr, 40);                 /* start things off */
+        sim_activate(uptr, 20);                 /* start things off */
+//@41   sim_activate(uptr, 40);                 /* start things off */
+//@41   sim_activate(uptr, 250);                /* start things off */
         return 0;
         break;
 
     case DSK_NOP:                               /* NOP 0x03 */
         uptr->CMDu3 |= cmd;                     /* save cmd */
-//@     sim_activate(uptr, 20);                 /* start things off */
-        sim_activate(uptr, 40);                 /* start things off */
+        sim_activate(uptr, 20);                 /* start things off */
+//@41   sim_activate(uptr, 40);                 /* start things off */
         return 0;
         break;
 
     case DSK_SNS:                               /* Sense 0x04 */
         uptr->CMDu3 |= cmd;                     /* save cmd */
-//@     sim_activate(uptr, 20);                 /* start things off */
-        sim_activate(uptr, 40);                 /* start things off */
+        sim_activate(uptr, 20);                 /* start things off */
+//@41   sim_activate(uptr, 40);                 /* start things off */
         break;
 
     case DSK_WSL:                               /* WSL 0x31 */
         uptr->CMDu3 |= cmd;                     /* save cmd */
-//@     sim_activate(uptr, 20);                 /* start things off */
-        sim_activate(uptr, 40);                 /* start things off */
+        sim_activate(uptr, 20);                 /* start things off */
+//@41   sim_activate(uptr, 40);                 /* start things off */
         return 0;
         break;
 
     case DSK_RSL:                               /* RSL 0x32 */
         uptr->CMDu3 |= cmd;                     /* save cmd */
-//@     sim_activate(uptr, 20);                 /* start things off */
-        sim_activate(uptr, 40);                 /* start things off */
+        sim_activate(uptr, 20);                 /* start things off */
+//@41   sim_activate(uptr, 40);                 /* start things off */
         return 0;
         break;
 
     case DSK_WTL:                               /* WTL 0x51 */
         uptr->CMDu3 |= cmd;                     /* save cmd */
-//@     sim_activate(uptr, 20);                 /* start things off */
-        sim_activate(uptr, 40);                 /* start things off */
+        sim_activate(uptr, 20);                 /* start things off */
+//@41   sim_activate(uptr, 40);                 /* start things off */
         return 0;
         break;
 
     case DSK_RTL:                               /* RTL 0x52 */
         uptr->CMDu3 |= cmd;                     /* save cmd */
-//@     sim_activate(uptr, 20);                 /* start things off */
-        sim_activate(uptr, 40);                 /* start things off */
+        sim_activate(uptr, 20);                 /* start things off */
+//@41   sim_activate(uptr, 40);                 /* start things off */
         return 0;
         break;
     }
@@ -534,8 +533,8 @@ uint8  disk_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
         cmd, chsa, uptr->SNS);
     if (uptr->SNS & 0xff)                      /* any other cmd is error */
         return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;
-//@ sim_activate(uptr, 20);                     /* start things off */
-    sim_activate(uptr, 40);                     /* start things off */
+    sim_activate(uptr, 20);                     /* start things off */
+//@41sim_activate(uptr, 40);                     /* start things off */
     return SNS_CHNEND|SNS_DEVEND;
 }
 
@@ -824,9 +823,13 @@ t_stat disk_srv(UNIT *uptr)
             return SCPE_OK;
         }
 #endif
+                /* we are on cylinder, seek is done */
+                sim_debug(DEBUG_CMD, dptr, "disk_srv seek over on cylinder unit=%02x %04x %04x\n",
+                    unit, uptr->STAR >> 16, uptr->CHS >> 16);
                 uptr->CHS = uptr->STAR;         /* we are there */
-//@             sim_activate(uptr, 10);
-                sim_activate(uptr, 20);
+                sim_activate(uptr, 10);
+//@41           sim_activate(uptr, 20);
+//@41           sim_activate(uptr, 80);
                 break;
             }
         }
@@ -928,8 +931,8 @@ t_stat disk_srv(UNIT *uptr)
             sim_debug(DEBUG_EXP, dptr,
                 "disk_srv seeking unit=%02x to cyl %04x trk %02x sec %02x\n",
                 unit, cyl, trk, buf[3]);
-//@         sim_activate(uptr, 20);             /* start us off */
-            sim_activate(uptr, 30);             /* start us off */
+            sim_activate(uptr, 20);             /* start us off */
+//@41       sim_activate(uptr, 30);             /* start us off */
         } else {
             /* we are on cylinder/track/sector, so go on */
             sim_debug(DEBUG_DETAIL, dptr,
@@ -949,17 +952,6 @@ t_stat disk_srv(UNIT *uptr)
         uptr->CMDu3 &= LMASK;                   /* remove old status bits & cmd */
         uptr->CMDu3 |= DSK_SCK;                 /* show as seek command */
         tstart = 0;                             /* byte offset is 0 */
-#ifdef NOT_NEEDED
-        /* Read in 1 dummy character for length to inhibit SLI posting */
-        if (chan_read_byte(chsa, &buf[0])) {
-            /* we have error, bail out */
-            uptr->CMDu3 &= LMASK;               /* remove old status bits & cmd */
-            uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
-            chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
-            return SCPE_OK;
-//XXX       break;
-        }
-#endif
 #ifndef DO_NEW_WAY
         /* just seek to the location where we will r/w data */
         if ((sim_fseek(uptr->fileref, tstart, SEEK_SET)) != 0) {  /* do seek */
@@ -1010,6 +1002,12 @@ t_stat disk_srv(UNIT *uptr)
             cyl = STAR2CYL(uptr->CHS);          /* get current cyl */
             trk = (uptr->CHS >> 8) & 0xff;      /* get trk/head */
             sec = uptr->CHS & 0xff;             /* get sec */
+#ifdef DO_DYNAMIC_DEBUG
+            if (cyl == 0 && trk == 0 && sec == 8 &&
+                chp->ccw_count == 0x2000 && chp->ccw_addr == 0x157c00)
+//              chp->ccw_count == 0x2000 && chp->ccw_addr == 0x1e7a40)
+    cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ);
+#endif
             /* get sector offset */
 //          tstart = STAR2SEC(uptr->STAR, SPT(type), SPC(type));
             tstart = STAR2SEC(uptr->CHS, SPT(type), SPC(type));
@@ -1067,7 +1065,7 @@ t_stat disk_srv(UNIT *uptr)
             tstart++;                           /* bump to next sector */
             /* convert sect back to chs value */
             uptr->CHS = disksec2star(tstart, type);
-            /* see of over end of disk */
+            /* see if over end of disk */
 //          if (tstart >= CAPB(type)) {
             if (tstart >= (uint32)CAP(type)) {
                 /* EOM reached, abort */
@@ -1083,8 +1081,8 @@ t_stat disk_srv(UNIT *uptr)
             sim_debug(DEBUG_DATA, dptr,
                 "DISK sector read complete, %x bytes to go from diskfile /%04x/%02x/%02x\n",
                 chp->ccw_count, STAR2CYL(uptr->CHS), ((uptr->CHS) >> 8)&0xff, (uptr->CHS&0xff));
-//@         sim_activate(uptr, 10);             /* wait to read next sector */
-            sim_activate(uptr, 30);             /* wait to read next sector */
+            sim_activate(uptr, 10);             /* wait to read next sector */
+//@41       sim_activate(uptr, 30);             /* wait to read next sector */
             break;
 //XXXrddone:
 //XXX       uptr->CMDu3 &= ~(0xffff);           /* remove old status bits & cmd */
@@ -1102,13 +1100,13 @@ t_stat disk_srv(UNIT *uptr)
                 unit, uptr->CMDu3, chp->ccw_count, chp->ccw_addr, cyl, trk, sec);
         }
         if (uptr->CMDu3 & DSK_WRITING) {        /* see if we are writing data */
+#ifdef DO_DYNAMIC_DEBUG
             cyl = STAR2CYL(uptr->CHS);          /* get current cyl */
             trk = (uptr->CHS >> 8) & 0xff;      /* get trk/head */
             sec = uptr->CHS & 0xff;             /* get sec */
-#ifdef DO_DYNAMIC_DEBUG
             if (cyl == 10 && trk == 3 && sec == 0 &&
-                chp->ccw_count == 0x2000 && chp->ccw_addr == 0x1e7a40)
-    /* start debugging at test 46 of cn.mmm diag */
+                chp->ccw_count == 0x2000 && chp->ccw_addr == 0x152800)
+//              chp->ccw_count == 0x2000 && chp->ccw_addr == 0x1e7a40)
     cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ);
 #endif
             /* get sector offset */
@@ -1172,8 +1170,8 @@ t_stat disk_srv(UNIT *uptr)
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
                 break;
             }
-//@         sim_activate(uptr, 10);             /* keep writing */
-            sim_activate(uptr, 30);             /* keep writing */
+            sim_activate(uptr, 10);             /* keep writing */
+//@41       sim_activate(uptr, 30);             /* keep writing */
             break;
          }
          break;
@@ -1550,7 +1548,7 @@ int disk_format(UNIT *uptr) {
     for (cyl = 0; cyl < cylv; cyl++) {
         if ((sim_fwrite(buff, 1, csize*ssize, uptr->fileref)) != csize*ssize) {
             sim_debug(DEBUG_CMD, dptr,
-            "Error on write to diskfile cyl %04x\n", cyl);
+                "Error on write to diskfile cyl %04x\n", cyl);
             free(buff);                             /* free cylinder buffer */
             buff = 0;
             return 1;

--- a/SEL32/sel32_iop.c
+++ b/SEL32/sel32_iop.c
@@ -163,8 +163,8 @@ uint8  iop_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
 //      set_inch(uptr, iop_chp[0].ccw_addr);        /* new address */
 
         uptr->u3 |= IOP_INCH2;                      /* save INCH command as 0xf0 */
-//@     sim_activate(uptr, 20);                     /* go on */
-        sim_activate(uptr, 40);                     /* go on */
+        sim_activate(uptr, 20);                     /* go on */
+//@41   sim_activate(uptr, 40);                     /* go on */
         return 0;                                   /* no status change */
         break;
 
@@ -173,8 +173,8 @@ uint8  iop_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
         uptr->u5 = SNS_RDY|SNS_ONLN;                /* status is online & ready */
         uptr->u3 &= LMASK;                          /* leave only chsa */
         uptr->u3 |= (cmd & IOP_MSK);                /* save NOP command */
-//@     sim_activate(uptr, 20);                     /* TRY 07-13-19 */
-        sim_activate(uptr, 40);                     /* TRY 07-13-19 */
+        sim_activate(uptr, 20);                     /* TRY 07-13-19 */
+//@41   sim_activate(uptr, 40);                     /* TRY 07-13-19 */
         return 0;                                   /* no status change */
         break;
 
@@ -184,10 +184,9 @@ uint8  iop_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
             chan, cmd, uptr->u5);
         uptr->u3 &= LMASK;                          /* leave only chsa */
         uptr->u3 |= (cmd & IOP_MSK);                /* save command */
-//@     sim_activate(uptr, 20);                     /* force interrupt */
-/*UTX*/ sim_activate(uptr, 40);                     /* force interrupt */
-//UTX   return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* not a valid cmd */
-/*UTX*/ return 0;                                   /* no status change */
+        sim_activate(uptr, 20);                     /* force interrupt */
+//@41   sim_activate(uptr, 40);                     /* force interrupt */
+        return 0;                                   /* no status change */
         break;
     }
 

--- a/SEL32/sel32_mfp.c
+++ b/SEL32/sel32_mfp.c
@@ -174,8 +174,8 @@ uint8  mfp_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
         uptr->u5 = SNS_RDY|SNS_ONLN;                /* status is online & ready */
         uptr->u3 &= LMASK;                          /* leave only chsa */
         uptr->u3 |= (cmd & MFP_MSK);                /* save NOP command */
-//@     sim_activate(uptr, 20);                     /* TRY 07-13-19 */
-        sim_activate(uptr, 40);                     /* TRY 07-13-19 */
+        sim_activate(uptr, 20);                     /* TRY 07-13-19 */
+//@41   sim_activate(uptr, 40);                     /* TRY 07-13-19 */
         return 0;                                   /* no status change */
         break;
 
@@ -185,10 +185,9 @@ uint8  mfp_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
             chan, cmd, uptr->u5);
         uptr->u3 &= LMASK;                          /* leave only chsa */
         uptr->u3 |= (cmd & MFP_MSK);                /* save command */
-//@     sim_activate(uptr, 20);                     /* force interrupt */
-//@     sim_activate(uptr, 40);                     /* force interrupt */
-        return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* not a valid command */
-//WAS   return 0;                                   /* no status change */
+        sim_activate(uptr, 20);                     /* force interrupt */
+//@41   sim_activate(uptr, 40);                     /* force interrupt */
+        return 0;                                   /* no status change */
         break;
     }
 
@@ -200,7 +199,6 @@ t_stat mfp_srv(UNIT *uptr)
 {
     uint16  chsa = GET_UADDR(uptr->u3);
     int     cmd = uptr->u3 & MFP_MSK;
-//  CHANP   *chp = find_chanp_ptr(chsa);            /* find the chanp pointer */
     CHANP   *chp = &mfp_chp[0];                     /* find the chanp pointer */
 //  int     i;
 //  int     len = chp->ccw_count;                   /* INCH command count */
@@ -230,6 +228,7 @@ t_stat mfp_srv(UNIT *uptr)
 
         /* the chp->ccw_addr location contains the inch address */
         /* call set_inch() to setup inch buffer */
+        //FIXME add code to test return
 //      i = set_inch(uptr, mema);                   /* new address */
         set_inch(uptr, mema);                       /* new address */
 //      chp->chan_inch_addr = mema;                 /* set inch buffer addr */


### PR DESCRIPTION
SEL32: Roll back sim_activate call times to March 7 values.
SEL32: Correct interrupt auto-reset logic.
SEL32: Add initial support for MFP.
SEL32: Correct Coverity detected errors.