### PR TITLE
KA10: Use MATCH_CMD to match command string.

### DIFF
--- a/PDP10/ka10_imx.c
+++ b/PDP10/ka10_imx.c
@@ -291,7 +291,7 @@ t_stat imx_set_channel (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
     return r;
 
   if (*tptr != 0) {
-    if (strcasecmp (tptr, "negate") != 0)
+    if (MATCH_CMD (tptr, "NEGATE"))
       return SCPE_ARG;
     negate = 1;
   }


### PR DESCRIPTION
Mark insists on this.