### PR TITLE
SEL32: Add workaround delay in channel processing for UTX logic errors.

### DIFF
--- a/SEL32/sel32_mt.c
+++ b/SEL32/sel32_mt.c
@@ -440,7 +440,7 @@ uint16 mt_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
             chan, cmd);
         uptr->SNS |= SNS_CMDREJ;
         /* send program check */
-        return SNS_CHNEND|STATUS_PCHK;
+        return SNS_CHNEND|SNS_DEVEND|STATUS_PCHK;   /* add DEVEND 08/16/20 */
         break;
     }
 #if 0
@@ -520,7 +520,7 @@ t_stat mt_srv(UNIT *uptr)
     uint32      mema;
     uint16      len;
     uint8       ch;
-    uint8       buf[1024];
+//  uint8       buf[1024];
 
     sim_debug(DEBUG_DETAIL, &mta_dev, "mt_srv unit %04x cmd %02x\n", unit, cmd);
     if ((uptr->flags & UNIT_ATT) == 0) {        /* unit attached status */
@@ -547,6 +547,7 @@ t_stat mt_srv(UNIT *uptr)
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
                 break;
         }
+#ifdef DIAG_WANTS_COUNT
         for (i=0; i < len; i++) {
             if (chan_read_byte(chsa, &buf[i])) {
                 /* we have error, bail out */
@@ -557,6 +558,7 @@ t_stat mt_srv(UNIT *uptr)
             }
             /* just dump data */
         }
+#endif
         /* the chp->ccw_addr location contains the inch address */
         /* call set_inch() to setup inch buffer */
         i = set_inch(uptr, mema);               /* new address */

--- a/SEL32/sel32_scsi.c
+++ b/SEL32/sel32_scsi.c
@@ -826,7 +826,6 @@ t_stat scsi_srv(UNIT *uptr)
         if (uptr->SNS & SNS_TCMD) {
             /* we need to process a read TCMD data */
             int cnt = scsi_buf[bufnum][unit][4];    /* byte count of status to send */
-            ch = scsi_buf[bufnum][unit][0];     /* return TCMD cmd */
             uint32  cyl = CYL(type);            /* number of cylinders */
             uint32  spt = SPT(type);            /* sectors per track */
             uint32  ssb = SSB(type);            /* sector size in bytes */
@@ -834,6 +833,7 @@ t_stat scsi_srv(UNIT *uptr)
             /* cnt has # bytes to return (0xf0) */
             uint8   pagecode = scsi_buf[bufnum][unit][2] & 0x3f;   /* get page code */
             uint8   pagecont = (scsi_buf[bufnum][unit][2] & 0xc0) >> 6; /* get page control */
+            ch = scsi_buf[bufnum][unit][0];     /* return TCMD cmd */
             uptr->SNS &= ~SNS_TCMD;             /* show not presessing TCMD cmd chain */
             sim_debug(DEBUG_CMD, dptr,
                 "scsi_srv processing TCMD read cmd %02x, chsa %04x tcma %06x cnt %04x\n",

--- a/SEL32/taptools/README.md
+++ b/SEL32/taptools/README.md
@@ -24,8 +24,8 @@ cutostap - This program scans a metadata .tap file and copies files
            .tap sdt image.  The mkfmcopy can be used to create a
            user sdt tape with files following the sdt image.
 
-           command filelist <file.tap >stdout
-           input - stdin  <file to remove sdt from
+           command: cutostap <file.tap >stdout
+           input -  stdin  <file to remove sdt from
            output - stdout >file to be written with sdt image
 
 diskload - This program reads an MPX load module and stores it into
@@ -36,16 +36,16 @@ diskload - This program reads an MPX load module and stores it into
            command: diskload -la program diskfile
            option -a - add filename to diskfile
            option -l - list files in diskfile SMD, ignore filename
-           input - filename - file to copy to system disk
-                 - diskfile - simulated system disk
+           input -  filename - file to copy to system disk
+                 -  diskfile - simulated system disk
            output - modified system disk
 
 filelist - This program scans a metadata .tap file and prints the
            file count and sizes.  Used to determine the file
            format contained in the metadata .tap file.
 
-           command filelist <file.tap >stdout
-           input - stdin  <file to dump
+           command: filelist <file.tap >stdout
+           input -  stdin  <file to dump
            output - stdout
 
 fmgrcopy - This program reads a MPX 1.x filemgr save tape.  The tape
@@ -58,8 +58,8 @@ fmgrcopy - This program reads a MPX 1.x filemgr save tape.  The tape
            as binary data to the named file.  The .tap file MUST be
            a filemgr save tape and not a MPX-1.x SDT tape.
 
-           command fmgrcopy file.tap >stdout
-           input - file.tap file to dump
+           command: fmgrcopy file.tap >stdout
+           input -  file.tap file to dump
            output - stdout filelist and sizes
            output - directory/files extracted to current directory
 
@@ -67,7 +67,7 @@ mkfmtape - This program creates an MPX 1.x filemgr save tape.  The
            tape can then be used to restore files to the MPX-1.X
            system.  The output will be in SIMH simulated .tap format.
 
-           command mkfmtape opts output.tap file1 file2 ...
+           command: mkfmtape opts output.tap file1 file2 ...
            input - list of filename to save to tape.
            output - output.tap a tap formatted file.
            options - -p = file type 0xca for programs
@@ -78,12 +78,12 @@ mkfmtape - This program creates an MPX 1.x filemgr save tape.  The
                    - -u = username (directory)
 
 mkvmtape - This program reads MPX files and stores them into a
-           simulated volmgr save tape. The tape may then become a 
-           MPX 3.X sdt boot tape to install MPX 3.X from or a volmgr
-           file restore tape for a running MPX system.  The output
-           will be in SIMH simulated .tap format.
+           simulated volmgr save tape. The tape may then become
+           a MPX 3.X sdt boot tape to install MPX 3.X from or a
+           volmgr file restore tape for a running MPX system.
+           The output will be in SIMH simulated .tap format.
 
-           command mkfmtape [-ptloa] [-bboot] [-iimage] [-jj.vfmt]
+           command: mkfmtape [-ptloa] [-bboot] [-iimage] [-jj.vfmt]
                             [-uusername] tapname file1 file2 ...
            intput - [options] volmtape filename, filename, etc.
            output - volmtape file, file list to stdout
@@ -101,6 +101,33 @@ mkvmtape - This program reads MPX files and stores them into a
                    - -j = j.vfmt filename
                    04/11/2020 update for mpx3.x
 
+mkdiagtape.c - This program extracts the diag command file (file 2)
+           from a diagnostic tape in .tap format and replaces it
+           with a new command file.  The rest of the tape is copied
+           unchanged.  The original command file from the diag tape
+           must be extracted from the diag tape using the diagcopy
+           utility.  This file can then be deblocked using the deblk
+           utility. The file can then be editied using VI or your
+           favorite editor.  Lines must be blank filled to 80 chars
+           exactly after editing.  The mpxblk utility must then be
+           used to restore the file to blocked MPX format before
+           installing it on the new diag tape.
+
+           1. mkdir temp; Create temp directory.
+           2. cp diag.tap temp; Copy in current diag tape.
+           3. cd temp; Move to temp directory.
+           4. diagcopy diag.tap; Extract diag tape contents.
+           5. deblk cmdfile >cmd.txt;  Creat unblocked text file.
+           6. vi cmd.txt; Edit text file with new commands and save.
+           7. mpxblk <cmd.txt >cmd.blk; Restore blocked file format.
+           8. mkdiagtape -c cmd.txt diag.tap newdiag.tap.
+           9. copy newdiag.tap to execution directory and run sel32.
+
+           command: mkdiagtape -c cmdfile olddiag newdiag
+           intput - simulated in_diagtape
+           output - simulated newtape
+           option - -c cmdfile
+
 diagcopy - This program reads a SEL .tap diagnostic boot tape and splits
            the contents into multiple files.  The first tape record
            is 204 bytes of boot code and is put into the file bootcode.
@@ -116,8 +143,8 @@ diagcopy - This program reads a SEL .tap diagnostic boot tape and splits
            the tape.  These records are all multiple of 768 bytes each
            and contain binary programs.
 
-           command diagcopy diag.tap
-           input - diag.tap file to dump
+           command: diagcopy diag.tap
+           input  - diag.tap file to dump
            output - stdout filelist and sizes
            output - if tape contains a valid diag image, it will be
                     output to files bootfile, cmdfile, dolfile and
@@ -130,8 +157,8 @@ tapdump -  This program reads a metadata .tap file and prints a side
            hitting <q> will terminate the display, and hitting <s>
            will skip to the next file on the simulated tape.
 
-           command tapdump <file.tap >stdout
-           input - stdin  <file to dump
+           command: tapdump <file.tap >stdout
+           input -  stdin  <file to dump
            output - stdout
 
 tape2disk - This program reads a tape assigned as input device.  It
@@ -142,8 +169,8 @@ tape2disk - This program reads a tape assigned as input device.  It
            MPX 3.x volmgr save tapes contain three EOFs so comment out
            the define for that case. 
 
-           command - tape2disk mt00 [file.tap]
-           input - mag tape device being read
+           command: tape2disk mt00 [file.tap]
+           input -  mag tape device being read
            output - list of files and sizes read from input tape
            output - metadata .tap file optionally specified
 
@@ -151,8 +178,8 @@ tapscan -  This program scans a metadata .tap file and prints the
            file count and sizes.  Used to determine the file
 
            format contained in the metadata .tap file.
-           command - tapscan file.tap >stdout
-           input - file.tap file to scan
+           command: tapscan file.tap >stdout
+           input -  file.tap file to scan
            output - stdout filelist and sizes
 
 volmcopy - This program reads a MPX 3.x volmgr save tape.  The tape
@@ -168,8 +195,8 @@ volmcopy - This program reads a MPX 3.x volmgr save tape.  The tape
            file MUST be a volmgr save tape and not a MPX-1.x SDT/save
            tape.
 
-           command fmgrcopy file.tap >stdout
-           input - file.tap file to dump
+           command: fmgrcopy file.tap >stdout
+           input -  file.tap file to dump
            output - stdout filelist and sizes
            output - directory/files extracted to current directory
 
@@ -181,7 +208,7 @@ ddump -    Create a sys by side ascii dump of a file.  Same operation
            hex address can be input to display data at a given offset
            in the file.  Optionall, the file data can be modified.
 
-           command - ddump -r filename
+           command:  ddump -r filename
            option -  -r means open file read only 
            input -   filename file to read
            output -  side by size ascii dump of file
@@ -190,7 +217,7 @@ deblk -    read and convert mpx blocked ifile to unblocked unix file
            format.  Compressed and uncompressed files records can be
            read.  Output is an ascii string with '\n' termination.
 
-           command - deblk [filename]
+           command:  deblk [filename]
            input -   filename or if non specified, stdin
            output -  ascii sting to stdout
 
@@ -198,7 +225,7 @@ mpxblk -   Create an MPX blocked file from a '\n' terminated ascii
            character string file.  Trailing blanks are not deleted
            from the source file.  Max line size is 254 bytes.
 
-           command - mpxblk <filein >fileout
+           command:  mpxblk <filein >fileout
            input   - read ascii file from stdin
            output  - write mpx blocked file to stdout
 
@@ -208,7 +235,7 @@ renum -    Create a numbered file from a '\n' terminated ascii file.
            A line number in the form of XXXX.000 are appended to
            create 80 char '\n' terminated lines.
 
-           command - renum <filein >fileout
+           command:  renum <filein >fileout
            input -   read ascii file from stdin
            output -  write numbered ascii file to stdout
 
@@ -217,9 +244,9 @@ small -   Remove line numbers and trailing blanks from an ascii '\n'
           stripped of trailing blanks.  Output is '\n' terminated
           ascii files.
 
-          command -  small <filein >fileout
+          command:   small <filein >fileout
           input -    read ascii file from stdin
           output -   write stripped ascii file to stdout
 
 James C. Bevier
-04/21/2020
+08/21/2020

--- a/SEL32/taptools/makefile
+++ b/SEL32/taptools/makefile
@@ -29,6 +29,7 @@ PROGS =			\
 	$(ROOT)/mkfmtape \
 	$(ROOT)/mkvmtape \
 	$(ROOT)/sdtfmgrcopy \
+	$(ROOT)/mkdiagtape \
 	$(ROOT)/tapdump	\
 	$(ROOT)/tape2disk \
 	$(ROOT)/tapscan \
@@ -89,6 +90,12 @@ $B/mkvmtape:	$D mkvmtape.c
 	@echo $(@F) installed in $B
 
 $B/sdtfmgrcopy:	$D sdtfmgrcopy.c
+	@-$(CC) $(CFLAGS) $(@F).c $(LFLAGS) -o $@
+	@chmod 755 $@
+	@cp $(@F) $B
+	@echo $(@F) installed in $B
+
+$B/mkdiagtape:	$D mkdiagtape.c
 	@-$(CC) $(CFLAGS) $(@F).c $(LFLAGS) -o $@
 	@chmod 755 $@
 	@cp $(@F) $B

--- a/SEL32/taptools/mkdiagtape.c
+++ b/SEL32/taptools/mkdiagtape.c
@@ -1,0 +1,276 @@
+/*
+ * mkdiagtape.c
+ *
+ * This program extracts the diag command file (file 2) from a
+ * diagnostic tape in .tap format and replaces it with a new
+ * command file.  The rest of the tape is copied unchanged.
+ * intput - simulated indiagtape outdiagtape
+ * output - simulated newtape
+ * option - -c = cmdfile
+ * 08/22/2020
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <string.h>
+#include <unistd.h>
+
+#define BLKSIZE 768                 /* MPX file sector size */
+unsigned char data[7680];           /* room for 10*768=(7680) 768 byte sectors per 7680 byte block */
+
+/* write 1 file to tape in 768 byte records */
+/* mblks is the maximum blockes to write from a file, 0=all */
+/* chunks is the number of sectors to wrote at a time 1-8 */
+int writefile(FILE *tp, char *fnp, u_int32_t mblks, int32_t chunks) {
+    u_int32_t word, blks=mblks;             /* just a temp word variable */         
+    u_int32_t size, bsize, csize;           /* size in 768 byte sectors */
+    FILE *fp;
+    int32_t n1, n2, hc, nw, cs;
+
+    memset((char *)data, 0, sizeof(data));  /* zero data storage */
+    /* write file to tape */
+    if ((fp = fopen(fnp, "r")) == NULL) {
+        fprintf(stderr, "error: can't open user file %s\n", fnp);
+        exit(1);
+    }
+    fseek(fp, 0, SEEK_END);                 /* seek to end */
+    word = ftell(fp);                       /* get filesize in bytes */
+//printf("MPX file %s is %x (%d) bytes\n", fnp, word, word);
+    fseek(fp, 0, SEEK_SET);                 /* rewind file */
+    size = (word/768);                      /* filesize in sectors */
+    if (word%768 != 0)                      /* see if byte left over */
+        size += 1;                          /* partial sector, add 1 */
+    if (mblks == 0) {
+        mblks = (word/768);                 /* blocks */
+        if ((word%768) != 0)                /* round up blks if remainder */
+            mblks++;                        /* total block to write */
+    }
+    blks = mblks/chunks;                    /* chunks */
+    if (mblks%768 != 0)                     /* see if blks left over */
+        blks += 1;                          /* partial blks, add 1 */
+
+    bsize = mblks;                          /* save # blks */
+
+//printf("MPX file %s is %x (%d) bytes blks %d chk %d\n",
+//        fnp, word, word, bsize, (bsize+1)/chunks);
+    csize = 0;
+    /* read in the image file */
+    while (bsize > 0) { 
+        if (bsize > chunks)                 /* see if there is a chunk left to read */
+            csize = chunks;                 /* yes, do max chunk size */
+        else
+            csize = bsize;                  /* no, use what is left */
+        cs = fread((char *)data, 1, csize*768, fp);
+        /* we have data to write */
+        hc = (csize*768 + 1) & ~1;          /* make byte count even */
+        /* write actual byte count to 32 bit word as header */
+        n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), tp);
+        /* write the data mod 2 */
+        nw = fwrite((unsigned char *)data, 1, (size_t)hc, tp);
+        /* write the byte count in 32 bit word as footer */
+        n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), tp);
+        if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc))
+        {
+            fprintf(stderr, "write to %s failure\n", fnp);
+            fprintf(stderr, "Operation aborted\n");
+            exit(1);
+        }
+        bsize -= csize;                     /* do next chunk */
+        memset((char *)data, 0, csize);     /* zero data storage */
+    }
+//printf("write file %s (size %d bytes) (%d sect) (%d blocks) (%d chunks)\n",
+//      fnp, word, size, mblks, blks);
+    fclose(fp);
+}
+
+/* read program file and output to a simulated diagnostic tape */
+/* mkdiagtape -c cmdfile diagtape diagtapeout */
+int main(argc, argv)
+int argc;
+char *argv[];
+{
+    FILE    *dp, *fp, *cp, *fopen();
+    int     targc;
+    char    **targv;
+    char    *p, *cmdp;
+    int     i;
+    unsigned char *fnp;                     /* file name pointer */
+    unsigned int size;                      /* size in 768 byte sectors */
+    unsigned int word;                      /* just a temp word variable */         
+    int goteof, goteom;                     /* end flags */
+    int writing;                            /* writing output */
+
+    memset((char *)data, 0, 4608);          /* zero data storage */
+
+    targv = argv;                           /* save filename */
+    if (argc <= 1) {                        /* see if correct # args */
+        fprintf(stderr, "Usage: %s [-ptloa] [-uusername] fmgrtape file1 file2 ...\n", *argv);
+        exit(1);
+    }
+    while(--argc > 0) {
+//      printf("argc %d argv %s\n", argc, *argv);
+        p = *++argv;
+        if (*p++ == '-') {
+            if (*p == '\0') {
+                fprintf(stderr, "Error: no option specified\n");
+                fprintf(stderr, "Usage: %s -c cmdfile infile outfile\n", *targv);
+                exit(1);
+            }
+//          printf("doing options %s\n", p);
+            while (*p != '\0') {
+                switch (*p++) {
+                    case 'c':
+                    case 'C':
+                        if (*p == '\0') {
+                            p = *++argv;    /* next parameter */
+                            --argc;         /* one less arg */
+                        };
+                        cmdp = p;           /* save ptr to file name */
+                        while (*p != '\0')
+                            p++;
+                        break;
+                    default:
+                        fprintf(stderr, "Error: no cmd file specified\n");
+                        fprintf(stderr, "Usage: %s -c cmdfile infile outfile\n", *targv);
+                        exit(1);
+                        break;
+                }   /* end switch */
+                continue;
+            }   /* end while */
+        }
+        else {
+            if ((dp = fopen(*argv, "r")) == NULL) {
+                fprintf(stderr, "error: can't open input diag tape file %s\n", *argv);
+                exit(1);
+            }
+            printf("opening %s file for tape\n", *argv);
+            *++argv;
+            break;                          /* go handle files now */
+        }
+        continue;
+    }
+    /* end while --argc */
+    if ((argc-1) <= 0) {
+        fprintf(stderr, "Error: incorrect number of parameters\n");
+        fprintf(stderr, "Usage: %s -c cmdfile infile outfile\n", *targv);
+        exit(1);
+    }
+    /* got input tapefile and options, handle output file now */
+//  printf("AT 3 argc %d argv %s\n", argc, *argv);
+    if (--argc > 0) {
+        int blks;
+
+        p = *argv++;
+        printf("argc %d argv3 %s\n", argc, p);
+        if ((fp = fopen(p, "w")) == NULL) {
+            fprintf(stderr, "error: can't open tape output file %s\n", p);
+            fprintf(stderr, "Usage: %s -c cmdfile infile outfile\n", *targv);
+            exit(1);
+        }
+        printf("opened output file %s\n", p);
+    }
+
+    /* now copy input tape until 1st EOF */
+    goteof = 0;                             /* no eof yet */
+    writing = 1;                            /* we are copying in to out */
+    while (goteof == 0) {
+        int n1, n2, hc, tc, n, nw;
+        /* read the byte count in 32 bit word as header */
+        n1 = fread((char *)(&hc), 1, (size_t)4, dp);
+
+        /* check for EOM on tape */
+        if ((n1 <= 0) || (hc & 0xffff0000)) {   /* check for garbage, assume EOM */
+            fprintf(stderr, "Premature EOM on input file bad tape\n");
+            exit(1);
+        }
+        /* see if at EOF */
+        if (hc == 0) {
+            /* we are at tape EOF */
+            if (writing == 0)
+                break;                      /* done with copy */
+            writing = 0;                    /* stop writing */
+            /* copy the EOF to the output tape */
+            n1 = fwrite((char *)(&hc), 1, (size_t)4, fp);
+            if (n1 != 4) {
+                fprintf(stderr, "Error write EOF to output file\n");
+                exit(1);
+            }
+            continue;                       /* continue processing */
+        }
+
+        /* read the data to copy to output */
+        n = fread(data, 1, (size_t)hc, dp);
+        if (n <= 0) {
+            fprintf(stderr, "Read error on input file bad tape\n");
+            exit(1);
+        }
+
+        /* if odd byte record, read extra byte and throw it away */
+        if (n & 0x1) {
+            n2 = fread((char *)(&tc), 1, (size_t)1, dp);
+            if (n2 <= 0) {
+                fprintf(stderr, "Read error on input file bad tape\n");
+                exit(1);
+            }
+        }
+        /* if writing, write out the record */
+        if (writing) {
+            int wc = n;                     /* get actual byte count */
+            /* write actual byte count to 32 bit word as header */
+            n1 = fwrite((char *)(&wc), 1, (size_t)4, fp);
+            /* write the data mod 2 */
+            nw = fwrite(data, 1, (size_t)hc, fp);
+            if (n1 != 4 || nw != hc) {
+                fprintf(stderr, "write error to tape\n");
+                exit(1);
+            }
+        }
+
+        /* read the byte count in 32 bit word as trailer */
+        n2 = fread((char *)(&tc), 1, (size_t)4, dp);
+        if (n2 <= 0) {
+            fprintf(stderr, "Read error on input file bad tape\n");
+            exit(1);
+        }
+        if (writing) {
+            /* write the byte count in 32 bit word as footer */
+            n2 = fwrite((char *)(&tc), 1, (size_t)4, fp);
+            if (n2 != 4) {
+                fprintf(stderr, "write error to tape\n");
+                exit(1);
+            }
+        }
+    }
+
+    /* now handle new command file */
+    /* we have copied the first file and bypassed the second */
+    /* copy in the new com file and write out 768 byte records */
+    writefile(fp, cmdp, 0, 1);                  /* write command file out in 768 byte blks */
+
+    word = 0;
+    /* copy the EOF to the output tape */
+    i = fwrite((char *)(&word), 1, (size_t)4, fp);
+    if (i != 4) {
+        fprintf(stderr, "Error writing EOF to output file\n");
+        exit(1);
+    }
+
+    while (1) {
+        /* read the data to copy to output */
+        i = fread(data, 1, (size_t)7680, dp);
+        if (i <= 0) {
+            fprintf(stderr, "EOM input file, done\n");
+            break;
+        }
+        /* write the data to output */
+        i = fwrite(data, 1, (size_t)i, fp);
+        if (i <= 0) {
+            fprintf(stderr, "Error writing data to output file\n");
+            break;
+        }
+    }
+    fclose(dp);
+    fclose(fp);
+    exit(0);
+}

--- a/SEL32/taptools/mkvmtape.c
+++ b/SEL32/taptools/mkvmtape.c
@@ -45,20 +45,23 @@
 #define BLKSIZE 768                     /* MPX file sector size */
 u_int32_t dir[32];                      /* directory name */
 u_int32_t vol[32];                      /* volume name */
-unsigned char data[4608];               /* room for 6*768=(4608) 768 byte sectors per 4608 byte block */
+unsigned char data[6144];               /* room for 8*768=(6144) 768 byte sectors per 4608 byte block */
 unsigned char bigdata[19200];           /* room for 6*768=(4608) 768 byte sectors per 4608 byte block */
 u_int32_t M[768];                       /* fake memory */
 unsigned char bootcode[2048];           /* room for bootcode */
-unsigned char savelist[6144];           /* room for 8 byte flags, 127 (48 char) file names */
+u_int32_t resdes[384];                  /* room for the 1536 char (two blks) resource descriptor */
+u_int32_t dirlist[1536];                /* 6144 byte directory listing */
 int16_t     savecnt = 0;                /* entries in save list */
 char sysname[16] = "SYSTEM          ";
 
 /* write 1 file to tape in 768 byte records */
-int writefile(FILE *tp, char *fnp, u_int32_t mblks) {
-    u_int32_t word, blks;                   /* just a temp word variable */         
-    u_int32_t size, bsize;                  /* size in 768 byte sectors */
+/* mblks is the maximum blockes to write from a file, 0=all */
+/* chunks is the number of sectors to wrote at a time 1-8 */
+int writefile(FILE *tp, char *fnp, u_int32_t mblks, int32_t chunks) {
+    u_int32_t word, blks=mblks;             /* just a temp word variable */         
+    u_int32_t size, bsize, csize;           /* size in 768 byte sectors */
     FILE *fp;
-    int32_t n1, n2, hc, nw;
+    int32_t n1, n2, hc, nw, cs;
 
     memset((char *)data, 0, sizeof(data));  /* zero data storage */
     /* write file to tape */
@@ -68,24 +71,34 @@ int writefile(FILE *tp, char *fnp, u_int32_t mblks) {
     }
     fseek(fp, 0, SEEK_END);                 /* seek to end */
     word = ftell(fp);                       /* get filesize in bytes */
-printf("MPX file %s is %x (%d) bytes\n", fnp, word, word);
+//printf("MPX file %s is %x (%d) bytes\n", fnp, word, word);
     fseek(fp, 0, SEEK_SET);                 /* rewind file */
     size = (word/768);                      /* filesize in sectors */
     if (word%768 != 0)                      /* see if byte left over */
         size += 1;                          /* partial sector, add 1 */
     if (mblks == 0) {
-        blks = (word/768);                  /* blocks */
+        mblks = (word/768);                 /* blocks */
         if ((word%768) != 0)                /* round up blks if remainder */
-            blks++; 
-    } else {
-        blks = mblks;                       /* write user specified blocks */
+            mblks++;                        /* total block to write */
     }
-    bsize = blks;                           /* save # blks */
+    blks = mblks/chunks;                    /* chunks */
+    if (mblks%768 != 0)                     /* see if blks left over */
+        blks += 1;                          /* partial blks, add 1 */
 
+    bsize = mblks;                          /* save # blks */
+
+//printf("MPX file %s is %x (%d) bytes blks %d chk %d\n",
+//        fnp, word, word, bsize, (bsize+1)/chunks);
+    csize = 0;
     /* read in the image file */
-    while ((bsize-- > 0) && fread((char *)data, 1, 768, fp) > 0) {
+    while (bsize > 0) { 
+        if (bsize > chunks)                 /* see if there is a chunk left to read */
+            csize = chunks;                 /* yes, do max chunk size */
+        else
+            csize = bsize;                  /* no, use what is left */
+        cs = fread((char *)data, 1, csize*768, fp);
         /* we have data to write */
-        hc = (768 + 1) & ~1;                /* make byte count even */
+        hc = (csize*768 + 1) & ~1;          /* make byte count even */
         /* write actual byte count to 32 bit word as header */
         n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), tp);
         /* write the data mod 2 */
@@ -98,10 +111,11 @@ printf("MPX file %s is %x (%d) bytes\n", fnp, word, word);
             fprintf(stderr, "Operation aborted\n");
             exit(1);
         }
-        memset((char *)data, 0, 768);       /* zero data storage */
+        bsize -= csize;                     /* do next chunk */
+        memset((char *)data, 0, csize);     /* zero data storage */
     }
-    printf("write file %s (size %d bytes) (%d sect) (%d blocks)\n",
-        fnp, word, size, blks);
+//printf("write file %s (size %d bytes) (%d sect) (%d blocks) (%d chunks)\n",
+//      fnp, word, size, mblks, blks);
     fclose(fp);
 }
 
@@ -119,7 +133,7 @@ u_int32_t readboot(char *name, char *buf, u_int32_t start, u_int32_t end) {
     n1 = fread(bootcode, 1, word, fp);      /* read bootcode */
     if (n1 <=0)                             /* check for read error */
         exit(1);                            /* bad tape format */
-printf("MPX bootfile %s is %x (%d) bytes\n", name, word, word);
+//printf("MPX bootfile %s is %x (%d) bytes\n", name, word, word);
     fclose(fp);
     fopen("volmboot", "w");
     fwrite(bootcode, 1, word, fp);
@@ -152,7 +166,7 @@ char *argv[];
     unsigned char volname[32];
     unsigned char dirname[32];
     char *p;
-    int i;
+    int i, n, eof;
 #define DOPROG  1
 #define DOADD  2
 #define DOOTHER  4
@@ -164,6 +178,7 @@ char *argv[];
 #define DOVFMT 256
 #define DOVOL 512
 #define DODIR 1024
+#define DOMASK (DOBOOT|DOIMG|DOVFMT)
     unsigned int option = DOTEXT;           /* what to do */
     unsigned char *fnp;                     /* file name pointer */
     unsigned int size;                      /* size in 768 byte sectors */
@@ -190,7 +205,7 @@ char *argv[];
     memset((char *)data, 0, 4608);          /* zero data storage */
     for (i=0; i<32; i++)
         username[i] = 0;                    /* use zero for system username */
-    typ = 0xee000000;                       /* set type */
+    typ = 0xee;                             /* set type */
     if (argc <= 1) {                        /* see if correct # args */
         fprintf(stderr,
             "Usage: %s [-ptloa] [-bboot] [-iimage] [-jj.vfmt] [-uusername] vmgrtape file1 file2 ...\n",
@@ -198,7 +213,7 @@ char *argv[];
         exit(1);
     }
     while(--argc > 0) {
-//      printf("argc %d argv %s\n", argc, *argv);
+//printf("argc %d argv %s\n", argc, *argv);
         p = *++argv;
         if (*p++ == '-') {
             if (*p == '\0') {
@@ -208,7 +223,7 @@ char *argv[];
                     *argv);
                 exit(1);
             }
-//          printf("doing options %s\n", p);
+//printf("doing options %s\n", p);
             while (*p != '\0') {
                 switch (*p++) {
                     case 'b':
@@ -277,7 +292,8 @@ char *argv[];
                     case 'L':
                     case 'l':
                         option |= DOLIB;    /* save library files */
-                        typ = 0xff;         /* set type */
+//                      typ = 0xff;         /* set type */
+                        typ = 0x00;         /* set type */
                         break;
                     case 'V':
                     case 'v':
@@ -325,7 +341,7 @@ error1:
             }   /* end while */
         }
         else {
-//          printf("option set to %x\n", option);
+//printf("option set to %x\n", option);
             if (option & DOADD) {
                 long bytes;
                 /* open read/write */
@@ -342,18 +358,23 @@ error1:
 
                 fseek(dp, 0, SEEK_END);             /* seek to end */
                 bytes = ftell(dp);                  /* get filesize in bytes */
-                printf("file length %ld bytes\n", bytes);
-                printf("start writing at %ld bytes offset\n", bytes-8);
+//printf("1 file length %ld %lx bytes\n", bytes, bytes);
+//printf("1 start writing at %ld %lx bytes offset\n", bytes-8, bytes-8);
                 fseek(dp, 0, SEEK_SET);             /* rewind file to beginning */
+                /* at this point, we are at the end of the tape */
+                /* we should see 3 EOF's w/ or w/o an EOM */
                 if (bytes > 8) {                    /* see if file written to already */
                     /* we need to find the EOT */
                     int32_t n1, n2, hc, tc, n;
                     int EOFcnt = 0;
 readmore:
+                    fseek(dp, bytes-4, SEEK_SET);   /* seek back to EOF/EOM code */
                     n1 = fread((char *)(&hc), 1, (size_t)4, dp);    /* read 4 byte record size */
                     if (n1 <=0)                     /* check for read error */
                         goto doabort;               /* bad tape format */
 
+//printf("2 file length %ld %lx bytes\n", bytes, bytes);
+//printf("2 start writing at %ld %lx bytes offset\n", bytes-8, bytes-8);
                     if (hc & 0xffff0000)            /* check for garbage */
                         hc = 0;                     /* assume EOF on disk */
 
@@ -362,19 +383,23 @@ readmore:
                         if (++EOFcnt == 2) {
                             /* we have second EOF, we need to backup 4 bytes */
 backup4:
-                            bytes = ftell(dp);      /* get file position in bytes */
+                            /* we are setting after 2nd EOF, start writing there */
+//                          bytes -= 4;             /* backup 4 bytes */
                             fseek(dp, bytes-4, SEEK_SET);   /* backspace over 2nd EOF */
+//printf("3 file length %ld %lx bytes\n", bytes, bytes);
+//printf("3 start writing at %ld %lx bytes offset\n", bytes-8, bytes-8);
                             goto getout;            /* start our processing */
                         }
                         /* we have first EOF, keep reading */
+                        bytes -= 4;                 /* backup 4 bytes */
                         goto readmore;              /* read more records */
                     } else
                     if (hc == -1) {                 /* check for EOM */
-                        if (EOFcnt == 1)
-                            /* see if one EOF followed by EOM (-1) */
-                            goto backup4;           /* start write over the EOM */
-                        /* we have an EOM without any EOF, so bad tape */
-                        goto doabort;               /* bad tape format */
+                        if (EOFcnt != 0)
+                            /* we have an EOM before an EOF, so bad tape */
+                            goto doabort;           /* bad tape format */
+                        bytes -= 4;                 /* backup 4 bytes */
+                        goto readmore;              /* read more records */
                     }
 
                     /* we have data, so no EOF */
@@ -404,10 +429,10 @@ doabort:
                     fprintf(stderr, "error: can't create/open simulated tape disk file %s\n", *argv);
                     exit(1);
                 }
-//              printf("3 opened output in w mode, write at start\n");
+//printf("3 opened output in w mode, write at start\n");
             }
 getout:
-//          printf("opening %s file for tape\n", *argv);
+//printf("opening %s file for tape\n", *argv);
             *++argv;
             break;      /* go handle files now */
         }
@@ -415,10 +440,12 @@ getout:
     }
     /* end while --argc */
 
-    if (!((option & DOBOOT) && (option & DOIMG) && (option & DOVFMT))) {
+    if (!DOADD) {
+    if ((option & DOMASK) && ((option & DOMASK) != DOMASK)) {
         fprintf(stderr, "Error: incorrect number of sdt files, must be three\n");
-        fprintf(stderr, "Usage: %s [-ptloa] [-uusername] fmgrtape, file1 file2 ...\n", *argv);
+        fprintf(stderr, "Usage: %s [-ptloa] [-uusername] vmgrtape, file1 file2 ...\n", *argv);
         exit(1);
+    }
     }
     /* process the bootfile first */
     if (option & DOBOOT) {
@@ -459,8 +486,7 @@ printf("bootfile %s is %x (%d) bytes\n", bootp, word, word);
            fprintf(stderr, "Operation aborted\n");
            exit(1);
         }
-        printf("write boot file %s (size %d bytes)\n",
-            bootp, word, word);
+printf("write boot file %s (size %d bytes)\n", bootp, word, word);
         /* setup for mpx image file */
         memset((char *)data, 0, 0x800);              /* zero data storage */
 #ifdef USE_FILENAME
@@ -499,23 +525,23 @@ printf("image file %s n1 %x (%d) n2 %x (%d) blks %x (%d)\n",
         fclose(fp);
 
         /* write mpx image file */
-        writefile(dp, imgp, blks);                  /* write max of "blks" blocks to file */
+        writefile(dp, imgp, blks, 1);               /* write max of "blks" blocks to file */
 
         /* write j.vfmt file */
-        writefile(dp, vfmtp, 0);
+        writefile(dp, vfmtp, 0, 1);                 /* write 1 blk at a time */
 
         /* write EOF (zero) to file */
         filen = 0;                                  /* zero count */
         fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
 
         /* write j.mount file */
-        writefile(dp, "j.mount", 0);
+        writefile(dp, "j.mount", 0, 1);             /* one blk at a time */
 
         /* write j.swapr file */
-        writefile(dp, "j.swapr", 0);
+        writefile(dp, "j.swapr", 0, 1);             /* one blk at a time */
 
         /* write volmgr file */
-        writefile(dp, "volmgr", 0);
+        writefile(dp, "volmgr", 0, 1);              /* all of file 1 blk at a time */
 
         /* write EOF (zero) to file */
         filen = 0;                                  /* zero count */
@@ -526,7 +552,7 @@ printf("image file %s n1 %x (%d) n2 %x (%d) blks %x (%d)\n",
         filen = -1;                                 /* make in -1 for EOM */
         /* do EOM */
         fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
-//  printf("setting at %ld bytes in file after EOM\n", ftell(dp));
+//printf("setting at %ld bytes in file after EOM\n", ftell(dp));
         fclose(dp);
         exit(0);
     }
@@ -536,126 +562,124 @@ printf("image file %s n1 %x (%d) n2 %x (%d) blks %x (%d)\n",
         fprintf(stderr, "Error: incorrect number of parameters\n");
         goto error1;                            /* we are done here */
     }
+    /* save up to 127 file names in 6144 byte record */
+    if (argc > 127) {
+        fprintf(stderr, "Error: only 127 files max at a time\n");
+        goto error1;                            /* we are done here */
+    }
 /*------------------------------------------------------------------------*/
-    savecnt = 0;                                /* files yet */
+    savecnt = 0;                                /* no files yet */
     /* make first pass over files and get filenames and sizes */
     /* got tapefile and options, handle files now */
     targc = argc;                               /* save argc to reread list */
     targv = argv;                               /* save argv to reread list */
-//  printf("AT 3 argc %d argv %s\n", argc, *argv);
+//printf("AT 3 argc %d argv %s\n", argc, *argv);
     filen = 0;                                  /* no files yet */
     totent = 0;                                 /* no files yet */
 
     /* save up to 127 file names in 6144 byte record */
+    if (argc > 127) {
+        fprintf(stderr, "Error: only 127 files max at a time\n");
+        goto error1;                            /* we are done here */
+    }
     /* filename/directory/volume */
     /* wd 1 is 1 for type 1 record */
     /* wd 2 will be # of 48 byte pathnames */ 
-    memset((char *)savelist, 0, sizeof(savelist));  /* zero data storage */
+    memset((char *)dirlist, 0, sizeof(dirlist));    /* zero data storage */
+
     /* populate the 48 byte entry starting at byte 2 */
 //  dirp = (u_int32_t *)dir;                    /* get word pointer for directory */
 //  volp = (u_int32_t *)vol;                    /* get word pointer for volume */
-    dirp = dirname;                             /* get word pointer for directory */
-    volp = volname;                             /* get word pointer for volume */
+//  dirp = dirname;                             /* get word pointer for directory */
+//  volp = volname;                             /* get word pointer for volume */
+/// dirp = sysname;                             /* get word pointer for directory */
+    volp = sysname;                             /* get word pointer for volume */
+    n = 2;
+    dirlist[0] = n << 24;                       /* set record type to 1 */
     while (--argc > 0) {
-        u_int32_t smd[8];                       /* smd entry data */
-        int blks;
+        u_int32_t smd[32];                      /* dir entry data */
+        int blks, eof;
 
-        for (i=0; i<8; i++)                     /* zero smd entry */
-            smd[i] = 0;
+        for (i=0; i<16; i++)                    /* zero smd entry */
+            smd[i] = 0x20;                      /* make blank */
         p = *argv++;
         i = strlen(p);                          /* filename size */
-        if (i == 0 || i > 8) {
-            fprintf(stderr, "error: Filename too long (%d>8) %s, Aborting\n", i, p);
+        if (i == 0 || i > 16) {
+            fprintf(stderr, "error: Filename too long (%d>16) %s, Aborting\n", i, p);
             exit(1);
         }
-//      printf("argc %d argv3 %s\n", argc, p);
+//printf("argc %d argv3 %s\n", argc, p);
         if ((fp = fopen(p, "r")) == NULL) {
             fprintf(stderr, "error: can't open user file %s\n", p);
             exit(1);
         }
         fnp = p;                                /* get file name pointer */
-        fseek(fp, 0, SEEK_END);                 /* seek to end */
-        word = ftell(fp);                       /* get filesize in bytes */
-        fseek(fp, 0, SEEK_SET);                 /* rewind file */
-        size = (word/768);                      /* filesize in sectors */
-        if (word%768 != 0)                      /* see if byte left over */
-            size += 1;                          /* partial sector, add 1 */
-        blks = (word/4608);                     /* blocks */
-        if ((word%4608) != 0)
-            blks++; 
-        printf("write SMD %s user %s size %d bytes %d sect %d blocks\n",
-            fnp, userp, word, size, blks);
-        fclose(fp);
 
-        /* create smd entry for this file */
-        memset(name, ' ', 8);                   /* blank filename */
-        for (i=0; i<8; i++) {
+        /* create dir entry for this file */
+        /* first is 16 char filename */
+        memset(name, ' ', 16);                  /* blank directory */
+        for (i=0; i<16; i++) {
             if (p[i] == '\0')                   /* check for null termination char */
                 break;
             name[i] = toupper(p[i]);            /* uppercase filename */
         }
-        /* populate the 32 byte SMD entry */
-        /* word 1 and 2 has filename */
-        smd[0] = name[3] << 24 | name[2] << 16 | name[1] << 8 | name[0];
-        smd[1] = name[7] << 24 | name[6] << 16 | name[5] << 8 | name[4];
-        /* type and smd loc in wd 2  */
-        smd[2] = typ;                           /* save the type of file */
-        /* size now has load module size in sectors */
-        size = 0x80000000 | (blks * 6);         /* file flags and size */
-        smd[3] = (size & 0xff) << 24 | (size & 0xff00) << 8 |
-            (size & 0xff0000) >> 8 | (size & 0xff000000) >> 24;
-        memset(name, ' ', 8);                   /* blank username */
-        for (i=0; i<8; i++) {
-            if (userp[i] == '\0')               /* check for null termination char */
+        /* populate the 16 byte file name entry */
+        dirlist[n+0] = name[3] << 24 | name[2] << 16 | name[1] << 8 | name[0];
+        dirlist[n+1] = name[7] << 24 | name[6] << 16 | name[5] << 8 | name[4];
+        dirlist[n+2] = name[11] << 24 | name[10] << 16 | name[9] << 8 | name[8];
+        dirlist[n+3] = name[15] << 24 | name[14] << 16 | name[13] << 8 | name[12];
+        n += 4;
+
+        /* populate the 16 byte directory/user name entry */
+        memset(name, ' ', 16);                  /* blank directory */
+        for (i=0; i<16; i++) {
+            if (dirp[i] == '\0')                /* check for null termination char */
                 break;
-            name[i] = toupper(userp[i]);        /* uppercase username */
+            name[i] = toupper(dirp[i]);         /* uppercase directory name */
         }
-        /* set username */
-        smd[4] = name[3] << 24 | name[2] << 16 | name[1] << 8 | name[0];
-        smd[5] = name[7] << 24 | name[6] << 16 | name[5] << 8 | name[4];
-        if ((smd[4] == 0x20202020 && smd[5] == 0x20202020) ||
-            (smd[4] == 0 && smd[5] == 0)) {
-            smd[4] = smd[5] = 0;                /* use null for system */
+        /* set directory name */
+        dirlist[n+0] = name[3] << 24 | name[2] << 16 | name[1] << 8 | name[0];
+        dirlist[n+1] = name[7] << 24 | name[6] << 16 | name[5] << 8 | name[4];
+        dirlist[n+2] = name[11] << 24 | name[10] << 16 | name[9] << 8 | name[8];
+        dirlist[n+3] = name[15] << 24 | name[14] << 16 | name[13] << 8 | name[12];
+        n += 4;
+
+        /* populate the 16 byte volume name entry */
+        memset(name, ' ', 16);                  /* blank directory */
+        for (i=0; i<16; i++) {
+            if (dirp[i] == '\0')                /* check for null termination char */
+                break;
+            name[i] = toupper(dirp[i]);         /* uppercase directory name */
         }
-        smd[6] = 0x00080000;                    /* no password or udt index */
-        smd[7] = 0x00000080;                    /* fmgr has 0x80000000 in it so I will too */
-        for (i=0; i<8; i++)
-            *dirp++ = smd[i];                   /* save smd entry */
+        /* set volume name */
+        dirlist[n+0] = sysname[3] << 24 | sysname[2] << 16 | sysname[1] << 8 | sysname[0];
+        dirlist[n+1] = sysname[7] << 24 | sysname[6] << 16 | sysname[5] << 8 | sysname[4];
+        dirlist[n+2] = sysname[11] << 24 | sysname[10] << 16 | sysname[9] << 8 | sysname[8];
+        dirlist[n+3] = sysname[15] << 24 | sysname[14] << 16 | sysname[13] << 8 | sysname[12];
+        n += 4;
+
         filen++;                                /* bump the file count */
         totent++;                               /* bump total count */
-        if (filen == 144) {                     /* see if entry is full */
-            /* we need to write out the directory entries */
-            int32_t n1, n2, nw;
-            /* we have data to write */
-            int32_t hc = (4608 + 1) & ~1;       /* make byte count even */
-            /* write actual byte count to 32 bit word as header */
-            n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
-            /* write the data mod 2 */
-            nw = fwrite((unsigned char *)dir, 1, (size_t)hc, dp);
-            /* write the byte count in 32 bit word as footer */
-            n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
-            if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc))
-            {
-                fprintf(stderr, "write (%d) failure\n", nw);
-                fprintf(stderr, "Operation aborted\n");
-                exit(1);
-            }
-//          memset((char *)dir, 0, 4608);       /* zero smd storage */
-            filen = 0;                          /* restart count */
-//          dirp = (u_int32_t *)dir;            /* get word pointer for smd data */
-        }
     }
 
+//printf("AT write file list with %d entries\n", filen);
+    /* dirlist now has 1-127 filename entries to save */
     /* write out the directory entries for the files to save */
     if (filen != 0) {
         /* we need to write out the directory entries */
         int32_t n1, n2, nw;
-        /* we have data to write */
-        int32_t hc = (4608 + 1) & ~1;           /* make byte count even */
+        int32_t hc = (6144 + 1) & ~1;           /* make byte count even */
+        /* put record type 1 in dirlist[0] byte swapped */
+        dirlist[0] = 0x01000000;                /* record type 1 */
+        /* put the number of entries into dirlist[1] */
+        dirlist[1] = (filen&0xff) << 24 | (filen&0xff00) << 16 |
+            (filen&0xff0000) >> 8 | ((filen&0xff000000) >> 16);
+
+        /* now output the record */
         /* write actual byte count to 32 bit word as header */
         n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
         /* write the data mod 2 */
-        nw = fwrite((unsigned char *)dir, 1, (size_t)hc, dp);
+        nw = fwrite((unsigned char *)dirlist, 1, (size_t)hc, dp);
         /* write the byte count in 32 bit word as footer */
         n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
         if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc))
@@ -664,66 +688,223 @@ printf("image file %s n1 %x (%d) n2 %x (%d) blks %x (%d)\n",
             fprintf(stderr, "Operation aborted\n");
             exit(1);
         }
-//      memset(dir, 0, 4608);                   /* zero smd storage */
-        filen = 0;                              /* restart count */
+//      filen = 0;                              /* restart count */
     }
+
+    /* write EOF (zero) to file */
+    eof = 0;                                    /* zero count */
+    fwrite((char *)(&eof), 1, (size_t)sizeof(eof), dp);
 
     /* totcnt has total number of files to output */
     memset((char *)data, 0, 4608);              /* zero data storage */
     argc = targc;                               /* restore argc for reread */
     argv = targv;                               /* restore argv for reread */
+    n = 2;
     /* read each file and output to save tape file in 6 sector blocks */
     while (--argc > 0) {
+        int32_t n1, n2, nw, k;
+        int32_t hc = (1536 + 1) & ~1;           /* make byte count even */
         int blks;
 
         p = *argv++;
-//      printf("argc %d argv3 %s\n", argc, p);
+//printf("at 4 argc %d argv %s\n", argc, p);
+
         if ((fp = fopen(p, "r")) == NULL) {
             fprintf(stderr, "error: can't open user file %s\n", p);
             exit(1);
         }
         fnp = p;                                /* get file name pointer */
+
+        /* we need to write the resource descriptor in 2 blks to file */
+        /* followed by file content is 8 blk chunks */
         fseek(fp, 0, SEEK_END);                 /* seek to end */
         word = ftell(fp);                       /* get filesize in bytes */
         fseek(fp, 0, SEEK_SET);                 /* rewind file */
         size = (word/768);                      /* filesize in sectors */
         if (word%768 != 0)                      /* see if byte left over */
             size += 1;                          /* partial sector, add 1 */
-        blks = (word/4608);                     /* blocks */
-        if ((word%4608) != 0)
-            blks++; 
-//      rewind(fp);                             /* back to beginning */
-        while (fread((char *)data, 1, 4608, fp) > 0) {
-            int32_t n1, n2, nw;
-            /* we have data to write */
-            int32_t hc = (4608 + 1) & ~1;       /* make byte count even */
-            /* write actual byte count to 32 bit word as header */
-            n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
-            /* write the data mod 2 */
-            nw = fwrite((unsigned char *)data, 1, (size_t)hc, dp);
-            /* write the byte count in 32 bit word as footer */
-            n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
-            if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc))
-            {
-                fprintf(stderr, "write (%d) failure\n", nw);
-                fprintf(stderr, "Operation aborted\n");
-                exit(1);
-            }
-            memset((char *)data, 0, 4608);      /* zero data storage */
-        }
-        printf("write file %s user %s (size %d bytes) (%d sect) (%d blocks)\n",
-            fnp, userp, word, size, blks);
+        /* round up mod 4 */
+        size += 3;
+        size &= ~3;
         fclose(fp);
+        /*******************************/
+        memset((char *)resdes, 0, sizeof(resdes));  /* zero resource descriptor storage */
+        /* wd 0 record type 2, wd 1 is zero of phase error flag n/u */
+        resdes[0] = 0x02000000;                 /* 2 byte swapped */
+        /* 48 char file/directory/volume name (122 wds) */
+        /* copy name from dirlist written earlier */
+        resdes[2] = dirlist[n+0];               /* file */
+        resdes[3] = dirlist[n+1];
+        resdes[4] = dirlist[n+2];
+        resdes[5] = dirlist[n+3];
+        resdes[6] = dirlist[n+4];               /* directory, system*/
+        resdes[7] = dirlist[n+5];
+        resdes[8] = dirlist[n+6];
+        resdes[9] = dirlist[n+7];
+        resdes[10] = dirlist[n+8];               /* volume, system */
+        resdes[11] = dirlist[n+9];
+        resdes[12]= dirlist[n+10];
+        resdes[13]= dirlist[n+11];
+        /* 16 word resource create block */
+        resdes[14] = dirlist[n+8];              /* owner, system */
+        resdes[15] = dirlist[n+9];
+        resdes[16]= dirlist[n+10];
+        resdes[17]= dirlist[n+11];
+        resdes[18] = dirlist[n+8];              /* group, system */
+        resdes[19] = dirlist[n+9];
+        resdes[20]= dirlist[n+10];
+        resdes[21]= dirlist[n+11];
+        n += 12;
+        resdes[22]=flip(0x80f00000);            /* owner rights */
+        resdes[23]=flip(0x80b00000);            /* group rights */
+        resdes[24]=flip(0x80800000);            /* other rights */
+        if (typ == 0xca)
+            resdes[25]=flip(0x00040110);        /* res mgmt flags */
+        else
+            resdes[25]=flip(0x00040110);        /* res mgmt flags */
+//          resdes[25]=flip(0x0004011c);        /* res mgmt flags */
+        resdes[29]=flip(size);                  /* org file size */
+        resdes[31]=flip(1000);                  /* file starting address n/u */
+        resdes[33]=flip(0x00fbfeef);            /* option flags */
+        /* reset of block is zero */
+
+        /* second block is resosurce descriptor from disk */
+        resdes[192] = dirlist[n+8];             /* volume, system */
+        resdes[193] = dirlist[n+9];
+        resdes[194]= dirlist[n+10];
+        resdes[195]= dirlist[n+11];
+
+        resdes[196]=flip(0x00003190);           /* creation date */
+        resdes[197]=flip(0x0e8c8000);           /* creation time */
+        resdes[198]=flip(0x000003c0);           /* abs blk if res des */
+        resdes[199]=flip(0x0000000a);           /* resource type, perm file */
+
+        resdes[200]=flip(0x000029cf);           /* creation date */
+        resdes[201]=flip(0x1dd8e074);           /* creation time */
+        //202
+        //203
+
+        //204
+        //205
+        resdes[206]=flip(0x000029cf);           /* last chge date */
+        resdes[207]=flip(0x1dd8e074);           /* last chge time */
+
+        resdes[208]=flip(0x00003190);           /* creation date */
+        resdes[209]=flip(0x0e8c8000);           /* creation time */
+        //210
+        //211
+
+        resdes[212] = dirlist[n+8];             /* ownername last changer, system */
+        resdes[213] = dirlist[n+9];
+        resdes[214] = dirlist[n+8];             /* ownername creator, system */
+        resdes[215] = dirlist[n+9];
+
+        //216
+        //217
+        resdes[218] = dirlist[n+8];             /* ownername of resource, system */
+        resdes[219] = dirlist[n+9];
+
+        resdes[220] = dirlist[n+8];             /* group of resource, system */
+        resdes[221] = dirlist[n+9];
+        resdes[222]=flip(0xf8400000);           /* owner access */
+//      resdes[223]=flip(0xf8e00000);           /* group access */
+        resdes[223]=flip(0xf8400000);           /* group access */
+
+        resdes[224]=flip(0x80000000);           /* other access */
+        //225
+        resdes[226]=flip(0x00000001);           /* resource link count */
+        //227
+
+        //228-255
+
+        resdes[256]=flip(0xca100010);           /* space definition flags */
+        if (typ == 0xca)
+            resdes[256]=flip(0xca100010);       /* space definition flags */
+        else
+        if (typ == 0xee)
+            resdes[256]=flip(0xee1000f1);       /* space definition flags */
+        else
+        if (typ == 0x00)
+            resdes[256]=flip(0x001000f1);       /* space definition flags */
+        resdes[257]=flip(0x00000018);           /* max extends */
+        resdes[258]=flip(0x00000008);           /* min incr */
+        //259
+
+//      resdes[260]=flip(size-1);               /* eof */
+//      resdes[261]=flip(size);                 /* eom */
+        resdes[260]=flip(size);                 /* eof */
+        resdes[261]=flip(size+1);               /* eom */
+        resdes[262]=flip(0x00000001);           /* segment */
+        //263
+
+        resdes[264]=resdes[6];                  /* directory, system*/
+        resdes[265]=resdes[7];
+        resdes[266]=resdes[8];
+        resdes[267]=resdes[9];
+
+        resdes[268]=flip(0x00000100);           /* parent blk number */
+        resdes[269]=flip(0x00000001);           /* segments at creation  */
+        //270
+        //271
+
+        resdes[272]=resdes[2];                  /* filename*/
+        resdes[273]=resdes[3];
+        resdes[274]=resdes[4];
+        resdes[275]=resdes[5];
+
+        resdes[276]=flip(0x00000100);           /* parent blk number */
+        resdes[277]=flip(0x000005c0);           /* parent didr index number */
+        //277
+        //278
+
+        //279-286
+
+        resdes[288]=flip(0x0000fda8);           /* file blk number */
+        resdes[289]=flip(size);                 /* eom */
+
+        /* all others are zero */
+
+        /* we have data to write */
+        /* write actual byte count to 32 bit word as header */
+        n1 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+        /* write the data mod 2 */
+        nw = fwrite((unsigned char *)resdes, 1, sizeof(resdes), dp);
+        /* write the byte count in 32 bit word as footer */
+        n2 = fwrite((char *)(&hc), 1, (size_t)sizeof(hc), dp);
+        if (n1 != sizeof(hc) || nw != hc || n2 != sizeof(hc))
+        {
+            fprintf(stderr, "rd write (%d) failure\n", nw);
+            fprintf(stderr, "Operation aborted\n");
+            exit(1);
+        }
+        /*******************************/
+        /* write file up to 8 blks at a time */
+        writefile(dp, fnp, 0, 8);               /* all of file 1 blk at a time */
+
+//printf("File written at 4 argc %d argv %s\n", argc, fnp);
+
+        /* write EOF (zero) to file */
+        eof = 0;                                /* zero count */
+        fwrite((char *)(&eof), 1, (size_t)sizeof(eof), dp);
     }
+    /* we have saved the files in the image, write 2 eof's & 1 EOM */
+//  word = ftell(dp);                           /* get position in bytes */
+//  printf("setting after file EOF write pos %x %d\n", word, word);
     /* write EOF (zero) to file */
     filen = 0;                                  /* zero count */
     fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
+//  word = ftell(dp);                           /* get position in bytes */
+//  printf("setting after 1st EOF file pos %x %d\n", word, word);
     /* do second EOF */
     fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
     filen = -1;                                 /* make in -1 for EOM */
+//  word = ftell(dp);                           /* get position in bytes */
+//  printf("setting after 2st EOF file pos %x %d\n", word, word);
     /* do EOM */
     fwrite((char *)(&filen), 1, (size_t)sizeof(filen), dp);
-//  printf("setting at %ld bytes in file after EOM\n", ftell(dp));
+//  word = ftell(dp);                           /* get position in bytes */
+//  printf("setting after EOM file pos %x %d\n", word, word);
+printf("setting at %lx (%ld) bytes in file after EOM\n", ftell(dp), ftell(dp));
     fclose(dp);
     exit(0);
 }

--- a/SEL32/taptools/tapdump.c
+++ b/SEL32/taptools/tapdump.c
@@ -50,11 +50,13 @@ int getloi(char *s, int lim)
                     fprintf(stderr, "file %d: record %d: size %d (%x)\n", filen, lcount, ln, ln);
             }
             fprintf(stderr, "file %d: eof after %d records: %d bytes (%x)\n", filen, count, size, size);
+            fprintf(stderr, "file %d EOFcnt %d offset %x\n", filen, EOFcnt, tsize);
 #endif
             filen++;    /* set next file number */
         } else {
 #ifndef NOTDUMP
             fprintf(stderr, "second eof after %d files: %d bytes (%x)\n", filen, size, size);
+            fprintf(stderr, "second file %d EOFcnt %d offset %x\n", filen, EOFcnt, tsize);
 #endif
         }
         count = 0;      /* file record count back to zero */


### PR DESCRIPTION
SEL32: Create mkdiagtape utility to generate SEL diagnostic tapes.
SEL32: Update DP disk and Ethernet software for diag detected errors.
SEL32: Update mkvmtape utility to correctly build MPX3X save tapes.
SEL32: Modify taptools makefile for new mkdiagtape utility.
SEL32: Update README.md file for taptools.