### PR TITLE
KA10: ITS build broken on Travis CI servers.

### DIFF
--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -4732,13 +4732,6 @@ in_loop:
                      goto in_loop;
              }
 #endif
-             /* Handle events during a indirect loop */
-             AIO_CHECK_EVENT;                                   /* queue async events */
-             if (--sim_interval <= 0) {
-                  if ((reason = sim_process_event()) != SCPE_OK) {
-                      return reason;
-                  }
-             }
              if ((!pi_cycle) & pi_pending
 #if KI | KL | KS
                              & (!trap_flag)
@@ -4754,6 +4747,13 @@ in_loop:
                  ind = 0;
              }
 #endif
+         }
+         /* Handle events during a indirect loop */
+         AIO_CHECK_EVENT;                                   /* queue async events */
+         if (--sim_interval <= 0) {
+              if ((reason = sim_process_event()) != SCPE_OK) {
+                  return reason;
+              }
          }
     } while (ind & !pi_rq);
 


### PR DESCRIPTION
Commit fdf17b80a1725a0d5c14beb89bd9ee1dd5d5f696 was the last to work with the ITS build script running on the Travis CI servers.  The next commit e4882ce3bc5c51b3f76c7214931be572f611f5c8 broke the build.  By reverting pieces of e488 I have determined that the move of sim_process_event in the indirect loop is the cause.  If I move those lines outside the if statement, c488 will work again.

I am in the process of testing this against the latest master commit.  I will post the result here.