### PR TITLE
SEL32: Add updates for MPX 3.X support.

### DIFF
--- a/SEL32/README.md
+++ b/SEL32/README.md
@@ -2,21 +2,22 @@
 # SEL32 Development Simulator
 
 This is a working copy of a simulator for the SEL Concept/32 computer.
-The current test version is for the SEL 32/27, 32/67, 32/77, 32/87 and
-32/97 computers.  Initial support is provided for the V6 and V9 cpus.
-Support for 32/55 computers may be added in the future.
+The current test version is for the SEL 32/27, 32/67, 32/77, 32/87,
+32/97, V6, and V9 computers.  All of the processors except for the
+32/77 can run Gould diags.  Support for 32/55 computers may be added
+in the future.
 
 # SEL Concept/32 
 
-This simulator is running a test version of MPX-32 1.5F.  It is capable of
-creating a disk image of the O/S from a SDT tape.  The disk image can be
-booted, initialized, and run many of the MPX utilities; including OPCOM & TSM.
-Eight terminals can be used to access TSM via Telnet port 4747.  Initial
-support has been added for excess 64 floating point arithmetic.  More testing
-is still required.  The sim32disk.gz can be uncompressed and booted with the
+This simulator is running a test version of MPX-32 1.5F.  It is capable
+of creating a disk image of the O/S from a SDT tape.  The disk image
+can be booted, initialized, and run many of the MPX utilities; including
+OPCOM & TSM.  Eight terminals can be used to access TSM via Telnet port
+4747. The sumulator has support for excess 64 floating point arithmetic.
+The sim32disk.gz can be uncompressed and booted with the
 sel32.27.sim32.disk.ini initialization file.  The sim32sdt.tap.gz file can
-also be uncompressed and started with the sel32.27.sim32.tape.ini initialization
-file to install to disk from tape.
+also be uncompressed and started with the sel32.27.sim32.tape.ini
+initialization file to do a sdt install to disk from tape.
 
 Available tap tools:
 taptools.tgz - set of tools to work with .tap formatted tapes.  Also tools
@@ -26,7 +27,7 @@ taptools.tgz - set of tools to work with .tap formatted tapes.  Also tools
 Available disk images:
 sim32disk.gz - bootable 300mb disk with MPX1.5F installed.  Unzip before
                any attempt to use it.  Use sel32.27.sim32.disk.ini command
-               file to start MPX 1.5.  ./sel32 sel32.27.sim32.disk.ini
+               file to start MPX 1.5. Type "./sel32 sel32.27.sim32.disk.ini"
 
 Available configuration SDT tapes:
 sim32sdt.tap - MPX 1.5f user SDT install tape.  Uses 300mb disk, IOP 8-line
@@ -42,12 +43,13 @@ sim32sdt.tap - MPX 1.5f user SDT install tape.  Uses 300mb disk, IOP 8-line
                FIL> X
 
 Available Level One Diagnostic boot tape:
-diag.ini       command file to start diags. ./sel32 diag.ini
-diag.tap       bootable level one diagnostic tape w/auto testing.  Set cpu type
-               to 32/27, 32/67, 32/87, 32/97, V6 or V9.  All cpu models now
-               run all diagnostics except cv.dxp which is used to run level 2
-               diagnostics. The diag stops at random places after a few
-               characters are entered into the console.
+diag.ini       command file to start diags. Type "./sel32 diag.ini"
+diag.tap       bootable level one diagnostic tape w/auto testing.  Set
+               cpu type to 32/27, 32/67, 32/87, 32/97, V6 or V9.  All
+               cpu models now run all diagnostics provided on the
+               diagnostic tape.  Running DEXP stand alone causes input
+               to stop after a few characters are entered.  More
+               itesting is still required.
 
                CV.CSL - Firmware control diag.  Disabled in auto testing.
                CV.CP1 - CPU diag part 1 runs OK.
@@ -59,10 +61,13 @@ diag.tap       bootable level one diagnostic tape w/auto testing.  Set cpu type
                CV.TRP - Traps diag runs OK.
                CV.CMD - Cache/Shadow diag.  Disabled in auto testing.
                CN.MMM - Non virtual memory diag runs OK.
-               VM.MMM - virtual memory diag for V6 & V9 runs OK.
+               VM.MMM - Virtual memory diag for V6 & V9 runs OK.
                CV.IPT - IPU trap diag.  Disabled in auto testing.
                CV.CSD - WCS read/write trap diag.  Disabled in auto testing.
                CV.CON - Operators Console runs all tests for all CPUs.
+               CV.DXP - Diagnostic executive for level 2 diags. OK in batch.
+               CV.MMM - Level two shared memory diag runs under DXP OK.
+               CV.ITD - Level two interval timer diag runs under DXP OK.
 
                Set GPR[0] = 0xffffffff before booting from tape to disable the
                auto test and go to the Diagnostic Overlay Loader (DOL>) prompt.
@@ -75,12 +80,11 @@ utx21a1.tap    bootable UTX install tape for testing basemode.  The current
                V6 & V9 will boot UTX into single user mode.  You can run a
                small subset of the commands that are on the installation tape.
                Prep, the disk preparation UTX program, can format a disk
-               drive.  Other files systems can be created, but cause the
-               system to hang at various places during the fsck command.
+               drive.  Other file systems can be created and saves restored.
                All basemode instructions have been tested with the CV.BRD diag.
                The virtual memory has been fully tested with the VM.MMM diag.
-               UTX needs better support for the disk controller before we can
-               move any farther with the installation.
+               UTX needs better support for operator console.  There are still
+               some random panics/halts.  More testing is still needed.
 
 Other MPX verion support:
                I am still looking for an MPX 3.X user or master SDT tape.  I have
@@ -89,5 +93,5 @@ Other MPX verion support:
                disk image of a bootable system..
 
 James C. Bevier
-03/30/2020 
+04/21/2020 
 

--- a/SEL32/sel32_com.c
+++ b/SEL32/sel32_com.c
@@ -184,8 +184,8 @@ TMXR com_desc = { COM_LINES_DFLT, 0, 0, com_ldsc };     /* com descr */
 
 /* u6 */
 
-uint8       com_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd);
-uint8       com_haltio(UNIT *uptr);
+uint16      com_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd);
+uint16      com_haltio(UNIT *uptr);
 void        com_ini(UNIT *, t_bool);
 void        coml_ini(UNIT *, t_bool);
 t_stat      com_reset(DEVICE *);
@@ -243,11 +243,11 @@ UNIT            com_unit[] = {
 //DIB com_dib = {NULL, com_startcmd, NULL, NULL, com_ini, com_unit, com_chp, COM_UNITS, 0x0f, 0x7e00, 0, 0, 0};
 
 DIB             com_dib = {
-    NULL,           /* uint8 (*pre_io)(UNIT *uptr, uint16 chan)*/   /* Pre Start I/O */
-    com_startcmd,   /* uint8 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start a command */
-    NULL,           /* uint8 (*halt_io)(UNIT *uptr) */          /* Stop I/O */
-    NULL,           /* uint8 (*test_io)(UNIT *uptr) */          /* Test I/O */
-    NULL,           /* uint8 (*post_io)(UNIT *uptr) */          /* Post I/O */
+    NULL,           /* uint16 (*pre_io)(UNIT *uptr, uint16 chan)*/  /* Pre Start I/O */
+    com_startcmd,   /* uint16 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start command */
+    NULL,           /* uint16 (*halt_io)(UNIT *uptr) */         /* Stop I/O */
+    NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
+    NULL,           /* uint16 (*post_io)(UNIT *uptr) */         /* Post I/O */
     com_ini,        /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     com_unit,       /* UNIT* units */                           /* Pointer to units structure */
     com_chp,        /* CHANP* chan_prg */                       /* Pointer to chan_prg structure */
@@ -275,7 +275,8 @@ DEVICE          com_dev = {
     COM_UNITS, 8, 15, 1, 8, 8,
     &tmxr_ex, &tmxr_dep, &com_reset, NULL, &com_attach, &com_detach,
     /* ctxt is the DIB pointer */
-    &com_dib, DEV_NET | DEV_DISABLE | DEV_DEBUG, 0, dev_debug,
+    &com_dib, DEV_NET|DEV_DISABLE|DEV_DEBUG, 0, dev_debug,
+//  &com_dib, DEV_NET|DEV_DIS|DEV_DISABLE|DEV_DEBUG, 0, dev_debug,
     NULL, NULL, NULL, NULL, NULL, &com_description
 };
 
@@ -314,11 +315,11 @@ UNIT            coml_unit[] = {
 
 //DIB coml_dib = { NULL, com_startcmd, NULL, NULL, NULL, coml_ini, coml_unit, coml_chp, COM_LINES*2, 0x0f, 0x7E00};
 DIB             coml_dib = {
-    NULL,           /* uint8 (*pre_io)(UNIT *uptr, uint16 chan)*/   /* Pre Start I/O */
-    com_startcmd,   /* uint8 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start a command */
-    NULL,           /* uint8 (*halt_io)(UNIT *uptr) */          /* Stop I/O */
-    NULL,           /* uint8 (*test_io)(UNIT *uptr) */          /* Test I/O */
-    NULL,           /* uint8 (*post_io)(UNIT *uptr) */          /* Post I/O */
+    NULL,           /* uint16 (*pre_io)(UNIT *uptr, uint16 chan)*/  /* Pre Start I/O */
+    com_startcmd,   /* uint16 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start command */
+    NULL,           /* uint16 (*halt_io)(UNIT *uptr) */         /* Stop I/O */
+    NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
+    NULL,           /* uint16 (*post_io)(UNIT *uptr) */         /* Post I/O */
     coml_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     coml_unit,      /* UNIT* units */                           /* Pointer to units structure */
     coml_chp,       /* CHANP* chan_prg */                       /* Pointer to chan_prg structure */
@@ -352,7 +353,8 @@ DEVICE          coml_dev = {
     NULL, NULL, &com_reset,
     NULL, NULL, NULL,
     /* ctxt is the DIB pointer */
-    &coml_dib, DEV_DISABLE | DEV_DEBUG, 0, dev_debug,
+    &coml_dib, DEV_DISABLE|DEV_DEBUG, 0, dev_debug,
+//  &coml_dib, DEV_DIS|DEV_DISABLE|DEV_DEBUG, 0, dev_debug,
     NULL, NULL, NULL, NULL, NULL, &com_description
 };
 
@@ -379,7 +381,7 @@ void com_ini(UNIT *uptr, t_bool f)
 }
 
 /* called from sel32_chan to start an I/O operation */
-uint8  com_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
+uint16  com_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
 {
     DEVICE      *dptr = get_dev(uptr);
     int         unit = (uptr - dptr->units);
@@ -643,7 +645,8 @@ uint8  com_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
         uptr->u5 |= SNS_CMDREJ;                     /* command rejected */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd Invald %02x status %02x\n",
             chan, cmd, uptr->u5);
-        return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* unit check */
+//      return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* unit check */
+        return SNS_CHNEND|STATUS_PCHK;
         break;
     }
 

--- a/SEL32/sel32_cpu.c
+++ b/SEL32/sel32_cpu.c
@@ -746,7 +746,7 @@ t_stat load_maps(uint32 thepsd[2], uint32 lmap)
             bpixmsdl = RMW(mpl+bpix);               /* get bpix msdl word address */
 
             /* check for valid bpix msdl addr */
-            if (!MEM_ADDR_OK(bpixmsdl & MASK24)) { /* see if in memory */
+            if (!MEM_ADDR_OK(bpixmsdl & MASK24)) {  /* see if in memory */
                 sim_debug(DEBUG_TRAP, &cpu_dev,
                     "load_maps MEM SIZE8 %06x bpix msdl %08x invalid\n",
                     MEMSIZE, bpixmsdl);
@@ -756,7 +756,7 @@ t_stat load_maps(uint32 thepsd[2], uint32 lmap)
             sdc = (bpixmsdl >> 24) & 0x3f;          /* get 6 bit segment description count */
             msdl = bpixmsdl & MASK24;               /* get 24 bit real address of msdl */
             /* check for valid msdl addr */
-            if (!MEM_ADDR_OK(msdl & MASK24)) { /* see if in memory */
+            if (!MEM_ADDR_OK(msdl & MASK24)) {      /* see if in memory */
                 sim_debug(DEBUG_TRAP, &cpu_dev,
                     "load_maps MEM SIZE9 %06x msdl %08x invalid\n", MEMSIZE, msdl);
                 return NPMEM;                       /* no, none present memory error */
@@ -768,7 +768,7 @@ t_stat load_maps(uint32 thepsd[2], uint32 lmap)
                 midl = RMW(msdl+i) & MASK24;        /* get 24 bit real word address of midl */
 
                 /* check for valid midl addr */
-                if (!MEM_ADDR_OK(midl & MASK24)) { /* see if in memory */
+                if (!MEM_ADDR_OK(midl & MASK24)) {  /* see if in memory */
                     sim_debug(DEBUG_TRAP, &cpu_dev,
                         "load_maps MEM SIZEa %06x midl %08x invalid\n", MEMSIZE, midl);
                     return NPMEM;                   /* no, none present memory error */
@@ -789,7 +789,7 @@ t_stat load_maps(uint32 thepsd[2], uint32 lmap)
 
         /* now load cpix maps */
         /* check for valid cpix msdl addr */
-        if (MEM_ADDR_OK(cpixmsdl & MASK24)) { /* see if in memory */
+        if (MEM_ADDR_OK(cpixmsdl & MASK24)) {       /* see if in memory */
             sim_debug(DEBUG_TRAP, &cpu_dev,
                 "load_maps MEM SIZEb %06x cpix msdl %08x invalid\n", MEMSIZE, cpixmsdl);
             return NPMEM;                           /* no, none present memory error */
@@ -798,7 +798,7 @@ t_stat load_maps(uint32 thepsd[2], uint32 lmap)
         sdc = (cpixmsdl >> 24) & 0x3f;              /* get 6 bit segment description count */
         msdl = cpixmsdl & 0xffffff;                 /* get 24 bit real address of msdl */
         /* check for valid msdl addr */
-        if (!MEM_ADDR_OK(msdl & MASK24)) {     /* see if in memory */
+        if (!MEM_ADDR_OK(msdl & MASK24)) {          /* see if in memory */
             sim_debug(DEBUG_TRAP, &cpu_dev,
                 "load_maps MEM SIZEc %06x msdl %08x invalid\n", MEMSIZE, msdl);
             return NPMEM;                           /* no, none present memory error */
@@ -810,7 +810,7 @@ t_stat load_maps(uint32 thepsd[2], uint32 lmap)
             midl = RMW(msdl+i) & MASK24;            /* get 24 bit real word address of midl */
 
             /* check for valid midl addr */
-            if (!MEM_ADDR_OK(midl & MASK24)) { /* see if in memory */
+            if (!MEM_ADDR_OK(midl & MASK24)) {      /* see if in memory */
                 sim_debug(DEBUG_TRAP, &cpu_dev,
                     "load_maps MEM SIZEd %06x midl %08x invalid\n", MEMSIZE, midl);
                 return NPMEM;                       /* no, none present memory error */
@@ -896,11 +896,13 @@ npmem:
     }
 
     /* output O/S and User MPX entries */
-    sim_debug(DEBUG_DETAIL, &cpu_dev,
+//041420    sim_debug(DEBUG_DETAIL, &cpu_dev,
+    sim_debug(DEBUG_EXP, &cpu_dev,
         "#MEMORY %06x MPL %06x MPL[0] %08x %06x MPL[%04x] %08x %06x\n",
         MEMSIZE, mpl, RMW(mpl), RMW(mpl+4), cpix,
         RMW(cpix+mpl), RMW(cpix+mpl+4));
-    sim_debug(DEBUG_DETAIL, &cpu_dev,
+//041420    sim_debug(DEBUG_DETAIL, &cpu_dev,
+    sim_debug(DEBUG_EXP, &cpu_dev,
         "MEMORY2 %06x BPIX %04x cpix %04x CPIX %04x CPIXPL %04x HIWM %04x\n",
         MEMSIZE, BPIX, cpix, CPIX, CPIXPL, HIWM);
 
@@ -950,7 +952,7 @@ nomaps:
 
         /* we have a valid count, load the O/S map list address */
         osmsdl &= MASK24;                           /* get 24 bit real address from mpl 0 wd2 */
-        if (!MEM_ADDR_OK(osmsdl)) {              /* see if address is within our memory */
+        if (!MEM_ADDR_OK(osmsdl)) {                 /* see if address is within our memory */
             sim_debug(DEBUG_TRAP, &cpu_dev,
                 "load_maps MEM SIZE2 %06x os page list address %06x invalid\n",
                 MEMSIZE, osmsdl);
@@ -967,7 +969,7 @@ nomaps:
                     "load_maps O/S page count overflow %04x, map fault\n", num);
                 goto nomaps;                        /* map overflow, map fault trap */
             }
-            if (!MEM_ADDR_OK(pad)) {             /* see if address is within our memory */
+            if (!MEM_ADDR_OK(pad)) {                /* see if address is within our memory */
                 sim_debug(DEBUG_TRAP, &cpu_dev,
                     "load_maps MEM SIZE3 %06x os page address %06x invalid\n",
                     MEMSIZE, pad);
@@ -986,9 +988,9 @@ nomaps:
             } else {
                 TLB[num] = 0;                       /* clear the TLB for non valid maps */
             }
-#ifdef FOR_DEBUG
+#ifndef FOR_DEBUG
             if ((num < 0x20) || (num > (spc - 0x10)))
-                sim_debug(DEBUG_TRAP, &cpu_dev,
+                sim_debug(DEBUG_DETAIL, &cpu_dev,
                     "OS pad %06x=%04x map #%4x, %04x, map2 %08x, TLB %08x MAPC %08x\n",
                     pad, map, num, map, (((map << 16) & 0xf8000000) | ((map & 0x7ff) << 13)),
                     TLB[num], MAPC[num/2]);
@@ -1068,7 +1070,7 @@ loaduser:
 
     /* This test fails cn.mmm diag at test 46, subtest 2 with unexpected error */
     /* Do this test if we are a LMAP instruction and not a 32/27 or 32/87 */
-    if (lmap && !MEM_ADDR_OK(msdl)) {          /* see if address is within our memory */
+    if (lmap && !MEM_ADDR_OK(msdl)) {               /* see if address is within our memory */
         sim_debug(DEBUG_TRAP, &cpu_dev,
             "load_maps MEM SIZE4 %06x user page list address %06x invalid\n",
             MEMSIZE, msdl);
@@ -1122,7 +1124,7 @@ loaduser:
 /*97&V6*/       TRAPSTATUS |= (BIT5|BIT9);          /* set bit 5 of trap status */
                 goto nomaps;                        /* map overflow, map fault trap */
             }
-            if (!MEM_ADDR_OK(pad)) {             /* see if address is within our memory */
+            if (!MEM_ADDR_OK(pad)) {                /* see if address is within our memory */
                 sim_debug(DEBUG_TRAP, &cpu_dev,
                     "load_maps MEM SIZE5 %06x User page address %06x invalid\n",
                     MEMSIZE, pad);
@@ -1142,12 +1144,14 @@ loaduser:
                 TLB[num] = 0;                       /* clear the TLB for non valid maps */
             WMR((num<<1), map);                     /* store map unmodified into cache */
 
+#ifndef FOR_DEBUG
             /* do partial map dump */
             if ((num < 0x20) || (num > (spc+BPIX) - 0x10))
                 sim_debug(DEBUG_DETAIL, &cpu_dev,
                     "UserN pad %06x=%04x map #%4x, %04x, map2 %08x, TLB %08x, MAPC %08x\n",
                     pad, map, num, map, (((map << 16) & 0xf8000000) | ((map & 0x7ff) << 13)),
                     TLB[num], MAPC[num/2]);
+#endif
         }
         if (num == 0) {                             /* see if any maps loaded */
             sim_debug(DEBUG_TRAP, &cpu_dev,
@@ -1195,7 +1199,7 @@ loaduser:
             goto nomaps;                            /* map overflow, map fault trap */
         }
 
-        if (!MEM_ADDR_OK(pad)) {                 /* see if address is within our memory */
+        if (!MEM_ADDR_OK(pad)) {                    /* see if address is within our memory */
             sim_debug(DEBUG_TRAP, &cpu_dev,
                 "load_maps MEM SIZE6 %06x User page address %06x non present\n",
                 MEMSIZE, pad);
@@ -1300,7 +1304,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
 
     if ((modes & MAPMODE) == 0) {
         /* we are in unmapped mode, check if valid real address */
-        if (!MEM_ADDR_OK(word)) {                /* see if address is within our memory */
+        if (!MEM_ADDR_OK(word)) {                  /* see if address is within our memory */
             if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9)) {
                 if (access == MEM_RD)
                     TRAPSTATUS |= BIT1;             /* set bit 1 of trap status */
@@ -1322,7 +1326,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
     /* unexpected machine check trap for 67 in test 37/0 cn.mmm */
     /* now check the O/S midl pointer for being valid */
     /* we may want to delay checking until we actually use it */
-    if (!MEM_ADDR_OK((RMW(mpl+4) & MASK24))) {   /* check OS midl */
+    if (!MEM_ADDR_OK((RMW(mpl+4) & MASK24))) {      /* check OS midl */
         sim_debug(DEBUG_TRAP, &cpu_dev,
             "RealAddr Non Present Memory O/S msdl MPL %06x MPL[1] %06x\n",
             mpl, RMW(mpl+4));
@@ -1352,8 +1356,13 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
     offset = word & 0x1fff;                         /* get 13 bit page offset */
 
     /* make sure map index is valid */
-    if (index >= (BPIX + CPIXPL)) {
-        sim_debug(DEBUG_TRAP, &cpu_dev,
+    // This change will allow MPX3x to run, but fails diags
+    // TRY 041420
+// WAS if (index >= (BPIX + CPIXPL)) {
+// MPX3x like this:    if (index > (BPIX + CPIXPL)) {
+//DIAG if (index >= (BPIX + CPIXPL)) {
+      if (index >= (BPIX + CPIXPL)) {
+            sim_debug(DEBUG_TRAP, &cpu_dev,
             "RealAddr %06x word %06x loadmap gets mapfault index %04x B(%x)+C(%x) %04x\n",
             word, addr, index, BPIX, CPIXPL, BPIX+CPIXPL);
         if ((CPU_MODEL == MODEL_97) || (CPU_MODEL == MODEL_V9))
@@ -1391,7 +1400,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
         // diag test 34/1 fails in cn.mmm
         // needed for 32/27 & 32/87
         /* check if valid real address */
-        if (!MEM_ADDR_OK(raddr & MASK24)) {    /* see if address is within our memory */
+        if (!MEM_ADDR_OK(raddr & MASK24)) {         /* see if address is within our memory */
             sim_debug(DEBUG_TRAP, &cpu_dev,
                 "RealAddr loadmap 0c non present memory fault addr %06x raddr %08x index %04x\n",
                 word, raddr, index);
@@ -1424,7 +1433,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
         index &= 0x7ff;                             /* map # */
         raddr = TLB[index];                         /* get the base address & bits */
         /* check if valid real address */
-        if (!MEM_ADDR_OK(raddr & MASK24)) {    /* see if address is within our memory */
+        if (!MEM_ADDR_OK(raddr & MASK24)) {         /* see if address is within our memory */
             sim_debug(DEBUG_TRAP, &cpu_dev,
                 "RealAddr loadmap 2a non present memory fault addr %08x raddr %08x index %04x\n",
                 addr, raddr, index);
@@ -1494,7 +1503,7 @@ t_stat RealAddr(uint32 addr, uint32 *realaddr, uint32 *prot, uint32 access)
 
     /* check user msdl address now that we are going to access it */
     msdl = RMW(mpl+CPIX+4);                     /* get msdl entry for given CPIX */
-    if (!MEM_ADDR_OK(msdl & MASK24)) {     /* check user midl */
+    if (!MEM_ADDR_OK(msdl & MASK24)) {          /* check user midl */
         sim_debug(DEBUG_TRAP, &cpu_dev,
             "RealAddr User CPIX Non Present Memory User msdl %06x CPIX %04x\n",
             msdl, CPIX);
@@ -2033,8 +2042,9 @@ wait_loop:
         else
             waitqcnt = 20;                      /* wait 10 instructions */
 //040120    waitqcnt = 10;                      /* wait 10 instructions */
+//
         /* process pending I/O interrupts */
-/*AIR*/ if (!loading && (irq_auto==0) && (wait4int || irq_pend)) {   /* see if ints are pending */
+/*AIR*/ if (!loading && (irq_auto==0) && (wait4int || irq_pend)) {  /* see if ints are pending */
             uint32 ilev;
             SPAD[0xf9] = CPUSTATUS;             /* save the cpu status in SPAD */
             int_icb = scan_chan(&ilev);         /* no, go scan for I/O int pending */
@@ -3417,6 +3427,9 @@ tbr:                                                /* handle basemode TBR too *
                     /* update the PSD with new address from reg */
                     PSD1 &= ~temp;                  /* clean the bits to be changed */
                     PSD1 |= (addr & temp);          /* insert the CC's and address */
+                    sim_debug(DEBUG_EXP, &cpu_dev,
+                        "TRSW REG %01x PSD %08x %08x modes %08x temp %06x\n",
+                        reg, PSD1, PSD2, modes, temp);
                     i_flags |= BT;                  /* we branched, so no PC update */
                     break;
 
@@ -3439,6 +3452,9 @@ tbr:                                                /* handle basemode TBR too *
                     if ((modes & BASEBIT) == 0)     /* see if nonbased */
                         goto inv;                   /* invalid instruction in nonbased mode */
                     PSD1 = ((PSD1 & 0x87fffffe) | ((GPR[reg] & 0xf) << 27));    /* insert CCs from reg */
+                    sim_debug(DEBUG_EXP, &cpu_dev,
+                        "TRCC REG %01x PSD %08x %08x modes %08x temp %06x\n",
+                        reg, PSD1, PSD2, modes, GPR[reg]);
                     break;
 
                 case 0x8:           /* BSUB */      /* Procedure call */
@@ -5110,10 +5126,17 @@ meoa:           /* merge point for eor, and, or */
                 OPSD1 &= 0x87FFFFFE;                /* clear the old CC's */
                 OPSD1 |= PSD1 & 0x78000000;         /* update the CC's in the PSD */
                 /* output mapped/unmapped */
+                if (modes & BASEBIT) {
                 if (modes & MAPMODE)
-                    sim_debug(DEBUG_INST, &cpu_dev, "M%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                    sim_debug(DEBUG_INST, &cpu_dev, "BM%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
                 else
-                    sim_debug(DEBUG_INST, &cpu_dev, "U%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                    sim_debug(DEBUG_INST, &cpu_dev, "BU%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                } else {
+                if (modes & MAPMODE)
+                    sim_debug(DEBUG_INST, &cpu_dev, "NM%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                else
+                    sim_debug(DEBUG_INST, &cpu_dev, "NU%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                }
                 if (cpu_dev.dctrl & DEBUG_INST)
                     fprint_inst(sim_deb, OIR, 0);   /* display instruction */
                 sim_debug(DEBUG_INST, &cpu_dev,
@@ -5505,10 +5528,17 @@ doovr2:
                     OPSD1 &= 0x87FFFFFE;            /* clear the old CC's */
                     OPSD1 |= PSD1 & 0x78000000;     /* update the CC's in the PSD */
                     /* output mapped/unmapped */
+                    if (modes & BASEBIT) {
                     if (modes & MAPMODE)
-                        sim_debug(DEBUG_INST, &cpu_dev, "M%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                        sim_debug(DEBUG_INST, &cpu_dev, "BM%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
                     else
-                        sim_debug(DEBUG_INST, &cpu_dev, "U%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                        sim_debug(DEBUG_INST, &cpu_dev, "BU%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                    } else {
+                    if (modes & MAPMODE)
+                        sim_debug(DEBUG_INST, &cpu_dev, "NM%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                    else
+                        sim_debug(DEBUG_INST, &cpu_dev, "NU%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+                    }
                     if (cpu_dev.dctrl & DEBUG_INST)
                         fprint_inst(sim_deb, OIR, 0);    /* display instruction */
                     sim_debug(DEBUG_INST, &cpu_dev,
@@ -6097,20 +6127,53 @@ doovr2:
                         if (PSD2 & MAPBIT) {
                             /* set mapped mode in cpu status */
                             CPUSTATUS |= 0x00800000;    /* set bit 8 of cpu status */
-                            sim_debug(DEBUG_DETAIL, &cpu_dev,
+//041420                    sim_debug(DEBUG_DETAIL, &cpu_dev,
+                            sim_debug(DEBUG_EXP, &cpu_dev,
                                 "B4 LPSDCM temp %06x TPSD %08x %08x PSD %08x %08x\n",
                                 temp, TPSD[0], TPSD[1], PSD1, PSD2);
-                            sim_debug(DEBUG_DETAIL, &cpu_dev,
+//041420                    sim_debug(DEBUG_DETAIL, &cpu_dev,
+                            sim_debug(DEBUG_EXP, &cpu_dev,
                                 "B4 LPSDCM BPIX %04x CPIX %04x CPIXPL %04x\n",
                                 BPIX, CPIX, CPIXPL);
-                            sim_debug(DEBUG_DETAIL, &cpu_dev,
-                                "B4 LPSDCM OS MAPC[0-5] %08x %08x %08x %08x %08x %08x\n",
-                                MAPC[0], MAPC[1], MAPC[2], MAPC[3], MAPC[4], MAPC[5]);
-                            sim_debug(DEBUG_DETAIL, &cpu_dev,
-                                "B4 LPSDCM US MAPC[%x-%x] %08x %08x %08x %08x %08x %08x\n",
-                                BPIX, BPIX+5, MAPC[BPIX], MAPC[BPIX+1], MAPC[BPIX+2],
-                                MAPC[BPIX+3], MAPC[BPIX+4], MAPC[BPIX+5]);
+#ifdef FOR_DEBUG_MPX_041420
+                            {
+                            int i;
+                            uint32 mpl = SPAD[0xf3];    /* get mpl from spad address */
+                            uint32 osmidl = RMW(mpl);   /* get O/S map count & retain flag from MPL[0] */
+                            uint32 osmsdl = RMW(mpl+4); /* get msdl pointer for OS from MPL[1] */
+                            int spc = osmidl & MASK16;  /* get 16 bit O/S segment description count */
+                            uint32 cpix = PSD2 & 0x3ff8;    /* get cpix 11 bit offset from psd wd 2 */
+                            uint32 midl = RMW(mpl+cpix);    /* get midl entry for given user cpix */
+                            uint32 msdl = RMW(mpl+cpix+4);  /* get mpl entry wd 1 for given cpix */
+                            int osc = osmidl & MASK16;  /* get 16 bit O/S segment description count */
 
+                            sim_debug(DEBUG_EXP, &cpu_dev,
+                                "B4 LPSDCM O/S cnt %04x User cnt %04x Last cnt %04x\n",
+                                osmidl&MASK16, midl&MASK16, CPIXPL);
+                            for (i=0; i<spc; i++) {
+                                uint32 pad = osmsdl+(i<<1); /* get page descriptor address */
+                                uint16 map = RMH(pad);  /* get page descriptor from memory */
+
+                                if ((i < 0x20) || (i > (osc - 0x10)))
+                                    sim_debug(DEBUG_TRAP, &cpu_dev,
+                    "OS pad %06x=%04x map #%3x, %04x, map2 %08x, TLB %08x MAPC %08x\n",
+                    pad, map, i, map, (((map << 16) & 0xf8000000) | ((map & 0x7ff) << 13)),
+                    TLB[i], MAPC[i/2]);
+                            }
+
+                            spc = midl & MASK16;        /* get 16 bit user segment description count */
+                            for (i=0; i<spc; i++) {
+                                uint32 pad = msdl+(i<<1); /* get page descriptor address */
+                                uint16 map = RMH(pad);  /* get page descriptor from memory */
+
+                                if ((i < 0x20) || (i > (spc+osc) - 0x10))
+                                    sim_debug(DEBUG_EXP, &cpu_dev,
+                    "UserV pad %06x=%04x map #%3x, %04x, map2 %08x, TLB %08x, MAPC %08x\n",
+                    pad, map, osc+i, map, (((map << 16) & 0xf8000000)|(map & 0x7ff)<<13)|0x04000000,
+                    TLB[BPIX+i], MAPC[(BPIX+i)/2]);
+                            }
+                            }
+#endif
                             /* this mod fixes MPX 1.X 1st swapr load */
                             /* any O/S or user maps yet? */
                             /* any user maps yet? */
@@ -6118,19 +6181,38 @@ doovr2:
                                 PSD2 &= ~RETMBIT;       /* no, turn off retain bit in PSD2 */
                                 sim_debug(DEBUG_EXP, &cpu_dev, "Turn off retain bit\n");
                             }
+
+                            /* test if user count is equal to CPIXPL, if not load maps */
+                            /* this fixes software error in MPX3X where count is changed */
+                            /* but the retain bit was left set, so new maps were not loaded */
+                            /* until the next context switch and causes loading eror */
+                            /* CHANGED 041420 maybe not right */
+                            if ((PSD2 & RETMBIT)) {     /* don't load maps if retain bit set */
+                                uint32 mpl = SPAD[0xf3];    /* get mpl from spad address */
+                                uint32 cpix = PSD2 & 0x3ff8;    /* get cpix 11 bit offset from psd wd 2 */
+                                uint32 midl = RMW(mpl+cpix);    /* get midl entry for given user cpix */
+                                int spc = midl & MASK16;    /* get 16 bit user segment description count */
+                                if (spc != CPIXPL)
+                                    PSD2 &= ~RETMBIT;   /* no, turn off retain bit in PSD2 */
+                            }
+
                             if ((PSD2 & RETMBIT) == 0) {    /* don't load maps if retain bit set */
                                 /* we need to load the new maps */
                                 TRAPME = load_maps(PSD, 0); /* load maps for new PSD */
-                                sim_debug(DEBUG_DETAIL, &cpu_dev,
+//041420                    sim_debug(DEBUG_DETAIL, &cpu_dev,
+                                sim_debug(DEBUG_EXP, &cpu_dev,
                                     "AF LPSDCM TPSD %08x %08x PSD %08x %08x TRAPME %02x\n",
                                     TPSD[0], TPSD[1], PSD1, PSD2, TRAPME);
-                                sim_debug(DEBUG_DETAIL, &cpu_dev,
+//041420                    sim_debug(DEBUG_DETAIL, &cpu_dev,
+                                sim_debug(DEBUG_EXP, &cpu_dev,
                                     "AF LPSDCM BPIX %04x CPIX %04x CPIXPL %04x\n",
                                     BPIX, CPIX, CPIXPL);
-                                sim_debug(DEBUG_DETAIL, &cpu_dev,
+//041420                    sim_debug(DEBUG_DETAIL, &cpu_dev,
+                                sim_debug(DEBUG_EXP, &cpu_dev,
                                     "AF LPSDCM OS MAPC[0-5] %08x %08x %08x %08x %08x %08x\n",
                                     MAPC[0], MAPC[1], MAPC[2], MAPC[3], MAPC[4], MAPC[5]);
-                                sim_debug(DEBUG_DETAIL, &cpu_dev,
+//041420                    sim_debug(DEBUG_DETAIL, &cpu_dev,
+                                sim_debug(DEBUG_EXP, &cpu_dev,
                                     "AF LPSDCM US MAPC[%x-%x] %08x %08x %08x %08x %08x %08x\n",
                                     BPIX, BPIX+5, MAPC[BPIX], MAPC[BPIX+1], MAPC[BPIX+2],
                                     MAPC[BPIX+3], MAPC[BPIX+4], MAPC[BPIX+5]);
@@ -6139,10 +6221,11 @@ doovr2:
                             SPAD[0xf5] = PSD2;          /* save the current PSD2 */
                             SPAD[0xf9] = CPUSTATUS;     /* save the cpu status in SPAD */
                             sim_debug(DEBUG_IRQ, &cpu_dev,
-                                "LPSDCM MAPS LOADED TRAPME = %02x PSD1 %08x PSD2 %08x CPUSTATUS %08x\n",
-                                TRAPME, PSD1, PSD2, CPUSTATUS);
+                                "LPSDCM MAPS LOADED TRAPME = %02x PSD1 %08x PSD2 %08x BPIX %02x CPIXPL %02x\n",
+                                TRAPME, PSD1, PSD2, BPIX, CPIXPL);
                         }
                         PSD2 &= ~RETMBIT;               /* turn off retain bit in PSD2 */
+///* 041820*/           skipinstr = 1;                  /* skip interrupt test */
                     } else {
                         /* LPSD */
                         /* if cpix is zero, copy cpix from PSD2 in SPAD[0xf5] */
@@ -6371,26 +6454,47 @@ doovr2:
                             TRAPSTATUS &= ~BIT1;        /* I/O processing error */
                             goto newpsd;                /* machine check trap */
                         }
+                        /* t has spad entry for device */
+                        /* get the 1's comp of interrupt address from bits 9-15 SPAD entry */
+                        ix = ((~t)>>16)&0x7f;           /* get positive number for interrupt */
                         if (opr & 0x1) {                /* see if CD or TD */
                             /* TODO process a TD */
-//                          if ((TRAPME = testEIO(device, testcode, &status)))
-//                              goto newpsd;            /* error returned, trap cpu */
-                            /* return status has new CC's in bits 1-4 of status word */
-                            PSD1 = ((PSD1 & 0x87fffffe) | (status & 0x78000000));  /* insert status CCs */
-                            goto inv;                   /* invalid instruction until I fix it */
+                            if (device == 0x7f) {
+                                /* if this is for the interval timer check cmd type */
+                                /* if TD 8000 or 4000, set all cc's zero */
+                                temp = (IR & 0xf000);   /* get cmd from instruction */
+                                if ((temp == 0x4000) || (temp == 0x8000))
+                                    status = 0;         /* no CC's */
+                                else
+                                /* if TD 2000 set CC2 for caller */
+                                if (temp == 0x2000)
+                                    status = CC2BIT;    /* set CC2 */
+                                /* return status has new CC's in bits 1-4 of status word */
+                                /* insert status CCs */
+                                PSD1 = ((PSD1 & 0x87fffffe) | (status & 0x78000000));
+#ifdef DO_DYNAMIC_DEBUG
+                /* start debugging */
+                cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ | DEBUG_TRAP);
+#endif
+                            } else {
+                                /* may want to handle class E someday */
+//                              if ((TRAPME = testEIO(device, testcode, &status)))
+//                                  goto newpsd;        /* error returned, trap cpu */
+                                /* return status has new CC's in bits 1-4 of status word */
+//                              /* insert status CCs */
+//                              PSD1 = ((PSD1 & 0x87fffffe) | (status & 0x78000000));
+                                goto inv;               /* invalid instruction until I fix it */
+                            }
                         } else {
                             /* TODO process a CD */
 //                          if ((TRAPME = startEIO(device, &status)))
 //                              goto newpsd;            /* error returned, trap cpu */
-//                          t = SPAD[device];           /* get spad entry for channel */
-                            /* t has spad entry for device */
-                            /* get the 1's comp of interrupt address from bits 9-15 SPAD entry */
-                            ix = ((~t)>>16)&0x7f;       /* get positive number for interrupt */
-                            temp = (IR & 0x7f);         /* get cmd from instruction */
                             if (device == 0x7f) {
+                                temp = (IR & 0x7f);     /* get cmd from instruction */
                                 status = itm_rdwr(temp, GPR[0], ix);    /* read/write the interval timer */
                                 /* see if the cmd does not return value */
-                                if ((temp != 0x39) && (temp != 0x3d) && (temp != 0x20)) 
+                                /* if bit 25 set, read reg val into R0 */
+                                if (temp & 0x40) 
                                     GPR[0] = status;    /* return count in reg 0 */
                                 /* No CC's going out */
                             } else {
@@ -6829,10 +6933,17 @@ mcheck:
 
         /* DEBUG_INST support code */
         /* output mapped/unmapped */
+        if (modes & BASEBIT) {
         if (modes & MAPMODE)
-            sim_debug(DEBUG_INST, &cpu_dev, "M%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+            sim_debug(DEBUG_INST, &cpu_dev, "BM%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
         else
-            sim_debug(DEBUG_INST, &cpu_dev, "U%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+            sim_debug(DEBUG_INST, &cpu_dev, "BU%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+        } else {
+        if (modes & MAPMODE)
+            sim_debug(DEBUG_INST, &cpu_dev, "NM%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+        else
+            sim_debug(DEBUG_INST, &cpu_dev, "NU%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+        }
         if (cpu_dev.dctrl & DEBUG_INST)
             fprint_inst(sim_deb, OIR, 0);           /* display instruction */
         sim_debug(DEBUG_INST, &cpu_dev,
@@ -6962,7 +7073,14 @@ newpsd:
                     tvl = M[tta>>2] & 0x7FFFC;      /* get 19 bit trap address from trap vector loc */
                 sim_debug(DEBUG_TRAP, &cpu_dev,
                     "tvl %08x, tta %08x status %08x page# %04x\n", tvl, tta, CPUSTATUS, pfault);
+#ifndef TEMP_CHANGE_FOR_MPX3X_DEBUG
                 if (tvl == 0 || (CPUSTATUS & 0x40) == 0) {
+#else
+                /* next line changed to force halt on halt trap */
+                /* TRIED 041320 for MPX3.X install and testing */
+                if (((tvl == 0) || (CPUSTATUS & 0x40) == 0) || 
+                    (TRAPME == PRIVHALT_TRAP)) {      /* 0xB8 PL0E Privlege Mode Halt Trap */
+#endif
                     /* vector is zero or software has not enabled traps yet */
                     /* execute a trap halt */
                     /* set the PSD to trap vector location */
@@ -7065,10 +7183,17 @@ newpsd:
 
         /* DEBUG_INST support code */
         /* output mapped/unmapped */
+        if (modes & BASEBIT) {
         if (modes & MAPMODE)
-            sim_debug(DEBUG_INST, &cpu_dev, "M%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+            sim_debug(DEBUG_INST, &cpu_dev, "BM%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
         else
-            sim_debug(DEBUG_INST, &cpu_dev, "U%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+            sim_debug(DEBUG_INST, &cpu_dev, "BU%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+        } else {
+        if (modes & MAPMODE)
+            sim_debug(DEBUG_INST, &cpu_dev, "NM%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+        else
+            sim_debug(DEBUG_INST, &cpu_dev, "NU%.8x %.8x %.8x ", OPSD1, PSD2, OIR);
+        }
         if (cpu_dev.dctrl & DEBUG_INST)
             fprint_inst(sim_deb, OIR, 0);    /* display instruction */
         sim_debug(DEBUG_INST, &cpu_dev,
@@ -7203,7 +7328,7 @@ t_stat cpu_ex(t_value *vptr, t_addr baddr, UNIT *uptr, int32 sw)
         return SCPE_NXM;                /* no, none existant memory error */
     }
     /* MSIZE is in 32 bit words */
-    if (!MEM_ADDR_OK(addr))              /* see if address is within our memory */
+    if (!MEM_ADDR_OK(addr))             /* see if address is within our memory */
         return SCPE_NXM;                /* no, none existant memory error */
     if (vptr == NULL)                   /* any address specified by user */
         return SCPE_OK;                 /* no, just ignore the request */
@@ -7220,7 +7345,7 @@ t_stat cpu_dep(t_value val, t_addr baddr, UNIT *uptr, int32 sw)
     static const uint32 bmasks[4] = {0x00FFFFFF, 0xFF00FFFF, 0xFFFF00FF, 0xFFFFFF00};
 
     /* MSIZE is in 32 bit words */
-    if (!MEM_ADDR_OK(addr))              /* see if address is within our memory */
+    if (!MEM_ADDR_OK(addr))             /* see if address is within our memory */
         return SCPE_NXM;                /* no, none existant memory error */
     val = (M[addr] & bmasks[baddr & 0x3]) | (val << (8 * (3 - (baddr & 0x3))));
     M[addr] = val;                      /* set new value */
@@ -7328,14 +7453,21 @@ t_stat cpu_show_hist(FILE *st, UNIT *uptr, int32 val, CONST void *desc)
     for (k = 0; k < lnt; k++) {         /* print specified entries */
         h = &hst[(++di) % hst_lnt];     /* entry pointer */
         /* display the instruction and results */
-        if (h->modes & MAPMODE)
-            fprintf(st, "M%.8x %.8x %.8x ", h->opsd1, h->npsd2, h->oir);
+        if (modes & BASEBIT) {
+        if (modes & MAPMODE)
+            fprintf(st, "BM%.8x %.8x %.8x ", h->opsd1, h->npsd2, h->oir);
         else
-            fprintf(st, "U%.8x %.8x %.8x ", h->opsd1, h->npsd2, h->oir);
+            fprintf(st, "BU%.8x %.8x %.8x ", h->opsd1, h->npsd2, h->oir);
+        } else {
+        if (modes & MAPMODE)
+            fprintf(st, "NM%.8x %.8x %.8x ", h->opsd1, h->npsd2, h->oir);
+        else
+            fprintf(st, "NU%.8x %.8x %.8x ", h->opsd1, h->npsd2, h->oir);
+        }
         if (h->modes & BASEBIT)
             fprint_inst(st, h->oir, SWMASK('M')); /* display basemode instruction */
         else
-            fprint_inst(st, h->oir, 0); /* display non basemode instruction */
+            fprint_inst(st, h->oir, SWMASK('N')); /* display non basemode instruction */
         fprintf(st, "\n");
         fprintf(st, "\tR0=%.8x R1=%.8x R2=%.8x R3=%.8x", h->reg[0], h->reg[1], h->reg[2], h->reg[3]);
         fprintf(st, " R4=%.8x R5=%.8x R6=%.8x R7=%.8x", h->reg[4], h->reg[5], h->reg[6], h->reg[7]);

--- a/SEL32/sel32_defs.h
+++ b/SEL32/sel32_defs.h
@@ -122,8 +122,8 @@
 //#define NUM_UNITS_DISK  4       /* 4 disk drive devices */
 #define NUM_DEVS_SCFI   1       /* 1 scfi (SCSI) disk drive units */
 #define NUM_UNITS_SCFI  1       /* 1 of 4 disk drive devices */
-#define NUM_DEVS_SCSI   1       /* 1 scsi (MFP SCSI) disk drive units */
-#define NUM_UNITS_SCSI  1       /* 1 of 4 disk drive devices */
+#define NUM_DEVS_SCSI   2       /* 2 scsi (MFP SCSI) scsi buss units */
+#define NUM_UNITS_SCSI  2       /* 2 of 4 scsi disk drive devices */
 #define NUM_DEVS_RTOM   1       /* 1 IOP RTOM channel */
 #define NUM_UNITS_RTOM  1       /* 1 IOP RTOM device (clock & interval timer) */
 #define NUM_DEVS_LPR    1       /* 1 IOP Line printer */
@@ -168,6 +168,12 @@ extern DEVICE sda_dev;
 #if NUM_DEVS_SCFI > 1
 extern DEVICE sdb_dev;
 #endif
+#ifdef NUM_DEVS_SCSI
+extern DEVICE sba_dev;
+#endif
+#if NUM_DEVS_SCSI > 1
+extern DEVICE sbb_dev;
+#endif
 #ifdef NUM_DEVS_COM
 extern DEVICE coml_dev;
 extern DEVICE com_dev;
@@ -202,15 +208,15 @@ typedef struct chp {
 #define FIFO_SIZE 256       /* fifo to hold 128 double words of status */
 typedef struct dib {
         /* Pre start I/O operation */
-        uint8       (*pre_io)(UNIT *uptr, uint16 chan);
+        uint16      (*pre_io)(UNIT *uptr, uint16 chan);
         /* Start a channel command SIO */
-        uint8       (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd);
+        uint16      (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd);
         /* Halt I/O HIO */
-        uint8       (*halt_io)(UNIT *uptr);
+        uint16      (*halt_io)(UNIT *uptr);
         /* Test I/O TESTIO */
-        uint8       (*test_io)(UNIT *uptr);
+        uint16      (*test_io)(UNIT *uptr);
         /* Post I/O processing  */
-        uint8       (*post_io)(UNIT *uptr);
+        uint16      (*post_io)(UNIT *uptr);
         /* Controller init */
         void        (*dev_ini)(UNIT *, t_bool); /* init function */
         UNIT        *units;             /* Pointer to units structure */
@@ -223,14 +229,18 @@ typedef struct dib {
         uint32      chan_fifo[FIFO_SIZE];   /* interrupt status fifo for each channel */
 } DIB;
 
-/* DEV 0x7F000000 UNIT 0x00ff0000 */
-#define DEV_V_ADDR        DEV_V_UF              /* Pointer to device address (16) */
-#define DEV_V_DADDR       (DEV_V_UF + 8)        /* Device address */
-#define DEV_ADDR_MASK     (0x7f << DEV_V_DADDR) /* 24 bits shift */
-#define DEV_V_UADDR       (DEV_V_UF)            /* Device address in Unit */
-#define DEV_UADDR         (1 << DEV_V_UADDR)
-#define GET_DADDR(x)      (0x7f & ((x) >> DEV_V_ADDR))
-#define DEV_ADDR(x)       ((x) << DEV_V_ADDR)
+#define DEV_CHAN          (1 << DEV_V_UF)       /* Device is channel mux if set */
+#define DEV_V_UF2         (DEV_V_UF+1)          /* current usage */
+
+#ifdef NOT_USED_NOW
+//#define DEV_V_ADDR        DEV_V_UF              /* Pointer to device address (16) */
+//#define DEV_V_DADDR       (DEV_V_UF + 8)        /* Device address */
+//#define DEV_ADDR_MASK     (0x7f << DEV_V_DADDR) /* 24 bits shift */
+//#define DEV_V_UADDR       (DEV_V_UF)            /* Device address in Unit */
+//#define DEV_UADDR         (1 << DEV_V_UADDR)
+//#define GET_DADDR(x)      (0x7f & ((x) >> DEV_V_ADDR))
+//#define DEV_ADDR(x)       ((x) << DEV_V_ADDR)
+#endif
 
 /* allow 255 type disks */
 #define UNIT_V_TYPE        (UNIT_V_UF + 0)
@@ -239,6 +249,7 @@ typedef struct dib {
 #define GET_TYPE(x)        ((UNIT_TYPE & (x)) >> UNIT_V_TYPE)
 #define SET_TYPE(x)        (UNIT_TYPE & ((x) << UNIT_V_TYPE))
 
+/* DEV 0x7F000000 UNIT 0x00ff0000 */
 #define UNIT_V_ADDR       16
 #define UNIT_ADDR_MASK    (0x7fff << UNIT_V_ADDR)
 #define GET_UADDR(x)      ((UNIT_ADDR_MASK & x) >> UNIT_V_ADDR)

--- a/SEL32/sel32_scfi.c
+++ b/SEL32/sel32_scfi.c
@@ -229,9 +229,9 @@ scfi_type[] =
     {NULL, 0}
 };
 
-uint8   scfi_preio(UNIT *uptr, uint16 chan);
-uint8   scfi_startcmd(UNIT *uptr, uint16 chan, uint8 cmd);
-uint8   scfi_haltio(UNIT *uptr);
+uint16  scfi_preio(UNIT *uptr, uint16 chan);
+uint16  scfi_startcmd(UNIT *uptr, uint16 chan, uint8 cmd);
+uint16  scfi_haltio(UNIT *uptr);
 t_stat  scfi_srv(UNIT *);
 t_stat  scfi_boot(int32 unitnum, DEVICE *);
 void    scfi_ini(UNIT *, t_bool);
@@ -269,11 +269,11 @@ UNIT            sda_unit[] = {
 //DIB sda_dib = {scfi_preio, scfi_startcmd, NULL, NULL, NULL, scfi_ini, sda_unit, sda_chp, NUM_UNITS_SCFI, 0x0f, 0x0400, 0, 0, 0};
 
 DIB             sda_dib = {
-    scfi_preio,     /* uint8 (*pre_io)(UNIT *uptr, uint16 chan)*/   /* Pre Start I/O */
-    scfi_startcmd,  /* uint8 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start a command */
-    NULL,           /* uint8 (*halt_io)(UNIT *uptr) */          /* Stop I/O */
-    NULL,           /* uint8 (*test_io)(UNIT *uptr) */          /* Test I/O */
-    NULL,           /* uint8 (*post_io)(UNIT *uptr) */          /* Post I/O */
+    scfi_preio,     /* uint16 (*pre_io)(UNIT *uptr, uint16 chan)*/  /* Pre Start I/O */
+    scfi_startcmd,  /* uint16 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start command */
+    NULL,           /* uint16 (*halt_io)(UNIT *uptr) */         /* Stop I/O */
+    NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
+    NULL,           /* uint16 (*post_io)(UNIT *uptr) */         /* Post I/O */
     scfi_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     sda_unit,       /* UNIT* units */                           /* Pointer to units structure */
     sda_chp,        /* CHANP* chan_prg */                       /* Pointer to chan_prg structure */
@@ -313,11 +313,11 @@ UNIT            sdb_unit[] = {
 //DIB sdb_dib = {scfi_preio, scfi_startcmd, NULL, NULL, NULL, scfi_ini, sdb_unit, sdb_chp, NUM_UNITS_SCFI, 0x0f, 0x0c00, 0, 0, 0};
 
 DIB             sdb_dib = {
-    scfi_preio,     /* uint8 (*pre_io)(UNIT *uptr, uint16 chan)*/   /* Pre Start I/O */
-    scfi_startcmd,  /* uint8 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start a command */
-    NULL,           /* uint8 (*halt_io)(UNIT *uptr) */          /* Stop I/O */
-    NULL,           /* uint8 (*test_io)(UNIT *uptr) */          /* Test I/O */
-    NULL,           /* uint8 (*post_io)(UNIT *uptr) */          /* Post I/O */
+    scfi_preio,     /* uint16 (*pre_io)(UNIT *uptr, uint16 chan)*/  /* Pre Start I/O */
+    scfi_startcmd,  /* uint16 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start command */
+    NULL,           /* uint16 (*halt_io)(UNIT *uptr) */         /* Stop I/O */
+    NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
+    NULL,           /* uint16 (*post_io)(UNIT *uptr) */         /* Post I/O */
     scfi_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     sdb_unit,       /* UNIT* units */                           /* Pointer to units structure */
     sdb_chp,        /* CHANP* chan_prg */                       /* Pointer to chan_prg structure */
@@ -352,7 +352,7 @@ uint32 scfisec2star(uint32 daddr, int type)
 }
 
 /* start a disk operation */
-uint8  scfi_preio(UNIT *uptr, uint16 chan)
+uint16 scfi_preio(UNIT *uptr, uint16 chan)
 {
     DEVICE      *dptr = get_dev(uptr);
     uint16      chsa = GET_UADDR(uptr->CMD);
@@ -366,7 +366,7 @@ uint8  scfi_preio(UNIT *uptr, uint16 chan)
     return 0;                                   /* good to go */
 }
 
-uint8  scfi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
+uint16 scfi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
 {
     uint16      addr = GET_UADDR(uptr->CMD);
     DEVICE      *dptr = get_dev(uptr);
@@ -900,7 +900,8 @@ wrdone:
         sim_debug(DEBUG_CMD, dptr, "invalid command %02x unit %02x\n", cmd, unit);
         uptr->SNS |= SNS_CMDREJ;
         uptr->CMD &= ~(0xffff);                 /* remove old status bits & cmd */
-        chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+//      chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+        return SNS_CHNEND|STATUS_PCHK;
         break;
     }
     sim_debug(DEBUG_CMD, dptr,

--- a/SEL32/sel32_scsi.c
+++ b/SEL32/sel32_scsi.c
@@ -27,6 +27,9 @@
 
 #define UNIT_SCSI   UNIT_ATTABLE | UNIT_IDLE | UNIT_DISABLE
 
+#define DEV_BUF_NUM(x)  (((x) & 07) << DEV_V_UF2)
+#define GET_DEV_BUF(x)  (((x) >> DEV_V_UF2) & 07)
+
 /* useful conversions */
 /* Fill STAR value from cyl, trk, sec data */
 #define CHS2STAR(c,h,s)	        (((c<<16) & LMASK)|((h<<8) & 0xff00)|(s & 0xff))
@@ -77,8 +80,8 @@ bits 0-7 - Flags
         bit  3   - 0=Reserved
         bit  4   - 1=Drive not present
         bit  5   - 1=Dual Port
-        bit  6   - 0=Reserved
-        bit  7   - 0=Reserved
+        bit  6   - 0=Blk size   00=768 byte blk
+        bit  7   - 0=Blk size   01=1024 byte blk
 bits 8-15 - sector count (sectors per track)(F16=16, F20=20)
 bits 16-23 - MHD Head count (number of heads on MHD)
 bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option of
@@ -92,12 +95,50 @@ bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option
 /*  26 words of scratchpad */
 /*   4 words of label buffer registers */
 
+/* track label / sector label definations */
+/*
+    short lcyl;	        cylinder
+    char ltkn;			track
+    char lid;			sector id
+    char lflg1;         track/sector status flags
+        bit 0           good
+            1           alternate
+            2           spare
+            3           reserved
+            4           flaw
+            5           last track
+            6           start of alternate
+    char lflg2;
+    short lspar1;
+    short lspar2;
+    short ldef1;
+    int ldeallp;        DMAP block number trk0
+    int lumapp;			UMAP block number sec1
+    short ladef3;
+    short laltcyl;
+    char lalttk;        sectors per track
+    char ldscnt;        number of heads
+    char ldatrflg;		device attributes
+        bit 0           n/u
+            1           disk is mhd
+            2           n/u
+            3           n/u
+            4           n/u
+            5           dual ported
+            6/7         00 768 bytes/blk
+                        01 1024 bytes/blk
+                        10 2048 bytes/blk
+    char ldatrscnt;     sectors per track (again)
+    char ldatrmhdc;     MHD head count
+    char ldatrfhdc;     FHD head count
+ */
+
 #define CMD     u3
 /* u3 */
 /* in u3 is device command code and status */
 #define DSK_CMDMSK      0x00ff                  /* Command being run */
 #define DSK_STAR        0x0100                  /* STAR value in u4 */
-#define DSK_NU2         0x0200                  /*                    */
+#define DSK_NU          0x0200                  /* Not used */
 #define DSK_READDONE    0x0400                  /* Read finished, end channel */
 #define DSK_ENDDSK      0x0800                  /* Sensed end of disk */
 #define DSK_SEEKING     0x1000                  /* Disk is currently seeking */
@@ -106,30 +147,36 @@ bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option
 #define DSK_BUSY        0x8000                  /* Disk is busy */
 /* commands */
 #define DSK_INCH        0x00                    /* Initialize channel */
-#define DSK_INCH2       0xf0                    /* Initialize channel for processing */
+#define DSK_INCH2       0xF0                    /* Initialize channel for processing */
 #define DSK_WD          0x01                    /* Write data */
 #define DSK_RD          0x02                    /* Read data */
 #define DSK_NOP         0x03                    /* No operation */
 #define DSK_SNS         0x04                    /* Sense */
 #define DSK_SCK         0x07                    /* Seek cylinder, track, sector */
 #define DSK_TIC         0x08                    /* Transfer in channel */
-#define DSK_FNSK        0x0B                    /* Format for no skip */
-#define DSK_LPL         0x13                    /* Lock protected label */
+//#define DSK_FNSK        0x0B                    /* Format for no skip */
+#define DSK_RBLK        0x13                    /* Reassign Block */
 #define DSK_LMR         0x1F                    /* Load mode register */
-#define DSK_RES         0x23                    /* Reserve */
-#define DSK_WSL         0x31                    /* Write sector label */
-#define DSK_RSL         0x32                    /* Read sector label */
-#define DSK_REL         0x33                    /* Release */
+#define DSK_RWD         0x23                    /* Rewind */
+//#define DSK_WSL         0x31                    /* Write sector label */
+//#define DSK_RSL         0x32                    /* Read sector label */
+//#define DSK_REL         0x33                    /* Release */
 #define DSK_XEZ         0x37                    /* Rezero */
-#define DSK_POR         0x43                    /* Priority Override */
-#define DSK_IHA         0x47                    /* Increment head address */
-#define DSK_SRM         0x4F                    /* Set reserve track mode */
-#define DSK_WTL         0x51                    /* Write track label */
-#define DSK_RTL         0x52                    /* Read track label */
-#define DSK_XRM         0x5F                    /* Reset reserve track mode */
-#define DSK_RAP         0xA2                    /* Read angular positions */
-#define DSK_TESS        0xAB                    /* Test STAR (subchannel target address register) */
-#define DSK_ICH         0xFF                    /* Initialize Controller */
+//#define DSK_ADV         0x43                    /* Advance Record */
+//#define DSK_IHA         0x47                    /* Increment head address */
+//#define DSK_SRM         0x4F                    /* Set reserve track mode */
+//#define DSK_WTL         0x51                    /* Write track label */
+//#define DSK_RTL         0x52                    /* Read track label */
+#define DSK_RCAP        0x53                    /* Read Capacity */
+//#define DSK_XRM         0x5F                    /* Reset reserve track mode */
+//#define DSK_RAP         0xA2                    /* Read angular positions */
+#define DSK_RES         0xA3                    /* Reserve Unit */
+//#define DSK_TESS        0xAB                    /* Test STAR (subchannel target address register) */
+#define DSK_INQ         0xB3                    /* Inquiry */
+#define DSK_REL         0xC3                    /* Release Unit */
+#define DSK_TCMD        0xD3                    /* Transfer Command Packet (specifies CDB to send) */
+//#define DSK_ICH         0xFF                    /* Initialize Controller */
+#define DSK_FRE         0xF3                    /* Reserved */
 
 #define STAR    u4
 /* u4 - sector target address register (STAR) */
@@ -148,7 +195,8 @@ bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option
 #define SNS_DIAGMOD     0x08000000              /* Diagnostic Mode ECC Code generation and checking */
 #define SNS_RSVTRK      0x04000000              /* Reserve Track mode: 1=OK to write, 0=read only */
 #define SNS_FHDOPT      0x02000000              /* FHD or FHD option = 1 */
-#define SNS_RESERV      0x01000000              /* Reserved */
+//#define SNS_RESERV      0x01000000              /* Reserved */
+#define SNS_TCMD        0x01000000              /* Presessing CMD cmd chain */
 
 /* Sense byte 1 */
 #define SNS_CMDREJ      0x800000                /* Command reject */
@@ -201,7 +249,7 @@ bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option
     mini-module)
 */
 
-/* Not Used     up7 */
+/* INCH addr    up7 */
 
 /* disk definition structure */
 struct scsi_t
@@ -209,7 +257,7 @@ struct scsi_t
     const char  *name;                          /* Device ID Name */
     uint16      nhds;                           /* Number of heads */
     uint16      ssiz;                           /* sector size in words */
-    uint16      spt;                            /* # sectors per track(cylinder) */
+    uint16      spt;                            /* # sectors per track(head) */
     uint16      ucyl;                           /* Number of cylinders used */
     uint16      cyl;                            /* Number of cylinders on disk */
     uint8       type;                           /* Device type code */
@@ -222,16 +270,21 @@ scsi_type[] =
 {
     /* Class F Disc Devices */
     /* MPX SCSI disks for SCSI controller */
-    {"MH1GB", 1, 192, 40, 34960, 34960, 0x40},   /*0 69920 1000M */
-    {"SG038", 1, 192, 20,  2190,  2190, 0x40},   /*1 21900   38M */
-    {"SG120", 1, 192, 40, 34970, 34970, 0x40},   /*2 69940 1200M */
-    {"SG076", 1, 192, 20, 46725, 46725, 0x40},   /*3 46725  760M */
+    {"SD150",   9, 192, 24,   324,   967, 0x40},   /*0  8820  150M  208872 sec */
+    {"SD300",   9, 192, 32,   648,  1409, 0x40},   /*1  8828  300M  396674 sec */
+    {"SD700",  15, 192, 35,   648,  1546, 0x40},   /*2  8833  700M  797129 sec */
+    {"SD1200", 15, 192, 49,   648,  1931, 0x40},   /*3  8835 1200M 1389584 sec */
+    {"8820",    9, 192, 18,   324,   966, 0x40},   /*4  8820  150M */
+    {"8828",    9, 192, 36,   648,   966, 0x40},   /*5  8828  300M */
+    {"8833",   18, 192, 20,   648, 46725, 0x40},   /*6  8833  700M */
+    {"8835",   18, 192, 20,   648, 46725, 0x40},   /*7  8835 1200M */
+    /* For UTX */
     {NULL, 0}
 };
 
-uint8   scsi_preio(UNIT *uptr, uint16 chan);
-uint8   scsi_startcmd(UNIT *uptr, uint16 chan, uint8 cmd);
-uint8   scsi_haltio(UNIT *uptr);
+uint16  scsi_preio(UNIT *uptr, uint16 chan);
+uint16  scsi_startcmd(UNIT *uptr, uint16 chan, uint8 cmd);
+uint16  scsi_haltio(UNIT *uptr);
 t_stat  scsi_srv(UNIT *);
 t_stat  scsi_boot(int32 unitnum, DEVICE *);
 void    scsi_ini(UNIT *, t_bool);
@@ -243,10 +296,15 @@ t_stat  scsi_get_type(FILE * st, UNIT *uptr, int32 v, CONST void *desc);
 t_stat  scsi_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr);
 const   char  *scsi_description (DEVICE *dptr);
 
-/* channel program information */
-CHANP           sca_chp[NUM_UNITS_SCSI] = {0};
+/* One buffer per unit */
+#define BUFFSIZE        (64)
+uint8   scsi_buf[NUM_DEVS_SCSI][NUM_UNITS_SCSI][BUFFSIZE];
+uint8   scsi_pcmd[NUM_DEVS_SCSI][NUM_UNITS_SCSI];
 
-MTAB            scsi_mod[] = {
+/* channel program information */
+CHANP   sba_chp[NUM_UNITS_SCSI] = {0};
+
+MTAB    scsi_mod[] = {
     {MTAB_XTD | MTAB_VUN | MTAB_VALR, 0, "TYPE", "TYPE",
     &scsi_set_type, &scsi_get_type, NULL, "Type of disk"},
     {MTAB_XTD | MTAB_VUN | MTAB_VALR, 0, "DEV", "DEV", &set_dev_addr,
@@ -254,87 +312,88 @@ MTAB            scsi_mod[] = {
     {0}
 };
 
-UNIT            sca_unit[] = {
-/* SET_TYPE(2) SG120 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(2), 0), 0, UNIT_ADDR(0x400)},  /* 0 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(2), 0), 0, UNIT_ADDR(0x410)},  /* 1 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(2), 0), 0, UNIT_ADDR(0x420)},  /* 2 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(2), 0), 0, UNIT_ADDR(0x430)},  /* 3 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(2), 0), 0, UNIT_ADDR(0x440)},  /* 4 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(2), 0), 0, UNIT_ADDR(0x450)},  /* 5 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(2), 0), 0, UNIT_ADDR(0x460)},  /* 6 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(2), 0), 0, UNIT_ADDR(0x470)},  /* 7 */
+UNIT    sba_unit[] = {
+/* SET_TYPE(0) SD150 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7600)},  /* 0 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7601)},  /* 1 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7602)},  /* 2 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7603)},  /* 3 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7604)},  /* 4 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7605)},  /* 5 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7606)},  /* 6 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7607)},  /* 7 */
 };
 
-//DIB sca_dib = {scsi_preio, scsi_startcmd, NULL, NULL, NULL, scsi_ini, sca_unit, sca_chp, NUM_UNITS_SCSI, 0x0f, 0x0400, 0, 0, 0};
+//DIB sba_dib = {scsi_preio, scsi_startcmd, NULL, NULL, NULL, scsi_ini, sba_unit, sba_chp, NUM_UNITS_SCSI, 0x0f, 0x0400, 0, 0, 0};
 
-DIB             sca_dib = {
-    scsi_preio,     /* uint8 (*pre_io)(UNIT *uptr, uint16 chan)*/   /* Pre Start I/O */
-    scsi_startcmd,  /* uint8 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start a command */
-    NULL,           /* uint8 (*halt_io)(UNIT *uptr) */          /* Stop I/O */
-    NULL,           /* uint8 (*test_io)(UNIT *uptr) */          /* Test I/O */
-    NULL,           /* uint8 (*post_io)(UNIT *uptr) */          /* Post I/O */
+DIB     sba_dib = {
+    scsi_preio,     /* uint16 (*pre_io)(UNIT *uptr, uint16 chan)*/  /* Pre Start I/O */
+    scsi_startcmd,  /* uint16 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start command */
+    NULL,           /* uint16 (*halt_io)(UNIT *uptr) */         /* Stop I/O */
+    NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
+    NULL,           /* uint16 (*post_io)(UNIT *uptr) */         /* Post I/O */
     scsi_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
-    sca_unit,       /* UNIT* units */                           /* Pointer to units structure */
-    sca_chp,        /* CHANP* chan_prg */                       /* Pointer to chan_prg structure */
+    sba_unit,       /* UNIT* units */                           /* Pointer to units structure */
+    sba_chp,        /* CHANP* chan_prg */                       /* Pointer to chan_prg structure */
     NUM_UNITS_SCSI, /* uint8 numunits */                        /* number of units defined */
-    0xF0,           /* uint8 mask */                            /* 16 devices - device mask */
-    0x0400,         /* uint16 chan_addr */                      /* parent channel address */
+    0x0f,           /* uint8 mask */                            /* 8 devices - device mask */
+    0x7600,         /* uint16 chan_addr */                      /* parent channel address */
     0,              /* uint32 chan_fifo_in */                   /* fifo input index */
     0,              /* uint32 chan_fifo_out */                  /* fifo output index */
     {0}             /* uint32 chan_fifo[FIFO_SIZE] */           /* interrupt status fifo for channel */
 };
 
-DEVICE          sca_dev = {
-    "SCA", sca_unit, NULL, scsi_mod,
+DEVICE  sba_dev = {
+    "SBA", sba_unit, NULL, scsi_mod,
     NUM_UNITS_SCSI, 16, 24, 4, 16, 32,
     NULL, NULL, &scsi_reset, &scsi_boot, &scsi_attach, &scsi_detach,
     /* ctxt is the DIB pointer */
-    &sca_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS, 0, dev_debug,
+    &sba_dib, DEV_BUF_NUM(0)|DEV_DISABLE|DEV_DEBUG|DEV_DIS, 0, dev_debug,
     NULL, NULL, &scsi_help, NULL, NULL, &scsi_description
 };
 
 #if NUM_DEVS_SCSI > 1
-/* channel program information */
-CHANP           sdb_chp[NUM_UNITS_SCSI] = {0};
 
-UNIT            sdb_unit[] = {
-/* SET_TYPE(0) DM1GB */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0xC00)},  /* 0 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0xC10)},  /* 1 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0xC20)},  /* 2 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0xC30)},  /* 3 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0xC40)},  /* 4 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0xC50)},  /* 5 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0xC60)},  /* 6 */
-    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0xC70)},  /* 7 */
+/* channel program information */
+CHANP   sbb_chp[NUM_UNITS_SCSI] = {0};
+
+UNIT    sbb_unit[] = {
+/* SET_TYPE(0) DM150 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7640)},  /* 0 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7641)},  /* 1 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7642)},  /* 2 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7643)},  /* 3 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7644)},  /* 4 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7645)},  /* 5 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7646)},  /* 6 */
+    {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7647)},  /* 7 */
 };
 
 //DIB sdb_dib = {scsi_preio, scsi_startcmd, NULL, NULL, NULL, scsi_ini, sdb_unit, sdb_chp, NUM_UNITS_SCSI, 0x0f, 0x0c00, 0, 0, 0};
 
-DIB             sdb_dib = {
-    scsi_preio,     /* uint8 (*pre_io)(UNIT *uptr, uint16 chan)*/   /* Pre Start I/O */
-    scsi_startcmd,  /* uint8 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start a command */
-    NULL,           /* uint8 (*halt_io)(UNIT *uptr) */          /* Stop I/O */
-    NULL,           /* uint8 (*test_io)(UNIT *uptr) */          /* Test I/O */
-    NULL,           /* uint8 (*post_io)(UNIT *uptr) */          /* Post I/O */
+DIB     sbb_dib = {
+    scsi_preio,     /* uint16 (*pre_io)(UNIT *uptr, uint16 chan)*/  /* Pre Start I/O */
+    scsi_startcmd,  /* uint16 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start command */
+    NULL,           /* uint16 (*halt_io)(UNIT *uptr) */         /* Stop I/O */
+    NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
+    NULL,           /* uint16 (*post_io)(UNIT *uptr) */         /* Post I/O */
     scsi_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
-    sdb_unit,       /* UNIT* units */                           /* Pointer to units structure */
-    sdb_chp,        /* CHANP* chan_prg */                       /* Pointer to chan_prg structure */
+    sbb_unit,       /* UNIT* units */                           /* Pointer to units structure */
+    sbb_chp,        /* CHANP* chan_prg */                       /* Pointer to chan_prg structure */
     NUM_UNITS_SCSI, /* uint8 numunits */                        /* number of units defined */
-    0xF0,           /* uint8 mask */                            /* 16 devices - device mask */
-    0x0C00,         /* uint16 chan_addr */                      /* parent channel address */
+    0x0f,           /* uint8 mask */                            /* 2 devices - device mask */
+    0x7600,         /* uint16 chan_addr */                      /* parent channel address */
     0,              /* uint32 chan_fifo_in */                   /* fifo input index */
     0,              /* uint32 chan_fifo_out */                  /* fifo output index */
     0,              /* uint32 chan_fifo[FIFO_SIZE] */           /* interrupt status fifo for channel */
 };
 
-DEVICE          sdb_dev = {
-    "SCB", sdb_unit, NULL, scsi_mod,
+DEVICE  sbb_dev = {
+    "SBB", sbb_unit, NULL, scsi_mod,
     NUM_UNITS_SCSI, 16, 24, 4, 16, 32,
     NULL, NULL, &scsi_reset, &scsi_boot, &scsi_attach, &scsi_detach,
     /* ctxt is the DIB pointer */
-    &sdb_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS, 0, dev_debug,
+    &sbb_dib, DEV_BUF_NUM(1)|DEV_DISABLE|DEV_DEBUG|DEV_DIS, 0, dev_debug,
     NULL, NULL, &scsi_help, NULL, NULL, &scsi_description
 };
 #endif
@@ -352,7 +411,7 @@ uint32 scsisec2star(uint32 daddr, int type)
 }
 
 /* start a disk operation */
-uint8  scsi_preio(UNIT *uptr, uint16 chan)
+uint16 scsi_preio(UNIT *uptr, uint16 chan)
 {
     DEVICE      *dptr = get_dev(uptr);
     uint16      chsa = GET_UADDR(uptr->CMD);
@@ -366,7 +425,7 @@ uint8  scsi_preio(UNIT *uptr, uint16 chan)
     return 0;                                   /* good to go */
 }
 
-uint8  scsi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
+uint16 scsi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
 {
     uint16      addr = GET_UADDR(uptr->CMD);
     DEVICE      *dptr = get_dev(uptr);
@@ -374,7 +433,7 @@ uint8  scsi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
     CHANP       *chp = find_chanp_ptr(addr);    /* find the chanp pointer */
 
     sim_debug(DEBUG_CMD, dptr,
-        "scsi_startcmd unit %02x cmd %04x CMD %08x\n",
+        "scsi_startcmd unit %02x cmd %02x CMD %08x\n",
         unit, cmd, uptr->CMD);
     if ((uptr->flags & UNIT_ATT) == 0) {        /* unit attached status */
         uptr->SNS |= SNS_INTVENT;               /* unit intervention required */
@@ -395,11 +454,14 @@ uint8  scsi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
     switch (cmd) {
 
     case DSK_INCH:                              /* INCH 0x00 */
+#ifdef DO_DYNAMIC_DEBUG
+    cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ | DEBUG_XIO);
+#endif
         sim_debug(DEBUG_CMD, dptr,
             "scsi_startcmd starting INCH %06x cmd, chsa %04x MemBuf %08x cnt %04x\n",
             uptr->u4, addr, chp->ccw_addr, chp->ccw_count);
 
-        uptr->CMD |= DSK_INCH2;                 /* use 0xf0 for inch, just need int */
+        uptr->CMD |= DSK_INCH2;                 /* use 0xF0 for inch, just need int */
         sim_activate(uptr, 20);                 /* start things off */
         return 0;
         break;
@@ -428,6 +490,20 @@ uint8  scsi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
         sim_activate(uptr, 20);                 /* start things off */
         return 0;
         break;
+
+    case DSK_RCAP:                              /* Read Capacity 0x53 */
+        uptr->CMD |= cmd;                       /* save cmd */
+        sim_activate(uptr, 20);                 /* start things off */
+        return 0;
+        break;
+
+    /* Transfer Command Packet (specifies CDB to send) */
+    case DSK_TCMD:                              /* Transfer command packet 0xD3 */
+        uptr->CMD |= cmd;                       /* save cmd */
+        sim_activate(uptr, 20);                 /* start things off */
+        return 0;
+        break;
+
     }
     sim_debug(DEBUG_CMD, dptr,
         "scsi_startcmd done with scsi_startcmd %02x addr %04x SNS %08x\n",
@@ -445,20 +521,22 @@ t_stat scsi_srv(UNIT *uptr)
     DEVICE          *dptr = get_dev(uptr);
     /* get pointer to Dev Info Blk for this device */
     DIB             *dibp = (DIB *)dptr->ctxt;
-    CHANP           *chp = (CHANP *)dibp->chan_prg;     /* get pointer to channel program */
+    CHANP           *chp = (CHANP *)dibp->chan_prg; /* get pointer to channel program */
     int             cmd = uptr->CMD & DSK_CMDMSK;
     int             type = GET_TYPE(uptr->flags);
-    uint32          trk, cyl, sec;
+//  uint32          trk, cyl, sec;
     int             unit = (uptr - dptr->units);
+    int             bufnum = GET_DEV_BUF(dptr->flags);
     int             len=0;
     int             i;
+    uint32          cap = CAP(type);
     uint8           ch;
-    uint16          ssize = scsi_type[type].ssiz*4;     /* Size of one sector in bytes */
-    int32           tstart = 0;                         /* Location of start of cyl/track/sect in data */
+    uint16          ssize = scsi_type[type].ssiz*4; /* Size of one sector in bytes */
+    int32           tstart = 0;                 /* Location of start of cyl/track/sect in data */
     uint8           buf2[1024];
     uint8           buf[1024];
 
-    sim_debug(DEBUG_DETAIL, &sca_dev,
+    sim_debug(DEBUG_DETAIL, &sba_dev,
         "scsi_srv entry unit %02x CMD %08x chsa %04x count %04x %x/%x/%x \n",
         unit, uptr->CMD, chsa, chp->ccw_count,
         STAR2CYL(uptr->CHS), (uptr->CHS >> 8)&0xff, (uptr->CHS&0xff));
@@ -475,7 +553,7 @@ t_stat scsi_srv(UNIT *uptr)
     case 0:                                     /* No command, stop disk */
         break;
 
-    case DSK_INCH2:                             /* use 0xff for inch, just need int */
+    case DSK_INCH2:                             /* use 0xF0 for inch, just need int */
     {
         uint32  mema;                           /* memory address */
 //      uint32  daws[8];                        /* drive attribute registers */
@@ -488,78 +566,36 @@ t_stat scsi_srv(UNIT *uptr)
             "scsi_srv starting INCH cmd, chsa %04x MemBuf %06x cnt %04x\n",
             chsa, chp->ccw_addr, chp->ccw_count);
 
-        /* mema has IOCD word 1 contents.  For the disk processor it contains */
-        /* a pointer to the INCH buffer followed by 8 drive attribute words that */
-        /* contains the flags, sector count, MHD head count, and FHD count */
-        /* len has the byte count from IOCD wd2 and should be 0x24 (36) */
-        /* the INCH buffer address must be set for the parrent channel as well */
-        /* as all other devices on the channel.  Call set_inch() to do this for us */
-        /* just return OK and channel software will use u4 as status buffer addr */
+        /* mema has IOCD word 1 contents.  For the MFP (scsi processor) */
+        /* a pointer to the INCH buffer. The INCH buffer address must be */
+        /* set for the parent channel as well as all other devices on the */
+        /* channel.  Call set_inch() to do this for us. Just return OK and */
+        /* channel software will use the status buffer addr */
 
-        len = chp->ccw_count;                   /* INCH command count */
-
-        if (len != 36) {
-                /* we have invalid count, error, bail out */
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
-                uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
-                chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
-                break;
-        }
-
-        /* read all 36 bytes, stopping every 4 bytes to make words */
-        /* the first word has the inch buffer address */
-        /* the next 8 words have drive data for each unit */
-        /* WARNING 8 drives must be defined for this controller */
-        /* so we will not have a map fault */
-//      for (i=0, j=0; i < 36; i++) {
-        for (i=0; i < 36; i++) {
-            if (chan_read_byte(chsa, &buf[i])) {
-                /* we have error, bail out */
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
-                uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
-                chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
-                break;
-            }
-            if (((i+1)%4) == 0) {               /* see if we have a word yet */
-                if (i == 3)
-                    /* inch buffer address */
-                    mema = (buf[0]<<24) | (buf[1]<<16) |
-                        (buf[2]<<8) | (buf[3]);
-                else
-                    /* drive attribute registers */
-//                  daws[j++] = (buf[i-3]<<24) | (buf[i-2]<<16)
-//                      | (buf[i-1]<<8) | (buf[i]);
-                    /* may want to use this later */    
-                    /* clear warning errors */
-                    tstart = (buf[i-3]<<24) | (buf[i-2]<<16)
-                        | (buf[i-1]<<8) | (buf[i]);
-            }
-        }
-        /* now call set_inch() function to write and test inch bybber addresses */
+        /* now call set_inch() function to write and test inch buffer addresses */
         i = set_inch(uptr, mema);               /* new address */
 #ifdef NOTYET
         if ((i == SCPE_MEM) || (i == SCPE_ARG)) {   /* any error */
             /* we have error, bail out */
-            uptr->CMD &= ~(0xffff);             /* remove old status bits & cmd */
+            uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
             uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
             break;
         }
 #endif
-        uptr->CMD &= ~(0xffff);                 /* remove old cmd */
+        uptr->CMD &= LMASK;                     /* remove old cmd */
         sim_debug(DEBUG_CMD, dptr,
             "scsi_srv cmd INCH chsa %04x addr %06x count %04x completed\n",
             chsa, mema, chp->ccw_count);
-#ifdef FIX4MPX
-        chan_end(chsa, SNS_CHNEND);             /* return just channel end OK */
-#else
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* return OK */
+#ifdef DO_DYNAMIC_DEBUG
+    cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ);
 #endif
     }
         break;
 
     case DSK_NOP:                               /* NOP 0x03 */
-        uptr->CMD &= ~(0xffff);                 /* remove old cmd */
+        uptr->CMD &= LMASK;                     /* remove old cmd */
         sim_debug(DEBUG_CMD, dptr,
             "scsi_srv cmd NOP chsa %04x count %04x completed\n",
             chsa, chp->ccw_count);
@@ -567,22 +603,80 @@ t_stat scsi_srv(UNIT *uptr)
         break;
 
     case DSK_SNS: /* 0x4 */
-        ch = uptr->SNS & 0xff;
-        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense unit=%02x 1 %02x\n", unit, ch);
-        chan_write_byte(chsa, &ch) ;
+        sim_debug(DEBUG_CMD, dptr, "scsi_startcmd CMD sense\n");
+
+        /* bytes 0,1 - Cyl entry from CHS reg */
+        ch = (uptr->CHS >> 24) & 0xff;
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense CHS b0 unit=%02x 1 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+        ch = (uptr->CHS >> 16) & 0xff;
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense CHS b1 unit=%02x 2 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+        /* byte 2 - Track entry from CHS reg */
+        ch = (uptr->CHS >> 8) & 0xff;
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense CHS b2 unit=%02x 3 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+        /* byte 3 - Sector entry from CHS reg */
+        ch = (uptr->CHS) & 0xff;
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense CHS b3 unit=%02x 4 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+
+        /* bytes 4 - mode reg, byte 0 of SNS */
+        ch = (uptr->SNS >> 24) & 0xff;          /* return the sense data */
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense unit=%02x 1 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+        /* bytes 5-7 - status bytes, bytes 1-3 of SNS */
+        ch = (uptr->SNS >> 16) & 0xff;
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense unit=%02x 2 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
         ch = (uptr->SNS >> 8) & 0xff;
-        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense unit=%02x 2 %02x\n", unit, ch);
-        chan_write_byte(chsa, &ch) ;
-        ch = 0;
-        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense unit=%02x 3 %02x\n", unit, ch);
-        chan_write_byte(chsa, &ch) ;
-        ch = unit;
-        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense unit=%02x 4 %02x\n", unit, ch);
-        chan_write_byte(chsa, &ch) ;
-        ch = 4;
-        sim_debug(DEBUG_CMD, dptr, "DISK SENSE %02x chars complete %08x, unit %02x\n",
-            ch, uptr->SNS, unit);
-        uptr->CMD &= ~(0xff00);
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense unit=%02x 3 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+        ch = (uptr->SNS) & 0xff;
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv sense unit=%02x 4 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+
+        /* bytes 8-11 - drive mode register entries from assigned disk */
+        ch = scsi_type[type].type & 0xff;       /* type byte */
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv datr unit=%02x 1 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+        ch = scsi_type[type].spt & 0xff;        /* get sectors per track */
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv datr unit=%02x 2 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+        ch = scsi_type[type].nhds & 0xff;       /* get # MHD heads */
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv datr unit=%02x 3 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+        ch = 0;                                 /* no FHD heads */
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv datr unit=%02x 4 %02x\n",
+            unit, ch);
+        chan_write_byte(chsa, &ch);
+
+        /* bytes 12 & 13 are optional, so check if read done */
+        /* TODO add drive status bits here */
+        if ((test_write_byte_end(chsa)) == 0) {
+            /* bytes 12 & 13 contain drive related status */
+            ch = 0;                             /* zero for now */
+            sim_debug(DEBUG_DETAIL, dptr, "scsi_srv dsr unit=%02x 1 %02x\n",
+                unit, ch);
+            chan_write_byte(chsa, &ch);
+
+            ch = 0x30;                          /* drive on cylinder and ready for now */
+            sim_debug(DEBUG_DETAIL, dptr, "scsi_srv dsr unit=%02x 2 %02x\n",
+                unit, ch);
+            chan_write_byte(chsa, &ch);
+        }
+        uptr->CMD &= LMASK;                     /* remove old status bits & cmd */
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
         break;
 
@@ -590,18 +684,21 @@ t_stat scsi_srv(UNIT *uptr)
         /* If we are waiting on seek to finish, check if there yet. */
         if (uptr->CMD & DSK_SEEKING) {
             /* see if on cylinder yet */
-            if (STAR2CYL(uptr->STAR) == STAR2CYL(uptr->CHS)) {
+            if (uptr->STAR == uptr->CHS) {
                 /* we are on cylinder, seek is done */
-                sim_debug(DEBUG_CMD, dptr, "scsi_srv seek on cylinder unit=%02x %04x %04x\n",
-                    unit, uptr->STAR >> 16, uptr->CHS >> 16);
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
+                sim_debug(DEBUG_CMD, dptr, "scsi_srv seek on sector unit=%02x %06x %06x\n",
+                    unit, uptr->STAR, uptr->CHS);
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
                 /* we have already seeked to the required sector */
                 /* we do not need to seek again, so move on */
                 chan_end(chsa, SNS_DEVEND|SNS_CHNEND);
-                sim_activate(uptr, 20);
+                return SCPE_OK;
                 break;
             } else {
                 /* we have wasted enough time, we there */
+                /* we are on cylinder, seek is done */
+                sim_debug(DEBUG_CMD, dptr, "scsi_srv seek over on cylinder unit=%02x %04x %04x\n",
+                    unit, uptr->STAR, uptr->CHS);
                 uptr->CHS = uptr->STAR;         /* we are there */
                 sim_activate(uptr, 10);
                 break;
@@ -609,47 +706,53 @@ t_stat scsi_srv(UNIT *uptr)
         }
 
         /* not seeking, so start a new seek */
-        /* Read in 4 character seek code */
+        /* Read in 1-4 character seek code */
         for (i = 0; i < 4; i++) {
             if (chan_read_byte(chsa, &buf[i])) {
-                /* we have error, bail out */
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
-                uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
-                chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
-                break;
+                if (i == 0) {
+                    sim_debug(DEBUG_DETAIL, dptr,
+                        "scsi_srv seek error unit=%02x star %02x %02x %02x %02x\n",
+                        unit, buf[0], buf[1], buf[2], buf[3]);
+                    /* we have error, bail out */
+                    uptr->CMD &= LMASK;           /* remove old status bits & cmd */
+                    uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
+                    chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+                    return SCPE_OK;
+                    break;
+                }
+                /* done reading, see how many we read */
+                if (i == 1) {
+                    /* UTX wants to set seek STAR to zero */
+                    buf[0] = buf[1] = buf[2] = buf[3] = 0;
+                    break;
+                }
+                /* just read the next byte */
             }
         }
-        /* the value is really a sector offset for the disk */
-        /* but will treat as c/h/s for processing */
-        /* the cyl, trk, and sect are ready to update */
+        /* else the cyl, trk, and sect are ready to update */
         sim_debug(DEBUG_CMD, dptr,
             "scsi_srv STAR unit=%02x star %02x %02x %02x %02x\n",
             unit, buf[0], buf[1], buf[2], buf[3]);
-rezero:
+
         sim_debug(DEBUG_DETAIL, dptr,
-            "scsi_srv seek unit=%02x star %02x %02x %02x %02x\n",
+            "scsi_srv seek unit=%02x star %02x%02x%02x%02x\n",
             unit, buf[0], buf[1], buf[2], buf[3]);
 
         /* save STAR (target sector) data in STAR */
         uptr->STAR = (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | (buf[3]);
-        cyl = STAR2CYL(uptr->STAR);             /* get the cylinder */
-        trk = buf[2];                           /* get the track */
 
         sim_debug(DEBUG_DETAIL, dptr,
-            "scsi_srv SEEK %08x cyl %04x trk %02x sec %02x unit=%02x\n",
-            uptr->CMD, cyl&0xffff, trk, buf[3], unit);
+            "scsi_srv SEEK %08x sector %06x (%d) unit=%02x\n",
+            uptr->CMD, uptr->STAR, uptr->STAR, unit);
 
         /* Check if seek valid */
-        if (cyl >= scsi_type[type].cyl ||
-            trk >= scsi_type[type].nhds ||
-            buf[3] >= scsi_type[type].spt)  {
-
+        if (uptr->STAR >= CAP(type)) {
             sim_debug(DEBUG_CMD, dptr,
-                "dsk_srv seek ERROR cyl %04x trk %02x sec %02x unit=%02x\n",
-                cyl, trk, buf[3], unit);
+                "scsi_srv seek ERROR sector %06x unit=%02x\n",
+                uptr->STAR, unit);
 
-            uptr->CMD &= ~(0xffff);             /* remove old status bits & cmd */
-            uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;  /* set error status */
+            uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
+            uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK; /* set error status */
 
             /* we have an error, tell user */
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);  /* end command */
@@ -659,33 +762,37 @@ rezero:
         /* calc the new sector address of data */
         /* calculate file position in bytes of requested sector */
         /* file offset in bytes */
-        tstart = STAR2SEC(uptr->STAR, SPT(type), SPC(type)) * SSB(type);
-        uptr->CHS = CHS2STAR(STAR2CYL(uptr->CHS), trk, buf[3]);
+        tstart = uptr->STAR * SSB(type);
+//      uptr->CHS = uptr->STAR;
 
         sim_debug(DEBUG_DETAIL, dptr,
-            "scsi_srv seek start %08x trk %04x sec %02x\n",
-            tstart, trk, buf[3]);
+            "scsi_srv seek start %04x sector %06x\n",
+            tstart, uptr->STAR);
 
         /* just seek to the location where we will r/w data */
-        if ((sim_fseek(uptr->fileref, tstart, SEEK_SET)) != 0) {  /* seek home */
+        if ((sim_fseek(uptr->fileref, tstart, SEEK_SET)) != 0) {  /* seek r/w sec */
+            uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
             sim_debug(DEBUG_DETAIL, dptr, "scsi_srv Error on seek to %08x\n", tstart);
+            chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+            return SCPE_OK;
         }
 
         /* Check if already on correct cylinder */
         /* if not, do a delay to slow things down */
-        if (STAR2CYL(uptr->STAR) != STAR2CYL(uptr->CHS)) {
+        if (uptr->STAR != uptr->CHS) {
             /* Do a fake seek to kill time */
             uptr->CMD |= DSK_SEEKING;           /* show we are seeking */
             sim_debug(DEBUG_DETAIL, dptr,
-                "scsi_srv seeking unit=%02x to cyl %04x trk %04x sec %04x\n",
-                unit, cyl, trk, buf[3]);
-            sim_activate(uptr, 20);
+                "scsi_srv seeking unit=%02x to sector %06x\n",
+                unit, uptr->STAR);
+            sim_activate(uptr, 40);
         } else {
             /* we are on cylinder/track/sector, so go on */
             sim_debug(DEBUG_DETAIL, dptr,
-                "scsi_srv calc sect addr seek start %08x cyl %04x trk %04x sec %02x\n",
-                tstart, cyl, trk, buf[3]);
-            uptr->CMD &= ~(0xffff);             /* remove old status bits & cmd */
+                "scsi_srv calc sect addr seek start %08x sector %06x\n",
+                tstart, uptr->STAR);
+            uptr->CHS = uptr->STAR;             /* set new sector position */
+            uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
             chan_end(chsa, SNS_DEVEND|SNS_CHNEND);
         }
         return SCPE_OK;
@@ -696,20 +803,22 @@ rezero:
         /* Do a seek to 0 */
         uptr->STAR = 0;                         /* set STAR to 0, 0, 0 */
         uptr->CHS = 0;                          /* set current CHS to 0, 0, 0 */
-        uptr->CMD &= ~(0xffff);                 /* remove old cmd */
+        uptr->CMD &= LMASK;                     /* remove old cmd */
         uptr->CMD |= DSK_SCK;                   /* show as seek command */
         tstart = 0;                             /* byte offset is 0 */
-        /* Read in 1 dummy character for length to inhibit SLI posting */
-        if (chan_read_byte(chsa, &buf[0])) {
-            /* we have error, bail out */
-            uptr->CMD &= ~(0xffff);             /* remove old status bits & cmd */
-            uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
+
+        /* just seek to the location where we will r/w data */
+        if ((sim_fseek(uptr->fileref, tstart, SEEK_SET)) != 0) {  /* do seek */
+            sim_debug(DEBUG_EXP, dptr, "scsi_srv Error on seek to %04x\n", tstart);
+            uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
-            break;
+            return SCPE_OK;
         }
-        /* zero stuff */
-        buf[0] = buf[1] = buf[2] = buf[3] = 0;
-        goto rezero;                            /* merge with seek code */
+        /* we are on cylinder/track/sector zero, so go on */
+        sim_debug(DEBUG_DETAIL, dptr, "scsi_srv done seek trk 0\n");
+        uptr->CMD &= LMASK;                     /* remove old status bits & cmd */
+        chan_end(chsa, SNS_DEVEND|SNS_CHNEND);
+        return SCPE_OK;
         break;
 
     case DSK_LMR:
@@ -717,42 +826,86 @@ rezero:
         /* Read in 1 character of mode data */
         if (chan_read_byte(chsa, &buf[0])) {
             /* we have error, bail out */
-            uptr->CMD &= ~(0xffff);             /* remove old status bits & cmd */
+            uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
             uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
             break;
         }
         sim_debug(DEBUG_CMD, dptr, "Load Mode Reg unit=%02x old %x new %x\n",
             unit, (uptr->SNS)&0xff, buf[0]);
-        uptr->CMD &= ~(0xffff);                 /* remove old cmd */
-        uptr->SNS &= 0x00ffffff;                /* clear old mode data */
+        uptr->CMD &= LMASK;                     /* remove old cmd */
+        uptr->SNS &= MASK24;                    /* clear old mode data */
         uptr->SNS |= (buf[0] << 24);            /* save mode value */
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
         break;
 
     case DSK_RD:                                /* Read Data */
+        if (uptr->SNS & SNS_TCMD) {
+            /* we need to process a read TCMD data */
+            int cnt = scsi_buf[bufnum][unit][4];    /* byte count of status to send */
+            ch = scsi_buf[bufnum][unit][0];         /* return TCMD cmd */
+            uptr->SNS &= ~SNS_TCMD;                 /* show not presessing TCMD cmd chain */
+            sim_debug(DEBUG_CMD, dptr,
+                "scsi_srv returning TCMD cmd status, chsa %04x tcma %06x cnt %04x\n",
+                chsa, chp->ccw_addr, chp->ccw_count);
+
+            /* ssize has sector size in bytes */
+            for (i=0; i<cnt; i++) {
+                buf[i] = 0;                         /* clear buffer */
+            }
+            /* set some sense data from SH.DCSCI driver code */
+            buf[0] = 0xf0;                          /* page code */
+            buf[4] = 0x81;
+            buf[8] = 0x91;
+            buf[12] = 0xf4;
+            buf[17] = HDS(type);                    /* # of heads */
+            buf[23] = SPT(type);                    /* Sect/track */
+//          buf[27] = SPT(type);                    /* Sect/track */
+            for (i=0; i<cnt; i++) {
+                if (chan_write_byte(chsa, &buf[i])) {
+                    /* we have error, bail out */
+                    uptr->CMD &= LMASK;             /* remove old status bits & cmd */
+                    uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
+                    chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+                    return SCPE_OK;
+                }
+            }
+            sim_debug(DEBUG_DETAIL, dptr,
+                "scsi_srv TCMD sense data chsa=%02x data %02x%02x%02x%02x %02x%02x%02x%02x\n",
+                chsa, buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
+            sim_debug(DEBUG_DETAIL, dptr,
+                "scsi_srv TCMD sense data chsa=%02x data %02x%02x%02x%02x %02x%02x%02x%02x\n",
+                chsa, buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15]);
+            sim_debug(DEBUG_DETAIL, dptr,
+                "scsi_srv TCMD sense data chsa=%02x data %02x%02x%02x%02x %02x%02x%02x%02x\n",
+                chsa, buf[16], buf[17], buf[18], buf[19], buf[20], buf[21], buf[22], buf[23]);
+
+            uptr->CMD &= LMASK;         /* remove old status bits & cmd */
+            chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
+            return SCPE_OK;
+        }
+
         /* tstart has start of sector address in bytes */
         if ((uptr->CMD & DSK_READING) == 0) {   /* see if we are reading data */
             uptr->CMD |= DSK_READING;           /* read from disk starting */
             sim_debug(DEBUG_CMD, dptr,
-                "DISK READ starting unit=%02x CMD %08x count %04x\n",
+                "SCSI READ starting unit=%02x CMD %08x count %04x\n",
                 unit, uptr->CMD, chp->ccw_count);
         }
 
         if (uptr->CMD & DSK_READING) {          /* see if we are reading data */
-            cyl = STAR2CYL(uptr->CHS);          /* get current cyl */
-            trk = (uptr->CHS >> 8) & 0xff;      /* get trk/head */
-            sec = uptr->CHS & 0xff;             /* get sec */
-            /* get sector offset */
-//          tstart = STAR2SEC(uptr->STAR, SPT(type), SPC(type));
-            tstart = STAR2SEC(uptr->CHS, SPT(type), SPC(type));
+            tstart = uptr->CHS;                 /* get sector offset */
+
+            sim_debug(DEBUG_CMD, dptr,
+                "SCSI READ reading CMD %08x chsa %04x tstart %04x buffer %06x count %04x\n",
+                uptr->CMD, chsa, tstart, chp->ccw_addr, chp->ccw_count);
 
             /* read in a sector of data from disk */
             if ((len=sim_fread(buf, 1, ssize, uptr->fileref)) != ssize) {
                 sim_debug(DEBUG_CMD, dptr,
-                    "Error %08x on read %04x of diskfile cyl %04x hds %02x sec %02x\n",
-                    len, ssize, cyl, trk, sec);
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
+                    "Error %08x on read %04x of diskfile sector %06x\n",
+                    len, ssize, tstart);
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
                 break;
             }
@@ -765,84 +918,73 @@ rezero:
                 ch = buf[i];                    /* get a char from buffer */
                 if (chan_write_byte(chsa, &ch)) {   /* put a byte to memory */
                     sim_debug(DEBUG_DATA, dptr,
-                        "DISK Read %04x bytes from diskfile /%04x/%02x/%02x tstart %08x\n",
-                        len, cyl, trk, sec, tstart);
-                    uptr->CMD &= ~(0xffff);     /* remove old status bits & cmd */
+                        "SCSI Read %04x bytes leaving %04x from diskfile sector %06x\n",
+                        i, chp->ccw_count, tstart);
+                    uptr->CMD &= LMASK;         /* remove old status bits & cmd */
                     chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
-                    goto rddone;
+                    return SCPE_OK;
                 }
             }
 
             sim_debug(DEBUG_CMD, dptr,
-                "DISK READ from sec end %04x bytes end %04x from diskfile /%04x/%02x/%02x tstart %08x\n",
-                len, ssize, cyl, trk, sec, tstart);
+                "SCSI READ %04x bytes leaving %4x to be read to %06x from diskfile sector %06x\n",
+                ssize, chp->ccw_count, chp->ccw_addr+4, tstart);
+
+            /* see if we are done reading data */
+            if (test_write_byte_end(chsa)) {
+                sim_debug(DEBUG_DATA, dptr,
+                    "SCSI Read complete for read from diskfile sector %06x\n",
+                    uptr->CHS);
+                uptr->CMD &= LMASK;               /* remove old status bits & cmd */
+                chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
+                break;
+            }
 
             /* tstart has file offset in sectors */
             tstart++;                           /* bump to next sector */
-            /* convert sect back to chs value */
-            uptr->CHS = scsisec2star(tstart, type);
-            /* see of over end of disk */
-//          if (tstart >= CAPB(type)) {
-            if (tstart >= CAP(type)) {
+            uptr->CHS = tstart;                 /* new position */
+            /* see if over end of disk */
+            if (tstart >= (uint32)CAP(type)) {
                 /* EOM reached, abort */
                 sim_debug(DEBUG_CMD, dptr,
-                    "DISK Read reached EOM for read from disk @ /%04x/%02x/%02x\n",
-                    STAR2CYL(uptr->CHS), (uptr->CHS >> 8)&0xff, (uptr->CHS&0xff));
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
+                    "SCSI Read reached EOM for read from disk @ sector %06x\n",
+                    tstart);
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
                 uptr->CHS = 0;                  /* reset cylinder position */
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
                 break;
             }
 
-            /* see if we are done reading data */
-            if (test_write_byte_end(chsa)) {
-                sim_debug(DEBUG_DATA, dptr,
-                    "DISK Read complete Read %04x bytes from diskfile /%04x/%02x/%02x tstart %08x\n",
-                    ssize, cyl, trk, sec, tstart);
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
-                chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
-                break;
-            } else {
-                sim_debug(DEBUG_DATA, dptr,
-                    "DISK sector read complete, %x bytes to go from diskfile /%04x/%02x/%02x\n",
-                    chp->ccw_count, STAR2CYL(uptr->CHS), ((uptr->CHS) >> 8)&0xff, (uptr->CHS&0xff));
-                sim_activate(uptr, 10);         /* wait to read next sector */
-                break;
-            }
-rddone:
-            uptr->CMD &= ~(0xffff);             /* remove old status bits & cmd */
+            sim_debug(DEBUG_DATA, dptr,
+                "SCSI sector read complete, %x bytes to go from diskfile sector %06x\n",
+                chp->ccw_count, uptr->CHS);
+            sim_activate(uptr, 10);             /* wait to read next aector */
+            break;
         }
         break;
 
     case DSK_WD:            /* Write Data */
-        /* tstart has start of sector address in bytes */
-
+        /* tstart has file offset in sectors */
         if ((uptr->CMD & DSK_WRITING) == 0) {   /* see if we are writing data */
             uptr->CMD |= DSK_WRITING;           /* write to disk starting */
             sim_debug(DEBUG_CMD, dptr,
-                "DISK WRITE starting unit=%02x CMD %08x bytes %04x\n",
-                unit, uptr->CMD, len);
+                "SCSI WRITE starting unit=%02x CMD %02x write %4x from %06x to sector %06x\n",
+                unit, uptr->CMD, chp->ccw_count, chp->ccw_addr, uptr->CHS);
         }
         if (uptr->CMD & DSK_WRITING) {          /* see if we are writing data */
-            cyl = STAR2CYL(uptr->CHS);          /* get current cyl */
-            trk = (uptr->CHS >> 8) & 0xff;      /* get trk/head */
-            sec = uptr->CHS & 0xff;             /* get sec */
-            /* get sector offset */
-//          tstart = STAR2SEC(uptr->STAR, SPT(type), SPC(type));
-            tstart = STAR2SEC(uptr->CHS, SPT(type), SPC(type));
-
+            tstart = uptr->CHS;                 /* get sector offset */
             /* process the next sector of data */
             len = 0;                            /* used here as a flag for short read */
             for (i=0; i<ssize; i++) {
-                if (chan_read_byte(chsa, &ch)) {    /* get a byte from memory */
+                if (chan_read_byte(chsa, &ch)) {/* get a byte from memory */
                     /* if error on reading 1st byte, we are done writing */
                     if (i == 0) {
-                        uptr->CMD &= ~(0xffff);  /* remove old status bits & cmd */
-                        sim_debug(DEBUG_DATA, dptr,
-                            "DISK Wrote %04x bytes to diskfile cyl %04x hds %02x sec %02x tstart %08x\n",
-                            ssize, cyl, trk, sec, tstart);
+                        uptr->CMD &= LMASK;     /* remove old status bits & cmd */
+                        sim_debug(DEBUG_CMD, dptr,
+                            "SCSI Wrote %04x bytes to diskfile sector %06x\n",
+                            ssize, tstart);
                         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
-                        goto wrdone;
+                        return SCPE_OK;
                     }
                     ch = 0;                     /* finish out the sector with zero */
                     len++;                      /* show we have no more data to write */
@@ -853,52 +995,148 @@ rddone:
             /* write the sector to disk */
             if ((i=sim_fwrite(buf2, 1, ssize, uptr->fileref)) != ssize) {
                 sim_debug(DEBUG_CMD, dptr,
-                    "Error %08x on write %04x to diskfile cyl %04x hds %02x sec %02x\n",
-                    i, ssize, cyl, trk, sec);
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
+                    "Error %08x on write %04x bytes to diskfile sector %06x\n",
+                    i, ssize, tstart);
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
                 break;
             }
             if (len != 0) {                     /* see if done with write command */
                 sim_debug(DEBUG_DATA, dptr,
-                    "DISK WroteB %04x bytes to diskfile cyl %04x hds %02x sec %02x tstart %08x\n",
-                    ssize, cyl, trk, sec, tstart);
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
+                    "SCSI WroteB %04x bytes to diskfile sector %06x\n",
+                    ssize, tstart);
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* we done */
                 break;
             }
             sim_debug(DEBUG_CMD, dptr,
-                "DISK WR to sec end %04x bytes end %04x to diskfile cyl %04x hds %02x sec %02x tstart %08x\n",
-                len, ssize, cyl, trk, sec, tstart);
+                "SCSI WR to sec end %04x bytes end %04x to diskfile sector %06x\n",
+                len, ssize, tstart);
 
             /* tstart has file offset in sectors */
             tstart++;                           /* bump to next sector */
-            /* convert sect back to chs value */
-            uptr->CHS = scsisec2star(tstart, type);
-            /* see of over end of disk */
-//          if (tstart >= CAPB(type)) {
-            if (tstart >= CAP(type)) {
+            uptr->CHS = tstart;                 /* save new sector */
+            /* see if over end of disk */
+            if (tstart >= (uint32)CAP(type)) {
                 /* EOM reached, abort */
                 sim_debug(DEBUG_CMD, dptr,
-                    "DISK Write reached EOM for write to disk @ /%04x/%02x/%02x\n",
-                    STAR2CYL(uptr->CHS), (uptr->CHS >> 8)&0xff, (uptr->CHS&0xff));
-                uptr->CMD &= ~(0xffff);         /* remove old status bits & cmd */
+                    "SCSI Write reached EOM for write to disk @ sector %06x\n",
+                    uptr->CHS);
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
                 uptr->CHS = 0;                  /* reset cylinder position */
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
                 break;
             }
             sim_activate(uptr, 10);             /* keep writing */
             break;
-wrdone:
-            uptr->CMD &= ~(0xffff);             /* remove old status bits & cmd */
          }
          break;
+
+    case DSK_RCAP:                              /* Read Capacity 0x53 */
+        /* return 8 bytes */
+        /* wd 1 disk size in sectors */
+        /* wd 2 is sector size in bytes */
+        /* cap has disk capacity */
+        for (i=0; i<4; i++) {
+            /* I think they want cap-1, not cap?????????? */
+            /* verified that MPX wants cap-1, else J.VFMT aborts */
+            ch = ((cap-1) >> ((3-i)*8)) & 0xff; /* use cap-1 */
+            if (chan_write_byte(chsa, &ch)) {   /* write byte to memory */
+                /* we have error, bail out */
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
+                uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
+                chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+                break;
+            }
+        }
+        /* ssize has sector size in bytes */
+        for (i=0; i<4; i++) {
+            ch = (ssize >> ((3-i)*8)) & 0xff;
+            if (chan_write_byte(chsa, &ch)) {
+                /* we have error, bail out */
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
+                uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
+                chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+                break;
+            }
+        }
+
+        /* command is completed */
+        uptr->CMD &= LMASK;                     /* remove old status bits & cmd */
+        sim_debug(DEBUG_CMD, dptr,
+            "scsi_srv cmd RCAP chsa %04x capacity %06x secsize %03x completed\n",
+            chsa, cap, ssize);
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* return OK */
+        return SCPE_OK;
+        break;
+
+    /* Transfer Command Packet (specifies CDB to send) */
+    /* address points to CDB */
+    case DSK_TCMD:                              /* Transfer command packet 0xD3 */
+        {
+        uint32  mema;                           /* memory address */
+//      uint32  daws[8];                        /* drive attribute registers */
+//      uint32  i, j;
+        uint32  i;
+
+        uptr->SNS &= ~SNS_TCMD;                 /* show not presessing TCMD cmd chain */
+        len = chp->ccw_count;                   /* INCH command count */
+        mema = chp->ccw_addr;                   /* get inch or buffer addr */
+        sim_debug(DEBUG_CMD, dptr,
+            "scsi_srv starting TCMD cmd, chsa %04x tcma %06x cnt %04x\n",
+            chsa, chp->ccw_addr, chp->ccw_count);
+
+        /* mema has IOCD word 1 contents. */
+        /* len has the byte count from IOCD wd2 */
+
+        len = chp->ccw_count;                   /* TCMD command count */
+
+#ifdef NOTNOW
+        if (len != 36) {
+                /* we have invalid count, error, bail out */
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
+                uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
+                chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+                break;
+        }
+#endif
+
+        for (i=0; i < len; i++) {
+            if (chan_read_byte(chsa, &buf[i])) {
+                /* we have error, bail out */
+                uptr->CMD &= LMASK;             /* remove old status bits & cmd */
+                uptr->SNS |= SNS_CMDREJ|SNS_EQUCHK;
+                chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+                break;
+            }
+        }
+        sim_debug(DEBUG_DETAIL, dptr,
+            "scsi_srv TCMD data chsa=%02x data %02x %02x %02x %02x %02x %02x\n",
+            chsa, buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]);
+
+        /* save the CMD packet */
+        for (i=0; i < len; i++) {
+            scsi_buf[bufnum][unit][i] = buf[i]; /* save the cmd */
+        }
+        scsi_pcmd[bufnum][unit] = buf[0];       /* save the cmd */
+        uptr->SNS |= SNS_TCMD;                  /* show Presessing CMD cmd chain */
+
+        /* command is completed */
+        uptr->CMD &= LMASK;                     /* remove old status bits & cmd */
+        sim_debug(DEBUG_CMD, dptr,
+            "scsi_srv cmd TCMD chsa %04x addr %06x count %04x completed\n",
+            chsa, mema, chp->ccw_count);
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* return OK */
+        }
+        return SCPE_OK;
+        break;
 
     default:
         sim_debug(DEBUG_CMD, dptr, "invalid command %02x unit %02x\n", cmd, unit);
         uptr->SNS |= SNS_CMDREJ;
-        uptr->CMD &= ~(0xffff);                 /* remove old status bits & cmd */
-        chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+        uptr->CMD &= LMASK;                     /* remove old status bits & cmd */
+//      chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
+        return SNS_CHNEND|STATUS_PCHK;
         break;
     }
     sim_debug(DEBUG_CMD, dptr,
@@ -912,13 +1150,16 @@ void scsi_ini(UNIT *uptr, t_bool f)
     DEVICE  *dptr = get_dev(uptr);
     int     i = GET_TYPE(uptr->flags);
 
-    uptr->CMD &= ~0xffff;                       /* clear out the flags but leave ch/sa */
-    uptr->SNS = ((uptr->SNS & 0x00ffffff) | (scsi_type[i].type << 24));  /* save mode value */
+    /* start out at sector 0 */
+    uptr->CHS = 0;                              /* set CHS to cyl/hd/sec = 0 */
+    uptr->STAR = 0;                             /* set STAR to cyl/hd/sec = 0 */
+    uptr->CMD &= LMASK;                         /* remove old status bits & cmd */
+    uptr->SNS = ((uptr->SNS & MASK24) | (scsi_type[i].type << 24));  /* save mode value */
     /* total sectors on disk */
     uptr->capac = CAP(i);                       /* disk size in sectors */
 
-    sim_debug(DEBUG_EXP, &sca_dev, "SCA init device %s on unit SCA%.1x cap %x\n",
-        dptr->name, GET_UADDR(uptr->CMD), uptr->CMD);
+    sim_debug(DEBUG_EXP, &sba_dev, "SBA init device %s on unit SBA%.1x cap %x %d\n",
+        dptr->name, GET_UADDR(uptr->CMD), uptr->capac, uptr->capac);
 }
 
 t_stat scsi_reset(DEVICE * dptr)
@@ -930,22 +1171,93 @@ t_stat scsi_reset(DEVICE * dptr)
 /* create the disk file for the specified device */
 int scsi_format(UNIT *uptr) {
 //  struct ddata_t  *data = (struct ddata_t *)uptr->up7;
-    uint16      addr = GET_UADDR(uptr->CMD);
     int         type = GET_TYPE(uptr->flags);
     DEVICE      *dptr = get_dev(uptr);
     int32       ssize = scsi_type[type].ssiz * 4;       /* disk sector size in bytes */
     uint32      tsize = scsi_type[type].spt;            /* get track size in sectors */
     uint32      csize = scsi_type[type].nhds * tsize;   /* get cylinder size in sectors */
     uint32      cyl = scsi_type[type].cyl;              /* get # cyl */
-//  uint16      spc = scsi_type[type].nhds * scsi_type[type].spt;   /* sectors/cyl */
     uint32      cap = scsi_type[type].cyl * csize;      /* disk capacity in sectors */
     uint32      cylv = cyl;                             /* number of cylinders */
     uint8       *buff;
+    int         i;
+
+                /* last sector address of disk (cyl * hds * spt) - 1 */
+    uint32      laddr = CAP(type) - 1;              /* last sector of disk */
+
+                /* last track address of disk (cyl * hds * spt) - spt */
+    uint32      ltaddr = CAP(type)-SPT(type);       /* last sector of disk */
+
+                /* get sector address of vendor defect table VDT */
+                /* put data = 0xf0000000 0xf4000000 */
+    int32       vaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-1) * SPT(type);
+
+                /* get sector address of utx diag map (DMAP) track 0 pointer */
+                /* put data = 0xf0000000 + (cyl-1), 0x8a000000 + daddr, */
+                /* 0x9a000000 + (cyl-1), 0xf4000008 */
+//WASint32       daddr = vaddr - SPT(type);
+    int32       daddr = (CYL(type)-4) * SPC(type) + (HDS(type)-2) * SPT(type);
+
+                /* get sector address of utx flaw data (1 track long) */
+                /* set trace data to zero */
+//WASint32       faddr = daddr - SPT(type);
+    int32       faddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
+
+                /* get sector address of utx flaw map sec 1 pointer */
+                /* use this address for sec 1 label pointer */
+//WASint32       uaddr = daddr - SPT(type);
+//WASint32       uaddr = daddr - (2*SPT(type));
+    int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-4) * SPT(type);
+
+                /* last user block available */
+    int32       luaddr = (CYL(type)-4) * SPC(type);
+
+                /* make up a UMAP with the partiton data for 9346 disk */
+    uint32      umap[256] =
+                {
+                    /* try to makeup a utx dmap */
+                    0x4e554d50,(cap-1),luaddr-1,0,0,0,0,0xe10,
+                    0,0x5320,0,0x4e60,0x46,luaddr,0,0xd360,
+                    0x88,0x186b0,0x13a,0xd100,0x283,0,0,0,
+                    0,0x22c2813e,0,0x06020000,0xf4,0,0x431b1c,0,
+                };
+
+#ifdef USE_FOR_MPX
+                {
+                    /* some values created by j.vfmt */
+//                  0xf003d14f,0x8a03cda0,0x9a03cdbf,0x8903cdc0,
+//                  0x9903d01f,0x8c03d020,0x9c03d14f,0xf4000000,
+                    0xf0000000 | (cap-1), 0x8a000000 | daddr,
+                        0x9a000000 | (daddr + ((2 * tsize) - 1)),
+                        0x89000000 | (daddr + (2 * tsize)),
+                        0x99000000 | ((cap-1)-spc),
+                        0x8c000000 | (cap-spc),
+                        0x9c000000 | (cap-1), 0xf4000000,
+                };
+#endif
+
+                /* vendor flaw map in vaddr */
+    uint32      vmap[2] = {0xf0000004, 0xf4000000};
+
+                /* defect map */
+    uint32      dmap[4] = {0xf0000000 | (cap-1), 0x8a000000 | daddr,
+                    0x9a000000 | (cap-1), 0xf4000000};
+//TRY               0x9a000000 | (cap-1), 0xf4000008};
+
+                /* utx flaw map */
+    uint32      fmap[4] = {0xf0000000 | (cap-1), 0x8a000000 | daddr,
+                    0x9a000000 | ltaddr, 0xf4000000};
+//TRY               0x9a000000 | ltaddr, 0xf4000008};
 
     /* see if user wants to initialize the disk */
     if (!get_yn("Initialize disk? [Y] ", TRUE)) {
         return 1;
     }
+
+    /* VDT  249264 (819/18/0) 0x3cdb0 for 9346 - 823/19/16 vaddr */
+    /* MDT  249248 (819/17/0) 0x3cda0 for 9346 - 823/19/16 daddr */
+    /* DMAP 249232 (819/16/0) 0x3cd90 for 9346 - 823/19/16 faddr */
+    /* UMAP 249216 (819/15/0) 0x3cd80 for 9346 - 823/19/16 uaddr */
 
     /* seek to sector 0 */
     if ((sim_fseek(uptr->fileref, 0, SEEK_SET)) != 0) { /* seek home */
@@ -953,7 +1265,7 @@ int scsi_format(UNIT *uptr) {
     }
 
     /* get buffer for track data */
-    if ((buff = (uint8 *)calloc(tsize*ssize, sizeof(uint8))) == 0) {
+    if ((buff = (uint8 *)calloc(csize*ssize, sizeof(uint8))) == 0) {
         detach_unit(uptr);
         return SCPE_ARG;
     }
@@ -965,9 +1277,10 @@ int scsi_format(UNIT *uptr) {
     sim_debug(DEBUG_CMD, dptr,
         "Creating disk file of trk size %04x bytes, capacity %d\n",
         tsize*ssize, cap*ssize);
+
     /* write zeros to each track of the disk */
     for (cyl = 0; cyl < cylv; cyl++) {
-        if ((sim_fwrite(buff, 1, tsize*ssize, uptr->fileref)) != tsize*ssize) {
+        if ((sim_fwrite(buff, 1, csize*ssize, uptr->fileref)) != csize*ssize) {
             sim_debug(DEBUG_CMD, dptr,
                 "Error on write to diskfile cyl %04x\n", cyl);
             free(buff);                         /* free cylinder buffer */
@@ -987,6 +1300,107 @@ int scsi_format(UNIT *uptr) {
     fputc('\n', stderr);
     free(buff);                                 /* free cylinder buffer */
     buff = 0;
+
+    /* byte swap the buffers for dmap and umap */
+    for (i=0; i<2; i++) {
+        vmap[i] = (((vmap[i] & 0xff) << 24) | ((vmap[i] & 0xff00) << 8) |
+            ((vmap[i] & 0xff0000) >> 8) | ((vmap[i] >> 24) & 0xff));
+    }
+    for (i=0; i<4; i++) {
+        dmap[i] = (((dmap[i] & 0xff) << 24) | ((dmap[i] & 0xff00) << 8) |
+            ((dmap[i] & 0xff0000) >> 8) | ((dmap[i] >> 24) & 0xff));
+    }
+    for (i=0; i<4; i++) {
+        fmap[i] = (((fmap[i] & 0xff) << 24) | ((fmap[i] & 0xff00) << 8) |
+            ((fmap[i] & 0xff0000) >> 8) | ((fmap[i] >> 24) & 0xff));
+    }
+    for (i=0; i<256; i++) {
+        umap[i] = (((umap[i] & 0xff) << 24) | ((umap[i] & 0xff00) << 8) |
+            ((umap[i] & 0xff0000) >> 8) | ((umap[i] >> 24) & 0xff));
+    }
+
+    /* now seek to end of disk and write the dmap data */
+    /* setup dmap pointed to by track label 0 wd[3] = (cyl-4) * spt + (spt - 1) */
+
+    /* write dmap data to last sector on disk */
+    if ((sim_fseek(uptr->fileref, laddr*ssize, SEEK_SET)) != 0) { /* seek last sector */
+        sim_debug(DEBUG_CMD, dptr,
+        "Error on last sector seek to sect %06x offset %06x\n",
+        cap-1, (cap-1)*ssize);
+        return 1;
+    }
+    if ((sim_fwrite((char *)&dmap, sizeof(uint32), 4, uptr->fileref)) != 4) {
+        sim_debug(DEBUG_CMD, dptr,
+        "Error writing DMAP to sect %06x offset %06x\n",
+        cap-1, (cap-1)*ssize);
+        return 1;
+    }
+
+    /* seek to vendor label area VMAP */
+    if ((sim_fseek(uptr->fileref, vaddr*ssize, SEEK_SET)) != 0) { /* seek VMAP */
+        sim_debug(DEBUG_CMD, dptr,
+        "Error on vendor map seek to sect %06x offset %06x\n",
+        vaddr, vaddr*ssize);
+        return 1;
+    }
+    if ((sim_fwrite((char *)&vmap, sizeof(uint32), 2, uptr->fileref)) != 2) {
+        sim_debug(DEBUG_CMD, dptr,
+        "Error writing VMAP to sect %06x offset %06x\n",
+        vaddr, vaddr*ssize);
+        return 1;
+    }
+
+    /* write DMAP to daddr that is the address in trk 0 label */
+    if ((sim_fseek(uptr->fileref, daddr*ssize, SEEK_SET)) != 0) { /* seek DMAP */
+        sim_debug(DEBUG_CMD, dptr,
+        "Error on diag map seek to sect %06x offset %06x\n",
+        daddr, daddr*ssize);
+        return 1;
+    }
+    if ((sim_fwrite((char *)&dmap, sizeof(uint32), 4, uptr->fileref)) != 4) {
+        sim_debug(DEBUG_CMD, dptr,
+        "Error writing DMAP to sect %06x offset %06x\n",
+        daddr, daddr*ssize);
+        return 1;
+    }
+
+    /* write dummy DMAP to faddr */
+    if ((sim_fseek(uptr->fileref, faddr*ssize, SEEK_SET)) != 0) { /* seek DMAP */
+        sim_debug(DEBUG_CMD, dptr,
+        "Error on media flaw map seek to sect %06x offset %06x\n",
+        faddr, faddr*ssize);
+        return 1;
+    }
+    if ((sim_fwrite((char *)&dmap, sizeof(uint32), 4, uptr->fileref)) != 4) {
+        sim_debug(DEBUG_CMD, dptr,
+        "Error writing flaw map to sect %06x offset %06x\n",
+        faddr, faddr*ssize);
+        return 1;
+    }
+
+    /* write UTX umap to uaddr */
+    if ((sim_fseek(uptr->fileref, uaddr*ssize, SEEK_SET)) != 0) { /* seek UMAP */
+        sim_debug(DEBUG_CMD, dptr,
+        "Error on umap seek to sect %06x offset %06x\n",
+        uaddr, uaddr*ssize);
+        return 1;
+    }
+    if ((sim_fwrite((char *)&umap, sizeof(uint32), 256, uptr->fileref)) != 256) {
+        sim_debug(DEBUG_CMD, dptr,
+        "Error writing UMAP to sect %06x offsewt %06x\n",
+        uaddr, uaddr*ssize);
+        return 1;
+    }
+
+    printf("writing to vmap sec %x (%d) bytes %x (%d)\n",
+        vaddr, vaddr, (vaddr)*ssize, (vaddr)*ssize);
+    printf("writing to flaw map sec %x (%d) bytes %x (%d)\n",
+        faddr, faddr, (faddr)*ssize, (faddr)*ssize);
+    printf("writing dmap to %x %d %x %d dmap to %x %d %x %d\n",
+       cap-1, cap-1, (cap-1)*ssize, (cap-1)*ssize,
+       daddr, daddr, daddr*ssize, daddr*ssize);
+    printf("writing to umap sec %x (%d) bytes %x (%d)\n",
+        uaddr, uaddr, (uaddr)*ssize, (uaddr)*ssize);
 
     /* seek home again */
     if ((sim_fseek(uptr->fileref, 0, SEEK_SET)) != 0) { /* seek home */
@@ -1017,8 +1431,8 @@ t_stat scsi_attach(UNIT *uptr, CONST char *file) {
     uptr->capac = CAP(type);                    /* disk capacity in sectors */
     ssize = SSB(type);                          /* get sector size in bytes */
 
-    sim_debug(DEBUG_CMD, dptr, "Disk %s cyl %d hds %d sec %d ssiz %d capacity %d\n",
-        scsi_type[type].name, scsi_type[type].cyl, scsi_type[type].nhds, 
+    sim_debug(DEBUG_CMD, dptr, "Disk %s %04x cyl %d hds %d sec %d ssiz %d capacity %d\n",
+        scsi_type[type].name, addr, scsi_type[type].cyl, scsi_type[type].nhds, 
         scsi_type[type].spt, ssize, uptr->capac); /* disk capacity */
 
 
@@ -1029,12 +1443,12 @@ t_stat scsi_attach(UNIT *uptr, CONST char *file) {
 
     /* read in the 1st sector of the 'disk' */
     if ((r = sim_fread(&buff[0], sizeof(uint8), ssize, uptr->fileref) != ssize)) {
-        sim_debug(DEBUG_CMD, &sca_dev, "Disk format fread ret = %04x\n", r);
+        sim_debug(DEBUG_CMD, dptr, "Disk format fread ret = %04x\n", r);
         goto fmt;
     }
 
     if ((buff[0] | buff[1] | buff[2] | buff[3]) == 0) {
-        sim_debug(DEBUG_CMD, &sca_dev,
+        sim_debug(DEBUG_CMD, dptr,
         "Disk format buf0 %02x buf1 %02x buf2 %02x buf3 %02x\n",
         buff[0], buff[1], buff[2], buff[3]);
 fmt:
@@ -1052,13 +1466,13 @@ fmt:
 
     uptr->CHS = 0;                              /* set CHS to cyl/hd/sec = 0 */
 
-    sim_debug(DEBUG_CMD, &sca_dev,
-        "Attach %s cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\n",
-        scsi_type[type].name, CYL(type), HDS(type), SPT(type), SPC(type),  
+    sim_debug(DEBUG_CMD, dptr,
+        "Attach %s %04x cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\n",
+        scsi_type[type].name, addr, CYL(type), HDS(type), SPT(type), SPC(type),  
         CAP(type), CAPB(type));
 
-    sim_debug(DEBUG_CMD, &sca_dev, "File %s attached to %s\r\n",
-        file, scsi_type[type].name);
+    sim_debug(DEBUG_CMD, dptr, "File %s at addr %04x attached to %s\r\n",
+        file, addr, scsi_type[type].name);
 
     set_devattn(addr, SNS_DEVEND);
     return SCPE_OK;
@@ -1067,7 +1481,7 @@ fmt:
 /* detach a disk device */
 t_stat scsi_detach(UNIT *uptr) {
     uptr->SNS = 0;                              /* clear sense data */
-    uptr->CMD &= ~0xffff;                       /* no cmd and flags */
+    uptr->CMD &= LMASK;                         /* no cmd and flags */
     return detach_unit(uptr);                   /* tell simh we are done with disk */
 }
 
@@ -1075,11 +1489,16 @@ t_stat scsi_detach(UNIT *uptr) {
 t_stat scsi_boot(int32 unit_num, DEVICE *dptr) {
     UNIT    *uptr = &dptr->units[unit_num];     /* find disk unit number */
 
-    sim_debug(DEBUG_CMD, &sca_dev, "SCSI Disk Boot dev/unit %04x\n", GET_UADDR(uptr->CMD));
+    sim_debug(DEBUG_CMD, dptr, "SCSI Disk Boot dev/unit %04x\n", GET_UADDR(uptr->CMD));
+
+    if ((uptr->flags & UNIT_ATT) == 0) {
+        sim_debug(DEBUG_EXP, dptr, "SCSI Disk Boot attach error dev/unit %04x\n",
+            GET_UADDR(uptr->CMD));
+        return SCPE_UNATT;                      /* attached? */
+    }
+
     SPAD[0xf4] = GET_UADDR(uptr->CMD);          /* put boot device chan/sa into spad */
     SPAD[0xf8] = 0xF000;                        /* show as F class device */
-    if ((uptr->flags & UNIT_ATT) == 0)
-        return SCPE_UNATT;                      /* attached? */
     return chan_boot(GET_UADDR(uptr->CMD), dptr);    /* boot the ch/sa */
 }
 
@@ -1122,7 +1541,7 @@ t_stat scsi_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag,
     const char *cptr)
 {
     int i;
-    fprintf (st, "SEL-32 MFP SCSI Disk Controller\r\n");
+    fprintf (st, "SEL-32 MFP SCSI Buss Disk Controller\r\n");
     fprintf (st, "Use:\r\n");
     fprintf (st, "    sim> SET %sn TYPE=type\r\n", dptr->name);
     fprintf (st, "Type can be: ");

--- a/SEL32/sel32_sys.c
+++ b/SEL32/sel32_sys.c
@@ -105,6 +105,12 @@ DEVICE *sim_devices[] = {
         &dpb_dev,
 #endif
 #endif
+#ifdef NUM_DEVS_SCSI
+        &sba_dev,
+#if NUM_DEVS_SCSI > 1
+        &sbb_dev,
+#endif
+#endif
 #ifdef NUM_DEVS_COM
         &coml_dev,
         &com_dev,
@@ -813,7 +819,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
     int      mode = 0;                              /* assume non base mode instructions */
     t_opcode *tab;
 
-///    printf("inst %x sw %x\r\n", val, sw);
+//  printf("inst %x sw %x\r\n", val, sw);
     if ((PSD[0] & 0x02000000) || (sw & SWMASK('M'))) /* bit 6 is base mode */
         mode = 1;
     /* loop through the instruction table for an opcode match and get the type */ 

--- a/SEL32/taptools/README.md
+++ b/SEL32/taptools/README.md
@@ -69,7 +69,7 @@ mkfmtape - This program creates an MPX 1.x filemgr save tape.  The
 
            command mkfmtape opts output.tap file1 file2 ...
            input - list of filename to save to tape.
-           output - output.tap a tap formated file.
+           output - output.tap a tap formatted file.
            options - -p = file type 0xca for programs
                    - -t = ascii text file 0xee
                    - -l = library/directory file 0xff
@@ -77,27 +77,29 @@ mkfmtape - This program creates an MPX 1.x filemgr save tape.  The
                    - -a = append entries to current file
                    - -u = username (directory)
 
-sdtfmgrcopy - This program reads a MPX 1.x filemgr save tape or a
-           user SDT followed by filemgr saves.  The filemgr tape 
-           must contain a filemgr save image with 4608 byte records.
-           A sdt tape starts with a 1920 byte record followed by
-           multiple 768 byte records to finish the sdt system image.
-           A sdt tape can be followed by one or more filemgr save
-           images of 4608 bytes. The boot image is put into bootfile1
-           in the current directory.  The program will create a
-           directory in the current directory for each different
-           username.  A null username will be the system directory.
-           Within each directory each file contained on the tape is
-           extracted and written as binary data to the named file.
-           The .tap file MUST be a filemgr save tape and not a
-           MPX 3.x volmgr save tape.
+mkvmtape - This program reads MPX files and stores them into a
+           simulated volmgr save tape. The tape may then become a 
+           MPX 3.X sdt boot tape to install MPX 3.X from or a volmgr
+           file restore tape for a running MPX system.  The output
+           will be in SIMH simulated .tap format.
 
-           command sdtfmgrcopy file.tap >stdout
-           input - file.tap file to dump
-           output - stdout filelist and sizes
-           output - if tape contains a sdt image, it will be output
-                    to the file bootfil1
-           output - directory/files extracted to current directory
+           command mkfmtape [-ptloa] [-bboot] [-iimage] [-jj.vfmt]
+                            [-uusername] tapname file1 file2 ...
+           intput - [options] volmtape filename, filename, etc.
+           output - volmtape file, file list to stdout
+
+           options - -p = file type 0xca for programs
+                   - -t = ascii text file 0xee
+                   - -l = library/directory file 0xff
+                   - -o = other 0x00
+                   - -a = append entries to current file
+                   - -u = username (username)
+                   - -d = dirname (directory)
+                   - -v = volname (volume)
+                   - -b = bootfile name
+                   - -i = system image file
+                   - -j = j.vfmt filename
+                   04/11/2020 update for mpx3.x
 
 diagcopy - This program reads a SEL .tap diagnostic boot tape and splits
            the contents into multiple files.  The first tape record
@@ -220,4 +222,4 @@ small -   Remove line numbers and trailing blanks from an ascii '\n'
           output -   write stripped ascii file to stdout
 
 James C. Bevier
-03/10/2020
+04/21/2020

--- a/SEL32/taptools/diagcopy.c
+++ b/SEL32/taptools/diagcopy.c
@@ -34,11 +34,11 @@ int smd = 0;
 int getloi(char *s, int lim)
 {
     int c, i;
-    int32_t n1, n2, hc, tc, n;
+    int n1, n2, hc, tc, n;
 
     errno = 0;
     /* read the byte count in 32 bit word as header */
-    n1 = read(inp, (char *)(&hc), (size_t)sizeof(hc));
+    n1 = read(inp, (char *)(&hc), (size_t)4);
     if (n1 <= 0)
         hc = -1;        /* at EOM on disk file */
 
@@ -71,8 +71,16 @@ int getloi(char *s, int lim)
 
     /* read the data */
     n = read(inp, s, (size_t)hc);
+
+    /* if odd byte record, read extra byte and throw it away */
+    if (n & 0x1) {
+        n2 = read(inp, (char *)(&tc), (size_t)1);
+        if (n2 <= 0)
+            return -1;          /* at EOM on disk file */
+    }
+
     /* read the byte count in 32 bit word as trailer */
-    n2 = read(inp, (char *)(&tc), (size_t)sizeof(tc));
+    n2 = read(inp, (char *)(&tc), (size_t)4);
     count++;        /* bump record count */
     size += n;      /* update bytes read */
     EOFcnt = 0;     /* not an EOF */

--- a/SEL32/taptools/diskload.c
+++ b/SEL32/taptools/diskload.c
@@ -82,8 +82,7 @@ char *argv[];
                 fprintf(stderr, "Usage: %s -la program diskfile\n", *--argv);
                 exit(1);
             }
-        }
-        else {
+        } else {
             argc++;
             argv--;
         }

--- a/SEL32/taptools/fmgrcopy.c
+++ b/SEL32/taptools/fmgrcopy.c
@@ -39,7 +39,7 @@ int getloi(char *s, int lim)
 
     errno = 0;
     /* read the byte count in 32 bit word as header */
-    n1 = read(inp, (char *)(&hc), (size_t)sizeof(hc));
+    n1 = read(inp, (char *)(&hc), (size_t)4);
     if (n1 <= 0)
         hc = -1;        /* at EOM on disk file */
 
@@ -68,8 +68,16 @@ int getloi(char *s, int lim)
 
     /* read the data */
     n = read(inp, s, (size_t)hc);
+
+    /* if odd byte record, read extra byte and throw it away */
+    if (n & 0x1) {
+        n2 = read(inp, (char *)(&tc), (size_t)1);
+        if (n2 <= 0)
+            return -1;          /* at EOM on disk file */
+    }
+
     /* read the byte count in 32 bit word as trailer */
-    n2 = read(inp, (char *)(&tc), (size_t)sizeof(tc));
+    n2 = read(inp, (char *)(&tc), (size_t)4);
     count++;        /* bump record count */
     size += n;      /* update bytes read */
     EOFcnt = 0;     /* not an EOF */

--- a/SEL32/taptools/loadMPXfile.txt
+++ b/SEL32/taptools/loadMPXfile.txt
@@ -1,0 +1,119 @@
+Following are the instructions for loading an ASCII file to an
+MPX-1.X system.  It is assumed that the reader has compiled the
+utilities in the taptools directory using the provided makefile.
+Filenames on MPX-1.X must be 8 chars or less.
+
+1. Create an ASCII file on Windows or Linux using your favorite editor.
+   The EDIT program on MPX works with numbered or unnumbered text files.
+   Each record in the text file uses columns 1-72 for text and columns
+   73-80 for a line number (xxx.xxx).  This is 80 column card format.
+
+2. To convert a newline terminated file to an MPX file use the utility
+   "renum" included in the taptools directory. Lines in the file will
+   be expanded to 72 characters or truncated to 72 characters. The
+   carriage return characters (\r) will be removed and lines will be
+   terminated with a newline (\n).  Line numbers of the form (xxx.xxx)
+   will then be appended to the text line to create the card format.
+   /somewhere/renum <textfile >cardfile
+   
+3. The next step is to convert the card image text file to an MPX
+   blocked file format.  This involves removing the carriage return
+   character and then encoding the line into the blocked format.
+   The block file format is the standard file format for MPX.
+   /somewhere/mpxblk <cardfile >blkfile
+
+4. Once we have the files converted, the next step involves creating
+   a FILEMGR formatted save tape.  The output file will be in SIMH
+   .tap simulated tape format.  The tape can then be read by the
+   FILEMGR on MPX to load the files into the desired directory.
+   The file system on MPX is a flat file where all files are in
+   the same file system.  A username is used to separate files for
+   each user.  A blank filename implies the system directory.
+   /somewhere/mkfmtape -t -u username usertape.tap file1 file2 ...
+   Valid options are:
+   -p : use file type 0xca for executable programs
+   -t : use file type 0xee for text files
+   -l : use file type 0xff for library files
+   -a : append current files to output tape
+   -u username : the username (directory) for the files
+
+    Make sure the usertape.tap file is assigned to the tape drive
+    in the .ini file or use the following commands at the sim>
+    prompt for SEL32.
+    hit ^E to get the sim> prompt.
+    sim>detach mta0                remove current assignment
+    sim>attach mta0 usertape.tap   assign your restore tape
+    sim>go
+
+5. Boot MPX-1.X.  Input @@A to get OPCOM prompt ??.  Use cap lock for
+   uppercase input.  Type "EXIT" to OPCOM prompt to get a TSM> prompt.
+   If you type WHO, TSM will display your current logon information. 
+
+TSM>WHO
+ADDRESS    OWNERNAME   USERNAME
+=======    =========   ========
+*TY7EFC    CONSOLE              
+
+   The username will be blank for system directory.  Use the command
+   TSM>USERNAME JOHNDOE to set username to the one specified in the
+   -u option above or just TSM>USERNAME to make it blank.  There is a
+   command file on MPX that is handy to restore files from tape that
+   does the device assignments to the FILEMGR program.  The file is
+   FMGR and can be run to input files from the assigned tape.  MPX-1.X
+   has been SYSGEN'd to have 4 tape drives defined at 1000, 1001, 1002,
+   & 1003.  SIMH names are mta0, mta1, mta2, & mta3.  So attach the
+   restore file to mta0 as show above.  Now execute the FILEMGR program.
+   TSM>FMGR 1000
+TSM>FMGR 1000
+                             * * *   F I L E    M A N A G E R   * * *
+ FUNCTION   USER NAME  FILE NAME  DEVICE   START      LENGTH     SPEED
+                                         (FIRST BLK) (# BLKS)
+
+   FILEMGR output will be assigned to the terminal and tape input from
+   device MT1000. The FILEMGR will output a heading and then the FILEMGR
+   prompt FIL>.  At this point you can use the command FIL>SAVELOG to
+   list the files on the tape or you can use the command FIL>RESTORE to
+   restore the files to the disk.  You can then type EXIT or X to the
+   FIL> prompt to exit the FILEMGR.
+FIL>RESTORE
+ RESTORE  JOHNDOE   FILE1    DM0800      234656       1052       SLOW    
+FIL>REWIND IN
+       REWIND          (IN)    
+FIL>X
+TSM>
+   If you would like to see your files listed in the system, use
+   FMGR again without any parameters.  Then use LOGU to log your
+   username files or LOG to log all files.
+TSM>FMGR
+   heading here
+FIL>LOGU
+ LOG      JOHNDOE     FILE1      DM0800     234656     1052     SLOW
+ LOG      JOHNDOE     XX*WRKFL   DM0800     233536     1120     SLOW
+FIL>LOG
+ LOG                  1X.PRE     DM0800     302916       24     SLOW
+ LOG                  7X.PRE     DM0800     302892       24     SLOW
+ LOG                  ALOC.L     DM0800     241312      800     SLOW
+ LOG                  ASM        DM0800     302884        8     SLOW
+ LOG                  ASSEMBLE   DM0800     296784       84     SLOW
+ LOG                  ASSM       DM0800     302872       12     SLOW
+ LOG                  ASSMJ      DM0800     302864        8     SLOW
+ LOG                  ASSML      DM0800     302860        4     SLOW
+ LOG                  BOOT27     DM0800     303424       24     SLOW
+   all files list here
+
+6. You can use the program EDIT to view or modify the file.  At the
+   TSM> prompt type EDIT XX, where XX is a two character editor
+   workfile name.  It will show up in the directory listing as XX*WRKFL.
+   At the EDT> prompt type USE FILE1.  You will get another prompt when
+   the editor is done reading the file.  Hit return to list the file.
+
+TSM>EDIT XX
+ BEGIN TEXT EDITOR     
+XX*WRKFL CLEAR
+EDT> USE FILE1
+   File listing will be here.
+
+See the MPX-1.X reference manuals for the other FILEMGR and EDIT commands.
+
+Jim Bevier
+03/10/2020

--- a/SEL32/taptools/makefile
+++ b/SEL32/taptools/makefile
@@ -27,6 +27,7 @@ PROGS =			\
 	$(ROOT)/filelist \
 	$(ROOT)/fmgrcopy \
 	$(ROOT)/mkfmtape \
+	$(ROOT)/mkvmtape \
 	$(ROOT)/sdtfmgrcopy \
 	$(ROOT)/tapdump	\
 	$(ROOT)/tape2disk \
@@ -76,6 +77,12 @@ $B/fmgrcopy:	$D fmgrcopy.c
 	@echo $(@F) installed in $B
 
 $B/mkfmtape:	$D mkfmtape.c
+	@-$(CC) $(CFLAGS) $(@F).c $(LFLAGS) -o $@
+	@chmod 755 $@
+	@cp $(@F) $B
+	@echo $(@F) installed in $B
+
+$B/mkvmtape:	$D mkvmtape.c
 	@-$(CC) $(CFLAGS) $(@F).c $(LFLAGS) -o $@
 	@chmod 755 $@
 	@cp $(@F) $B

--- a/SEL32/taptools/mkvmtape.c
+++ b/SEL32/taptools/mkvmtape.c
@@ -1,0 +1,728 @@
+/*
+ * mkvmtape.c
+ *
+ * This program reads MPX files and stores them into a simulated
+ * volmgr save tape. The tape may then become an sdt boot tape
+ * to install MPX from or a volmgr file restore tape on a running
+ * MPX system.
+ *
+ * intput - [options] volmtape filename, filename, etc.
+ * output - volmtape file, file list to stdout
+ *
+ * options - -p = file type 0xca for programs
+ *         - -t = ascii text file 0xee
+ *         - -l = library/directory file 0xff
+ *         - -o = other 0x00
+ *         - -a = append entries to current file
+ *         - -u = username (username)
+ *         - -d = dirname (directory)
+ *         - -v = volname (volume)
+ *         - -b = bootfile name
+ *         - -i = system image file
+ *         - -j = j.vfmt filename
+ * 04/11/2020 update for mpx3.x
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <string.h>
+
+#define MASK24 0x00ffffff
+
+/* memory access macros */
+/* The RMW and WMW macros are used to read/write memory words */
+/* RMW(addr) or WMW(addr, data) where addr is a byte alligned word address */
+#define RMB(a) ((M[(a)>>2]>>(8*(7-(a&3))))&0xff)    /* read memory addressed byte */
+#define RMH(a) ((a)&2?(M[(a)>>2]&RMASK):(M[(a)>>2]>>16)&RMASK)  /* read memory addressed halfword */
+#define RMW(a) (M[((a)&MASK24)>>2])     /* read memory addressed word */
+#define WMW(a,d) (M[((a)&MASK24)>>2]=d) /* write memory addressed word */
+/* write halfword to memory address */
+#define WMH(a,d) ((a)&2?(M[(a)>>2]=(M[(a)>>2]&LMASK)|((d)&RMASK)):(M[(a)>>2]=(M[(a)>>2]&RMASK)|((d)<<16)))
+/* write byte to memory */
+#define WMB(a,d) (M[(a)>>2]=(((M[(a)>>2])&(~(0xff<<(8*(7-(a&3))))))|((d&0xff)<<(8*(7-(a&3))))))
+
+#define BLKSIZE 768                     /* MPX file sector size */
+u_int32_t dir[32];                      /* directory name */
+u_int32_t vol[32];                      /* volume name */
+unsigned char data[4608];               /* room for 6*768=(4608) 768 byte sectors per 4608 byte block */
+unsigned char bigdata[19200];           /* room for 6*768=(4608) 768 byte sectors per 4608 byte block */
+u_int32_t M[768];                       /* fake memory */
+unsigned char bootcode[2048];           /* room for bootcode */
+unsigned char savelist[6144];           /* room for 8 byte flags, 127 (48 char) file names */
+int16_t     savecnt = 0;                /* entries in save list */
+char sysname[16] = "SYSTEM          ";
+
+/* write 1 file to tape in 768 byte records */
+int writefile(FILE *tp, char *fnp, u_int32_t mblks) {
+    u_int32_t word, blks;                   /* just a temp word variable */         
+    u_int32_t size, bsize;                  /* size in 768 byte sectors */
+    FILE *fp;
+    int32_t n1, n2, hc, nw;
+
+    memset((char *)data, 0, sizeof(data));  /* zero data storage */
+    /* write file to tape */
+    if ((fp = fopen(fnp, "r")) == NULL) {
+        fprintf(stderr, "error: can't open user file %s\n", fnp);
+        exit(1);
+    }
+    fseek(fp, 0, SEEK_END);                 /* seek to end */
+    word = ftell(fp);                       /* get filesize in bytes */
+printf("MPX file %s is %x (%d) bytes\n", fnp, word, word);
+    fseek(fp, 0, SEEK_SET);                 /* rewind file */
+    size = (word/768);                      /* filesize in sectors */
+    if (word%768 != 0)                      /* see if byte left over */
+        size += 1;                          /* partial sector, add 1 */
+    if (mblks == 0) {
+        blks = (word/768);                  /* blocks */
+        if ((word%768) != 0)                /* round up blks if remainder */
+            blks++; 
+    } else {
+        blks = mblks;                       /* write user specified blocks */
+    }
+    bsize = blks;                           /* save # blks */
+
+    /* read in the image file */
+    while ((bsize-- > 0) && fread((char *)data, 1, 768, fp) > 0) {
+        /* we have data to write */
+        hc = (768 + 1) & ~1;                /* make byte count even */
+        /* write actual byte count to 32 bit word as header */
+        n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), tp);
+        /* write the data mod 2 */
+        nw = fwrite((unsigned char *)data, 1, (size_t)hc, tp);
+        /* write the byte count in 32 bit word as footer */
+        n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), tp);
+        if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc))
+        {
+            fprintf(stderr, "write to %s failure\n", fnp);
+            fprintf(stderr, "Operation aborted\n");
+            exit(1);
+        }
+        memset((char *)data, 0, 768);       /* zero data storage */
+    }
+    printf("write file %s (size %d bytes) (%d sect) (%d blocks)\n",
+        fnp, word, size, blks);
+    fclose(fp);
+}
+
+u_int32_t readboot(char *name, char *buf, u_int32_t start, u_int32_t end) {
+    u_int32_t word = end-start+4;           /* just a temp word variable */         
+    FILE *fp;
+    int32_t n1, n2;
+
+    memset((char *)bootcode, 0, sizeof(bootcode));  /* zero data storage */
+    if ((fp = fopen(name, "r")) == NULL) {
+        fprintf(stderr, "error: can't open user file %s\n", name);
+        exit(1);
+    }
+    fseek(fp, start, 0);                    /* seek to boot code */
+    n1 = fread(bootcode, 1, word, fp);      /* read bootcode */
+    if (n1 <=0)                             /* check for read error */
+        exit(1);                            /* bad tape format */
+printf("MPX bootfile %s is %x (%d) bytes\n", name, word, word);
+    fclose(fp);
+    fopen("volmboot", "w");
+    fwrite(bootcode, 1, word, fp);
+    fclose(fp);
+    for (n2=0; n2<word; n2++)
+        buf[n2] = bootcode[n2];
+    return word;
+}
+
+/* byte swap the 32 bit word */
+u_int32_t flip(u_int32_t val) {
+    /* byte swap the buffers for dmap and umap */
+    return (((val & 0xff) << 24) | ((val & 0xff00) << 8) |
+            ((val & 0xff0000) >> 8) | ((val >> 24) & 0xff));
+}
+
+/* read program file and output to a simulated mpx3.x volmgr savetape */
+/* mkvmtape [opt] volmtape, filename, filename, ... */
+int main(argc, argv)
+int argc;
+char *argv[];
+{
+    FILE    *fp, *dp, *fopen();
+    int     targc;
+    char    **targv;
+    unsigned char username[32];
+    unsigned char bootname[32];
+    unsigned char imgname[32];
+    unsigned char vfmtname[32];
+    unsigned char volname[32];
+    unsigned char dirname[32];
+    char *p;
+    int i;
+#define DOPROG  1
+#define DOADD  2
+#define DOOTHER  4
+#define DOTEXT  8
+#define DOLIB  16
+#define DOUSER  32
+#define DOBOOT  64
+#define DOIMG  128
+#define DOVFMT 256
+#define DOVOL 512
+#define DODIR 1024
+    unsigned int option = DOTEXT;           /* what to do */
+    unsigned char *fnp;                     /* file name pointer */
+    unsigned int size;                      /* size in 768 byte sectors */
+    unsigned int word;                      /* just a temp word variable */         
+    unsigned char name[128];                /* LM name */
+    unsigned int typ;                       /* file type requested by user */
+    char *userp = username;                 /* pointer to username */
+    char *bootp = bootname;                 /* pointer to boot file name */
+    char *imgp= imgname;                    /* pointer to image file name */
+    char *vfmtp = vfmtname;                 /* pointer to j.vfmt file name */
+    int ofd;                                /* output file number */
+    int32_t filen;                          /* file number */
+//  u_int32_t *dirp = dir;                  /* directory entry pointer */
+//  u_int32_t *volp = vol;                  /* volume entry pointer */
+    char *dirp = dirname;                   /* directory entry pointer */
+    char *volp = volname;                   /* volume entry pointer */
+    int32_t totent;                         /* total smd entries */
+    char    j_vfmt[] = {"!VOLSYST!DIRSYST!FIL    J.VFMT          "};
+    char    j_mount[] = {"!VOLSYST!DIRSYST!FIL    J.MOUNT         "};
+    char    j_swapr[] = {"!VOLSYST!DIRSYST!FIL    J.SWAPR         "};
+    char    volmgr[] = {"!VOLSYST!DIRSYST!FIL    VOLMGR          "};
+
+//  memset((char *)dir, 0, 4608);           /* zero smd storage */
+    memset((char *)data, 0, 4608);          /* zero data storage */
+    for (i=0; i<32; i++)
+        username[i] = 0;                    /* use zero for system username */
+    typ = 0xee000000;                       /* set type */
+    if (argc <= 1) {                        /* see if correct # args */
+        fprintf(stderr,
+            "Usage: %s [-ptloa] [-bboot] [-iimage] [-jj.vfmt] [-uusername] vmgrtape file1 file2 ...\n",
+            *argv);
+        exit(1);
+    }
+    while(--argc > 0) {
+//      printf("argc %d argv %s\n", argc, *argv);
+        p = *++argv;
+        if (*p++ == '-') {
+            if (*p == '\0') {
+                fprintf(stderr, "Error: no option specified\n");
+                fprintf(stderr,
+            "Usage: %s [-ptloa] [-bboot] [-iimage] [-jj.vfmt] [-uusername] vmgrtape file1 file2 ...\n",
+                    *argv);
+                exit(1);
+            }
+//          printf("doing options %s\n", p);
+            while (*p != '\0') {
+                switch (*p++) {
+                    case 'b':
+                    case 'B':
+                        if (option & DOADD) { /* error if append specified with boot command */
+                            fprintf(stderr, "Error: -b cannot be specified with -a option\n");
+                            goto error1;    /* we are done here */
+                        }
+                        option |= DOBOOT;   /* save boot code, mpx image, and j.vfmt */
+                        if (*p == '\0') {
+                            p = *++argv;    /* next parameter */
+                            --argc;         /* one less arg */
+                        };
+                        bootp = p;
+                        while (*p != '\0')
+                            p++;
+                        typ = 0xca;         /* set type */
+                        break;
+                    case 'i':
+                    case 'I':
+                        option |= DOIMG;    /* save mpx image filename */
+                        if (*p == '\0') {
+                            p = *++argv;    /* next parameter */
+                            --argc;         /* one less arg */
+                        };
+                        imgp = p;
+                        while (*p != '\0')
+                            p++;
+                        typ = 0xca;         /* set type */
+                        break;
+                    case 'j':
+                    case 'J':
+                        option |= DOVFMT;   /* save j.vfmt file name */
+                        if (*p == '\0') {
+                            p = *++argv;    /* next parameter */
+                            --argc;         /* one less arg */
+                        };
+                        vfmtp = p;
+                        while (*p != '\0')
+                            p++;
+                        typ = 0xca;         /* set type */
+                        break;
+                    case 'p':
+                    case 'P':
+                        option |= DOPROG;   /* save program modules */
+                        typ = 0xca;         /* set type */
+                        break;
+                    case 'A':
+                    case 'a':
+                        if (option & DOBOOT) { /* error if boor specified with append command */
+                            fprintf(stderr, "Error: -a cannot be specified with -b option\n");
+                            goto error1;    /* we are done here */
+                        }
+                        option |= DOADD;    /* append to save tape */
+                        break;
+                    case 'O':
+                    case 'o':
+                        option |= DOOTHER;  /* other type files */
+                        typ = 0x00;         /* set type */
+                        break;
+                    case 'T':
+                    case 't':
+                        option |= DOTEXT;   /* save text files */
+                        typ = 0xee;         /* set type */
+                        break;
+                    case 'L':
+                    case 'l':
+                        option |= DOLIB;    /* save library files */
+                        typ = 0xff;         /* set type */
+                        break;
+                    case 'V':
+                    case 'v':
+                        option |= DOVOL;    /* save volume name files */
+                        if (*p == '\0') {
+                            p = *++argv;    /* next parameter */
+                            --argc;         /* one less arg */
+                        };
+                        volp = p;           /* save volume pointer */
+                        while (*p != '\0')
+                            p++;
+                        break;
+                    case 'D':
+                    case 'd':
+                        option |= DODIR;    /* save directory name for files */
+                        if (*p == '\0') {
+                            p = *++argv;    /* next parameter */
+                            --argc;         /* one less arg */
+                        };
+                        dirp = p;
+                        while (*p != '\0')
+                            p++;
+                        break;
+                    case 'U':
+                    case 'u':
+                        option |= DOUSER;   /* save username for files */
+                        if (*p == '\0') {
+                            p = *++argv;    /* next parameter */
+                            --argc;         /* one less arg */
+                        };
+                        userp = p;
+                        while (*p != '\0')
+                            p++;
+                        break;
+                    default:
+                        fprintf(stderr, "Error: no option specified\n");
+error1:
+                        fprintf(stderr,
+            "Usage: %s [-ptloa] [-bboot] [-iimage] [-jj.vfmt] [-uusername] vmgrtape file1 file2 ...\n",
+                            *argv);
+                        exit(1);
+                        break;
+                }   /* end switch */
+                continue;
+            }   /* end while */
+        }
+        else {
+//          printf("option set to %x\n", option);
+            if (option & DOADD) {
+                long bytes;
+                /* open read/write */
+                if ((dp = fopen(*argv, "r+")) == NULL) {
+                    /* file not there, create one by opening w+ */
+                    if ((dp = fopen(*argv, "w")) == NULL) {
+                        fprintf(stderr, "error: can't create/open simulated tape disk file %s\n", *argv);
+                        exit(1);
+                    }
+//                  printf("1 opened output in w mode, write at start\n");
+                }
+//              else
+//                  printf("2 opened output in r+ mode write at end\n");
+
+                fseek(dp, 0, SEEK_END);             /* seek to end */
+                bytes = ftell(dp);                  /* get filesize in bytes */
+                printf("file length %ld bytes\n", bytes);
+                printf("start writing at %ld bytes offset\n", bytes-8);
+                fseek(dp, 0, SEEK_SET);             /* rewind file to beginning */
+                if (bytes > 8) {                    /* see if file written to already */
+                    /* we need to find the EOT */
+                    int32_t n1, n2, hc, tc, n;
+                    int EOFcnt = 0;
+readmore:
+                    n1 = fread((char *)(&hc), 1, (size_t)4, dp);    /* read 4 byte record size */
+                    if (n1 <=0)                     /* check for read error */
+                        goto doabort;               /* bad tape format */
+
+                    if (hc & 0xffff0000)            /* check for garbage */
+                        hc = 0;                     /* assume EOF on disk */
+
+                    if (hc == 0) {                  /* check for EOF on file */
+                        /* EOF found */
+                        if (++EOFcnt == 2) {
+                            /* we have second EOF, we need to backup 4 bytes */
+backup4:
+                            bytes = ftell(dp);      /* get file position in bytes */
+                            fseek(dp, bytes-4, SEEK_SET);   /* backspace over 2nd EOF */
+                            goto getout;            /* start our processing */
+                        }
+                        /* we have first EOF, keep reading */
+                        goto readmore;              /* read more records */
+                    } else
+                    if (hc == -1) {                 /* check for EOM */
+                        if (EOFcnt == 1)
+                            /* see if one EOF followed by EOM (-1) */
+                            goto backup4;           /* start write over the EOM */
+                        /* we have an EOM without any EOF, so bad tape */
+                        goto doabort;               /* bad tape format */
+                    }
+
+                    /* we have data, so no EOF */
+                    EOFcnt = 0;                     /* reset EOF count */
+
+                    /* read the data */
+                    tc = hc;                        /* save record size */
+                    n = fread(bigdata, 1, (size_t)hc, dp);  /* read in record size */
+                    if (n <= 0) {                   /* check for read error */
+                        goto doabort;               /* bad tape format */
+                    }
+                    n2 = fread((char *)(&hc), 1, (size_t)4, dp);    /* read 4 byte record size */
+                    if (n2 <= 0) {                  /* check for read error */
+doabort:
+                        /* error, abort the operation */
+                        fprintf(stderr, "error: formatting error on simulated tape disk file %s\n", *argv);
+                        exit(1);
+                    }
+                    /* verify counts & sizes */
+                    if ((tc != hc) || (hc != n)) 
+                        goto doabort;               /* bad tape format */
+                    goto readmore;                  /* read more records */
+                }
+            }
+            else {
+                if ((dp = fopen(*argv, "w")) == NULL) {
+                    fprintf(stderr, "error: can't create/open simulated tape disk file %s\n", *argv);
+                    exit(1);
+                }
+//              printf("3 opened output in w mode, write at start\n");
+            }
+getout:
+//          printf("opening %s file for tape\n", *argv);
+            *++argv;
+            break;      /* go handle files now */
+        }
+        continue;
+    }
+    /* end while --argc */
+
+    if (!((option & DOBOOT) && (option & DOIMG) && (option & DOVFMT))) {
+        fprintf(stderr, "Error: incorrect number of sdt files, must be three\n");
+        fprintf(stderr, "Usage: %s [-ptloa] [-uusername] fmgrtape, file1 file2 ...\n", *argv);
+        exit(1);
+    }
+    /* process the bootfile first */
+    if (option & DOBOOT) {
+        int32_t w2, n1, n2, nw, hc, blks;
+        fnp = bootp;                                /* get file name pointer */
+#ifdef USE_FILENAME
+        memset((char *)data, 0, 0x800);              /* zero data storage */
+        if ((fp = fopen(bootp, "r")) == NULL) {
+            fprintf(stderr, "error: can't open boot file %s\n", bootp);
+            exit(1);
+        }
+        fseek(fp, 0, SEEK_END);                     /* seek to end */
+        word = ftell(fp);                           /* get filesize in bytes */
+printf("bootfile %s is %x (%d) bytes\n", bootp, word, word);
+        fseek(fp, 0, SEEK_SET);                     /* rewind file */
+        /* bootfile must be <= 0x780 chars */
+//      if (word > 0x780) {
+//          fprintf(stderr, "error: boot file %s greater than 0x780 bytes\n", bootp);
+//          exit(1);
+//      }
+        w2 = fread((char *)data, 1, word, fp);      /* read the boot file */
+#else
+        /* go cut the boot code from the volmgr load module */
+        w2 = readboot("volmgr", (char *)data, 0x1c9a0, 0x1d144);
+#endif
+        /* we have data to write */
+        hc = (w2 + 1) & ~1;                         /* make byte count even */
+//      hc = (0x780 + 1) & ~1;                      /* make byte count even */
+        /* write actual byte count to 32 bit word as header */
+        n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+        /* write the data mod 2 */
+        nw = fwrite((unsigned char *)data, 1, (size_t)hc, dp);
+        /* write the byte count in 32 bit word as footer */
+        n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+        if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc)) {
+            fprintf(stderr, "write (%d) failure\n", nw);
+           fprintf(stderr, "Operation aborted\n");
+           exit(1);
+        }
+        printf("write boot file %s (size %d bytes)\n",
+            bootp, word, word);
+        /* setup for mpx image file */
+        memset((char *)data, 0, 0x800);              /* zero data storage */
+#ifdef USE_FILENAME
+        fclose(fp);
+#endif
+
+        memset((char *)M, 0, 192);                  /* zero data storage */
+        if ((fp = fopen(imgp, "r")) == NULL) {
+            fprintf(stderr, "error: can't open boot file %s\n", imgp);
+            goto error1;                            /* we are done here */
+        }
+        fnp = imgp;                                 /* get file name pointer */
+        fseek(fp, 0, SEEK_END);                     /* seek to end */
+        word = ftell(fp);                           /* get filesize in bytes */
+printf("image file %s is %x (%d) bytes\n", imgp, word, word);
+        fseek(fp, 0, SEEK_SET);                     /* rewind file */
+        w2 = fread((char *)M, sizeof(u_int32_t), 192, fp);  /* read the image file */
+//      n1 = RMW(0x68);                             /* get PR.BYTDR bytes in dsect rel matrix */
+//      n2 = RMW(0x64);                             /* get PR.SFADR sec addr of rel matrix */
+        n1 = flip(M[0x68/4]);                       /* get PR.BYTDR bytes in dsect rel matrix */
+        n2 = flip(M[0x64/4]);                       /* get PR.SFADR sec addr of rel matrix */
+        if (n2 == 0) {                              /* if zero use PR.SFAD rel addr of dsect */
+//          n1 = RMW(0x5C);                         /* get PR.BYTED bytes in dsect */
+//          n2 = RMW(0x58);                         /* get PR.SFADR sec addr of dsect */
+            n1 = flip(M[0x5C/4]);                   /* get PR.BYTED bytes in dsect */
+            n2 = flip(M[0x58/4]);                   /* get PR.SFADR sec addr of dsect */
+            n2 += 1;                                /* add 1 blk for sys debug blk */
+        }
+        blks = n1/768;                              /* get #block rounded mod 768 */
+        if ((n1%768) != 0)                          /* round up blks if remainder */
+            blks++; 
+        blks += n2;                                 /* get total blks to read */
+printf("image file %s n1 %x (%d) n2 %x (%d) blks %x (%d)\n",
+   imgp, n1, n1, n2, n2, blks, blks);
+        fseek(fp, 0, SEEK_SET);                     /* rewind file */
+        fclose(fp);
+
+        /* write mpx image file */
+        writefile(dp, imgp, blks);                  /* write max of "blks" blocks to file */
+
+        /* write j.vfmt file */
+        writefile(dp, vfmtp, 0);
+
+        /* write EOF (zero) to file */
+        filen = 0;                                  /* zero count */
+        fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
+
+        /* write j.mount file */
+        writefile(dp, "j.mount", 0);
+
+        /* write j.swapr file */
+        writefile(dp, "j.swapr", 0);
+
+        /* write volmgr file */
+        writefile(dp, "volmgr", 0);
+
+        /* write EOF (zero) to file */
+        filen = 0;                                  /* zero count */
+        fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
+
+        /* do second EOF */
+        fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
+        filen = -1;                                 /* make in -1 for EOM */
+        /* do EOM */
+        fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
+//  printf("setting at %ld bytes in file after EOM\n", ftell(dp));
+        fclose(dp);
+        exit(0);
+    }
+
+    /* process save files */
+    if ((argc-1) <= 0) {
+        fprintf(stderr, "Error: incorrect number of parameters\n");
+        goto error1;                            /* we are done here */
+    }
+/*------------------------------------------------------------------------*/
+    savecnt = 0;                                /* files yet */
+    /* make first pass over files and get filenames and sizes */
+    /* got tapefile and options, handle files now */
+    targc = argc;                               /* save argc to reread list */
+    targv = argv;                               /* save argv to reread list */
+//  printf("AT 3 argc %d argv %s\n", argc, *argv);
+    filen = 0;                                  /* no files yet */
+    totent = 0;                                 /* no files yet */
+
+    /* save up to 127 file names in 6144 byte record */
+    /* filename/directory/volume */
+    /* wd 1 is 1 for type 1 record */
+    /* wd 2 will be # of 48 byte pathnames */ 
+    memset((char *)savelist, 0, sizeof(savelist));  /* zero data storage */
+    /* populate the 48 byte entry starting at byte 2 */
+//  dirp = (u_int32_t *)dir;                    /* get word pointer for directory */
+//  volp = (u_int32_t *)vol;                    /* get word pointer for volume */
+    dirp = dirname;                             /* get word pointer for directory */
+    volp = volname;                             /* get word pointer for volume */
+    while (--argc > 0) {
+        u_int32_t smd[8];                       /* smd entry data */
+        int blks;
+
+        for (i=0; i<8; i++)                     /* zero smd entry */
+            smd[i] = 0;
+        p = *argv++;
+        i = strlen(p);                          /* filename size */
+        if (i == 0 || i > 8) {
+            fprintf(stderr, "error: Filename too long (%d>8) %s, Aborting\n", i, p);
+            exit(1);
+        }
+//      printf("argc %d argv3 %s\n", argc, p);
+        if ((fp = fopen(p, "r")) == NULL) {
+            fprintf(stderr, "error: can't open user file %s\n", p);
+            exit(1);
+        }
+        fnp = p;                                /* get file name pointer */
+        fseek(fp, 0, SEEK_END);                 /* seek to end */
+        word = ftell(fp);                       /* get filesize in bytes */
+        fseek(fp, 0, SEEK_SET);                 /* rewind file */
+        size = (word/768);                      /* filesize in sectors */
+        if (word%768 != 0)                      /* see if byte left over */
+            size += 1;                          /* partial sector, add 1 */
+        blks = (word/4608);                     /* blocks */
+        if ((word%4608) != 0)
+            blks++; 
+        printf("write SMD %s user %s size %d bytes %d sect %d blocks\n",
+            fnp, userp, word, size, blks);
+        fclose(fp);
+
+        /* create smd entry for this file */
+        memset(name, ' ', 8);                   /* blank filename */
+        for (i=0; i<8; i++) {
+            if (p[i] == '\0')                   /* check for null termination char */
+                break;
+            name[i] = toupper(p[i]);            /* uppercase filename */
+        }
+        /* populate the 32 byte SMD entry */
+        /* word 1 and 2 has filename */
+        smd[0] = name[3] << 24 | name[2] << 16 | name[1] << 8 | name[0];
+        smd[1] = name[7] << 24 | name[6] << 16 | name[5] << 8 | name[4];
+        /* type and smd loc in wd 2  */
+        smd[2] = typ;                           /* save the type of file */
+        /* size now has load module size in sectors */
+        size = 0x80000000 | (blks * 6);         /* file flags and size */
+        smd[3] = (size & 0xff) << 24 | (size & 0xff00) << 8 |
+            (size & 0xff0000) >> 8 | (size & 0xff000000) >> 24;
+        memset(name, ' ', 8);                   /* blank username */
+        for (i=0; i<8; i++) {
+            if (userp[i] == '\0')               /* check for null termination char */
+                break;
+            name[i] = toupper(userp[i]);        /* uppercase username */
+        }
+        /* set username */
+        smd[4] = name[3] << 24 | name[2] << 16 | name[1] << 8 | name[0];
+        smd[5] = name[7] << 24 | name[6] << 16 | name[5] << 8 | name[4];
+        if ((smd[4] == 0x20202020 && smd[5] == 0x20202020) ||
+            (smd[4] == 0 && smd[5] == 0)) {
+            smd[4] = smd[5] = 0;                /* use null for system */
+        }
+        smd[6] = 0x00080000;                    /* no password or udt index */
+        smd[7] = 0x00000080;                    /* fmgr has 0x80000000 in it so I will too */
+        for (i=0; i<8; i++)
+            *dirp++ = smd[i];                   /* save smd entry */
+        filen++;                                /* bump the file count */
+        totent++;                               /* bump total count */
+        if (filen == 144) {                     /* see if entry is full */
+            /* we need to write out the directory entries */
+            int32_t n1, n2, nw;
+            /* we have data to write */
+            int32_t hc = (4608 + 1) & ~1;       /* make byte count even */
+            /* write actual byte count to 32 bit word as header */
+            n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+            /* write the data mod 2 */
+            nw = fwrite((unsigned char *)dir, 1, (size_t)hc, dp);
+            /* write the byte count in 32 bit word as footer */
+            n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+            if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc))
+            {
+                fprintf(stderr, "write (%d) failure\n", nw);
+                fprintf(stderr, "Operation aborted\n");
+                exit(1);
+            }
+//          memset((char *)dir, 0, 4608);       /* zero smd storage */
+            filen = 0;                          /* restart count */
+//          dirp = (u_int32_t *)dir;            /* get word pointer for smd data */
+        }
+    }
+
+    /* write out the directory entries for the files to save */
+    if (filen != 0) {
+        /* we need to write out the directory entries */
+        int32_t n1, n2, nw;
+        /* we have data to write */
+        int32_t hc = (4608 + 1) & ~1;           /* make byte count even */
+        /* write actual byte count to 32 bit word as header */
+        n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+        /* write the data mod 2 */
+        nw = fwrite((unsigned char *)dir, 1, (size_t)hc, dp);
+        /* write the byte count in 32 bit word as footer */
+        n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+        if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc))
+        {
+            fprintf(stderr, "write (%d) failure\n", nw);
+            fprintf(stderr, "Operation aborted\n");
+            exit(1);
+        }
+//      memset(dir, 0, 4608);                   /* zero smd storage */
+        filen = 0;                              /* restart count */
+    }
+
+    /* totcnt has total number of files to output */
+    memset((char *)data, 0, 4608);              /* zero data storage */
+    argc = targc;                               /* restore argc for reread */
+    argv = targv;                               /* restore argv for reread */
+    /* read each file and output to save tape file in 6 sector blocks */
+    while (--argc > 0) {
+        int blks;
+
+        p = *argv++;
+//      printf("argc %d argv3 %s\n", argc, p);
+        if ((fp = fopen(p, "r")) == NULL) {
+            fprintf(stderr, "error: can't open user file %s\n", p);
+            exit(1);
+        }
+        fnp = p;                                /* get file name pointer */
+        fseek(fp, 0, SEEK_END);                 /* seek to end */
+        word = ftell(fp);                       /* get filesize in bytes */
+        fseek(fp, 0, SEEK_SET);                 /* rewind file */
+        size = (word/768);                      /* filesize in sectors */
+        if (word%768 != 0)                      /* see if byte left over */
+            size += 1;                          /* partial sector, add 1 */
+        blks = (word/4608);                     /* blocks */
+        if ((word%4608) != 0)
+            blks++; 
+//      rewind(fp);                             /* back to beginning */
+        while (fread((char *)data, 1, 4608, fp) > 0) {
+            int32_t n1, n2, nw;
+            /* we have data to write */
+            int32_t hc = (4608 + 1) & ~1;       /* make byte count even */
+            /* write actual byte count to 32 bit word as header */
+            n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+            /* write the data mod 2 */
+            nw = fwrite((unsigned char *)data, 1, (size_t)hc, dp);
+            /* write the byte count in 32 bit word as footer */
+            n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+            if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc))
+            {
+                fprintf(stderr, "write (%d) failure\n", nw);
+                fprintf(stderr, "Operation aborted\n");
+                exit(1);
+            }
+            memset((char *)data, 0, 4608);      /* zero data storage */
+        }
+        printf("write file %s user %s (size %d bytes) (%d sect) (%d blocks)\n",
+            fnp, userp, word, size, blks);
+        fclose(fp);
+    }
+    /* write EOF (zero) to file */
+    filen = 0;                                  /* zero count */
+    fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
+    /* do second EOF */
+    fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
+    filen = -1;                                 /* make in -1 for EOM */
+    /* do EOM */
+    fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
+//  printf("setting at %ld bytes in file after EOM\n", ftell(dp));
+    fclose(dp);
+    exit(0);
+}

--- a/SEL32/taptools/sdtfmgrcopy.c
+++ b/SEL32/taptools/sdtfmgrcopy.c
@@ -32,11 +32,11 @@ int inp, outp;
 int getloi(char *s, int lim)
 {
     int c, i;
-    int32_t n1, n2, hc, tc, n;
+    int n1, n2, hc, tc, n;
 
     errno = 0;
     /* read the byte count in 32 bit word as header */
-    n1 = read(inp, (char *)(&hc), (size_t)sizeof(hc));
+    n1 = read(inp, (char *)(&hc), (size_t)4);
     if (n1 <= 0)
         hc = -1;        /* at EOM on disk file */
 
@@ -69,8 +69,16 @@ int getloi(char *s, int lim)
 
     /* read the data */
     n = read(inp, s, (size_t)hc);
+
+    /* if odd byte record, read extra byte and throw it away */
+    if (n & 0x1) {
+        n2 = read(inp, (char *)(&tc), (size_t)1);
+        if (n2 <= 0)
+            return -1;          /* at EOM on disk file */
+    }
+
     /* read the byte count in 32 bit word as trailer */
-    n2 = read(inp, (char *)(&tc), (size_t)sizeof(tc));
+    n2 = read(inp, (char *)(&tc), (size_t)4);
     count++;        /* bump record count */
     size += n;      /* update bytes read */
     EOFcnt = 0;     /* not an EOF */

--- a/SEL32/taptools/tapdump.c
+++ b/SEL32/taptools/tapdump.c
@@ -27,11 +27,11 @@ int inp;
 int getloi(char *s, int lim)
 {
     int c, i;
-    int32_t n1, n2, hc, tc, n;
+    int n1, n2, hc, tc, n;
 
     errno = 0;
     /* read the byte count in 32 bit word as header */
-    n1 = read(inp, (char *)(&hc), (size_t)sizeof(hc));
+    n1 = read(inp, (char *)(&hc), (size_t)4);
     if (n1 <= 0)
         hc = -1;        /* at EOM on disk file */
 
@@ -39,14 +39,11 @@ int getloi(char *s, int lim)
     if (hc & 0xffff0000)    /* check for garbage, assume EOM */
         hc = -1;        /* at EOM on disk file */
 
-    if (hc == 0)
-    {
+    if (hc == 0) {
         /* we are at tape EOF */
-        if (++EOFcnt < 2)       /* if 1st EOF, print file info */
-        {
+        if (++EOFcnt < 2) {     /* if 1st EOF, print file info */
 #ifndef NOTDUMP
-            if (ln > 0)
-            {
+            if (ln > 0) {
                 if (count - lcount > 1)
                     fprintf(stderr, "file %d: records %d to %d: size %d (%x)\n", filen, lcount, count-1, ln, ln);
                 else
@@ -55,9 +52,7 @@ int getloi(char *s, int lim)
             fprintf(stderr, "file %d: eof after %d records: %d bytes (%x)\n", filen, count, size, size);
 #endif
             filen++;    /* set next file number */
-        }
-        else
-        {
+        } else {
 #ifndef NOTDUMP
             fprintf(stderr, "second eof after %d files: %d bytes (%x)\n", filen, size, size);
 #endif
@@ -71,8 +66,7 @@ int getloi(char *s, int lim)
         /* we have EOF */
         return 0;       /* return EOF on tape data */
     }
-    if (hc == -1)
-    {
+    if (hc == -1) {
 #ifndef NOTDUMP
         /* we have EOM */
         fprintf(stderr, "mpx eot\n");
@@ -83,16 +77,22 @@ int getloi(char *s, int lim)
     }
     /* read the data */
     n = read(inp, s, (size_t)hc);
+
+    /* if odd byte record, read extra byte and throw it away */
+    if (n & 0x1) {
+        n2 = read(inp, (char *)(&tc), (size_t)1);
+        if (n2 <= 0)
+            return -1;  /* at EOM on disk file */
+    }
+
     /* read the byte count in 32 bit word as trailer */
-    n2 = read(inp, (char *)(&tc), (size_t)sizeof(tc));
-    count++;        /* bump record count */
-    size += n;      /* update bytes read */
-    EOFcnt = 0;     /* not an EOF */
-    if (n != ln)
-    {
+    n2 = read(inp, (char *)(&tc), (size_t)4);
+    count++;            /* bump record count */
+    size += n;          /* update bytes read */
+    EOFcnt = 0;         /* not an EOF */
+    if (n != ln) {
 #ifndef NOTDUMP
-        if (ln > 0)
-        {
+        if (ln > 0) {
             if (count - lcount > 1)
                 fprintf(stderr, "file %d: records %d to %d: size %d (%x)\n", filen, lcount, count-1, ln, ln);
             else
@@ -118,21 +118,18 @@ int main (int argc, char *argv[])
     unsigned int fileaddr, file_byte_count=0, curchar, buffptr, bufflen;
     int skipfile = 0;
 
-    if (argc != 2)
-    {
+    if (argc != 2) {
         fprintf(stderr, "usage: %s infile\n", argv[0]);
         exit(1);
     } /* end of if */
 
-    if ((inp = open(argv[1], O_RDONLY, 0666)) < 0)
-    {
+    if ((inp = open(argv[1], O_RDONLY, 0666)) < 0) {
         fprintf(stderr,"%s: fopen: unable to open input file %s\n", argv[0], argv[1]);
         return (1);
     }
 
     /* get a 512k buffer */
-    if ((buf = malloc(buf_size)) == NULL)
-    {
+    if ((buf = malloc(buf_size)) == NULL) {
         fprintf(stderr, "Can't allocate memory for %s\n", argv[0]);
         return (4);
     }
@@ -151,32 +148,26 @@ int main (int argc, char *argv[])
     printf("\nfile %d:\n", filen);
 
     /* get lines until eof */
-    while ((ll=getloi(buf, buf_size)) != EOF)
-    {
-        if (ll == 0)
-        {
+    while ((ll=getloi(buf, buf_size)) != EOF) {
+        if (ll == 0) {
             /* eof found, process new file */
             skipfile = 0;
             file_byte_count = 0;
             fileaddr = 0;
             printf("\nfile %d:\n", filen);
-        }
-        else
-        {
+        } else {
             int cc = 0;
             buffptr = 0;
             char buff[257];
             int ans;
 
             /* see if skipping to next file */
-            if (skipfile == 1)
-            {
+            if (skipfile == 1) {
                 continue;
             }
 
             /* process the returned buffer */
-            while (cc < ll)
-            {
+            while (cc < ll) {
                 curchar = (unsigned int)buf[cc++] & 0xff;
                 file_byte_count++;
                 if (!buffptr)
@@ -185,19 +176,16 @@ int main (int argc, char *argv[])
                 buff[buffptr++] = PRINTABLE(curchar);
                 if (!(buffptr % 4))
                     printf(" ");
-                if (buffptr >= bufflen)
-                {
+                if (buffptr >= bufflen) {
                     buff[buffptr] = 0;
                     printf(" |%s|\n",buff);
                     buffptr = 0;
                     fileaddr += bufflen;
-                    if (!(file_byte_count % 256))
-//                  if (!(file_byte_count % 768))
-                    {
+                    if (!(file_byte_count % 256)) {
+//                  if (!(file_byte_count % 768)) {
                         printf("\n<cr> - continue, q = quit, s = skip > ");
                         ans = getchar();
-                        if (ans == 'q')
-                        {
+                        if (ans == 'q') {
                             close(inp);
                             free(buf);
                             exit(1);
@@ -213,11 +201,9 @@ int main (int argc, char *argv[])
                 } /* end of if */
             } /* end of while */
 
-            if (buffptr && !skipfile)
-            {
+            if (buffptr && !skipfile) {
                 buff[buffptr] = 0;
-                while (buffptr++ < bufflen)
-                {
+                while (buffptr++ < bufflen) {
                     printf("  ");
                     if (!(buffptr % 4))
                         printf(" ");
@@ -227,8 +213,7 @@ int main (int argc, char *argv[])
                 /* see what user wants to do */
                 printf("\n<cr> - continue, q = quit > ");
                 ans = getchar();
-                if (ans == 'q')
-                {
+                if (ans == 'q') {
                     close(inp);
                     free(buf);
                     exit(1);

--- a/SEL32/tests/diag.ini
+++ b/SEL32/tests/diag.ini
@@ -7,10 +7,10 @@ set debug -n sel.log
 ;set CPU 32/27 2M
 ;set CPU 32/27 4M
 ;set CPU 32/87 4M
-;set CPU 32/67 4M
+set CPU 32/67 4M
 ;End of Bad
 ;set CPU 32/97 4M
-set CPU V6 4M
+;set CPU V6 4M
 ;set CPU V6 8M
 ;set CPU V9 4M
 ;set CPU V9 8M
@@ -18,13 +18,14 @@ set CPU V6 4M
 ; CPU debug options
 ;set cpu debug=cmd;exp;inst;detail;trap;xio;irq
 ; Set instruction trace history size
-;set cpu history=10000
+;;set cpu history=10000
 ; useful options
 ;set cpu debug=cmd;exp
 ;set cpu debug=cmd;exp;irq;trap;xio
 ;set cpu debug=cmd;irq;trap;exp
 ;set cpu debug=irq;trap;exp;xio
 ;set cpu debug=irq;xio
+;set cpu debug=irq;exp
 ;
 ; RTC realtime clock
 set RTC 50
@@ -33,7 +34,7 @@ set RTC 50
 ;set RTC debug=cmd
 ;
 ; ITM interval timer
-;set ITM debug=cmd
+set ITM debug=cmd
 ;
 ; IOP
 ;set iop debug=cmd
@@ -80,6 +81,7 @@ set mta0 dev=1000
 ;at mta0 utx21a1.tap
 ;at mta0 sim32sdt.tap
 at mta0 diag.tap
+set mta0 locked
 ;at mta1 temptape.tap
 ;at mta2 output.tap
 ;


### PR DESCRIPTION
SEL32: Add VOLMGR tape creator for MPX 3.X SDT and save tapes.
SEL32: Add MFP SCSI disk support.
SEL32: Change device status returns to 16 bits.
SEL32: Update README.md for current project status.
SEL32: Update .ini files for latest simulator configurations.
SEL32: Update taptools to correct odd record byte count error.
SEL32: Update interval timer code to pass SEL diagnostics.
SEL32: Correct single/double floating point arithmetic.