### PR TITLE
SEL32: Correct map loading for MPX run requested tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,27 +173,32 @@ Support for the following units:
     Communications
     * 2703 with 16 lines of 1050.
 
-# SEL32 Development Simulator
+# SEL32 Concept/32 Simulator
 
 This is a working simulator for the SEL Concept/32 line of computers.  The
-current test version is for the SEL 32/27, 32/67, 32/87, 32/97, V6, and V9
+current version is for the SEL 32/27, 32/67, 32/87, 32/97, V6, and V9
 computers.  Support for 32/55, and 32/75 computers may be added in the future.
 This simulator is co-authors with James C. Bevier. I did the initial parts
 of the simulator, James took it to a working simulator, I am assisting him
-in maintaining and enhancing the simulator. This simulator is running a test
-version of MPX-32 1.5F.  It is capable of creating a disk image of the O/S
-from a SDT tape.  The disk image can be booted, initialized, and run many of
-the MPX utilities; including OPCOM & TSM.  Eight terminals can be used to
-access TSM via Telnet port 4747.  Initial support has been added for excess
-64 floating point arithmetic.  More testing is still required.  The sim32disk.gz
-can be uncompressed and booted with the sel32.27.sim32.disk.ini initialization
-file.  The sim32sdt.tap.gz file can also be uncompressed and started with the
-sel32.27.sim32.tape.ini initialization file to install from tape.
+in maintaining and enhancing the simulator. 
 
-The current version can also install and run UTX 2.1A from an install tape.
-It is the SEL version of System V Unix and BSD Unix ported to the V6 and V9
-processors.  It can run in single or multi user mode.  UTX utilizes the basemode
-instruction set and a virtual memory system provided by the V6 & V9 CPUs.
-There are still some random halts and panics.  The system needs further
-testing to solidify the SEL32 simulator code.
+All of the processors except for the 32/77 can run the Gould diags.  MPX 1.X
+support for the 32/77 computers may be added in the future.  The level one
+diags are run as part of the SIMH build of SEL32 to verify that the simulator
+is operating correctly.  The diags are located in the tests directory.  Diag.tap
+contains the diagnostic programs and diag.ini contains the directives to
+configure and run the SEL32 simulator.
+
+This simulator is capable of running UTX2.1A, UTX2.1B, MPX 1.5F, and a
+test version of MPX 3.4.  It is capable of creating a disk image for the
+O/S from a UTX or MPX SDT tape. The disk image can be booted, initialized,
+and can run many of the UTX and MPX utilities and programs. Ethernet is
+supported on UTX and may be added to MPX in the future.  Eight terminals
+can be used to access MPX via Telnet port 4747. The sumulator has support
+for excess 64 floating point arithmetic and passes the 32/27 and 32/67 FP
+diags.  UTX is the SEL version of System V Unix and BSD Unix ported to the
+V6 and V9 processors.  UTX utilizes the basemode instruction set and a
+virtual memory system supported by the V6 & V9 CPUs.  The system needs
+further testing to solidify the SEL32 simulator code in all of the
+supported environmenets.
 

--- a/SEL32/README.md
+++ b/SEL32/README.md
@@ -1,23 +1,37 @@
 
-# SEL32 Development Simulator
+# SEL32 Concept/32 Simulator
 
-This is a working copy of a simulator for the SEL Concept/32 computer.
-The current test version is for the SEL 32/27, 32/67, 32/77, 32/87,
-32/97, V6, and V9 computers.  All of the processors except for the
-32/77 can run the Gould diags.  Support for 32/55 computers may be added
-in the future.
+This is a working simulator for the SEL Concept/32 computer. The 
+current version is for the SEL 32/27, 32/67, 32/77, 32/87, 32/97, V6,
+and V9 computers.  All of the processors except for the 32/77 can run
+the Gould diags.  Operational support for the 32/77 computers may be
+added in the future.
 
 # SEL Concept/32 
 
-This simulator is running a test version of MPX-32 1.5F.  It is capable
-of creating a disk image of the O/S from a SDT tape.  The disk image
-can be booted, initialized, and run many of the MPX utilities; including
-OPCOM & TSM.  Eight terminals can be used to access TSM via Telnet port
-4747. The sumulator has support for excess 64 floating point arithmetic.
-The sim32disk.gz can be uncompressed and booted with the
-sel32.27.sim32.disk.ini initialization file.  The sim32sdt.tap.gz file can
-also be uncompressed and started with the sel32.27.sim32.tape.ini
-initialization file to do a sdt install to disk from tape.
+This simulator is capable of running UTX2.1A, UTX2.1B, MPX 1.5F, and a
+test version of MPX 3.4.  It is capable of creating a disk image for the
+O/S from a UTX or MPX SDT tape. The disk image can be booted, initialized,
+and can run many of the UTX and MPX utilities and programs. Ethernet is
+supported on UTX and may be added to MPX in the future.  Eight terminals
+can be used to access MPX via Telnet port 4747. The sumulator has support
+for excess 64 floating point arithmetic and passes the 32/27 and 32/67 FP
+diags.
+
+The sim32disk.gz file is a prebuilt MPX 1.5F system disk.  It can be
+uncompressed and booted with the sel32.27.sim32.disk.ini initialization
+file.  The sim32sdt.tap.gz file can also be uncompressed and started with
+the sel32.27.sim32.tape.ini initialization file to do a sdt install to
+disk from tape.  There are three test versions of UTX.  Utxtest1a.ini,
+utxtest1b.ini, utxtest1c.ini are three initialization files to build a
+UTX 2.1A system.  Utxtest1a.ini builds and loads the root filesystem on
+/dev/dk0a.  Utxtest1b.ini boots the new root file system from disk and
+builds the usr file system on /dev/dk0d.  Utxtest1c.ini boots the UTX
+system from disk and enters multi-user mode.  Utxtest2[a-c].ini files
+do the same thing for UTX 2.1B.  Utxscsi[a-c].ini builds a MFP SCSI disk
+UTX 2.1B system.  These files are only available from my sims project at
+https://github.com/AZBevier/sims.  A MPX 3.X test version will be added
+in the future when testing is complete.
 
 Available tap tools:
 taptools.tgz - set of tools to work with .tap formatted tapes.  Also tools
@@ -43,7 +57,7 @@ sim32sdt.tap - MPX 1.5f user SDT install tape.  Uses 300mb disk, IOP 8-line
                FIL> X
 
 Available Level One Diagnostic boot tape:
-diag.ini       command file to start diags. Type "./sel32 diag.ini"
+diag.ini       command file to start diags. Type "./sel32 tests/diag.ini"
 diag.tap       bootable level one diagnostic tape w/auto testing.  Set
                cpu type to 32/27, 32/67, 32/87, 32/97, V6 or V9.  All
                cpu models now run all diagnostics provided on the
@@ -66,7 +80,7 @@ diag.tap       bootable level one diagnostic tape w/auto testing.  Set
                CV.CSD - WCS read/write trap diag.  Disabled in auto testing.
                CV.CON - Operators Console runs all tests for all CPUs.
                CV.DXP - Diagnostic executive for level 2 diags. OK in batch.
-               CV.MMM - Level two shared memory diag runs under DXP OK.
+               67.FPT - Level two floating point diag runs under DXP OK.
                CV.ITD - Level two interval timer diag runs under DXP OK.
 
                Set GPR[0] = 0xffffffff before booting from tape to disable the
@@ -75,7 +89,7 @@ diag.tap       bootable level one diagnostic tape w/auto testing.  Set
                diagnostics.  Updates to follow as tests are corrected.
 
 Available UTX-21a install tape for testing:
-utxtape1.ini   command file to start UTX install tape.  ./sel32 utxtape1.ini
+utxtest1a.ini  command file to start UTX install tape.  "./sel32 utxtest1a.ini"
 utx21a1.tap    bootable UTX install tape for testing basemode.  The current
                V6 & V9 will boot UTX into single/multi user mode.  You can run
                the full set of the commands that are on the installation tapes.
@@ -83,15 +97,13 @@ utx21a1.tap    bootable UTX install tape for testing basemode.  The current
                drive.  Other file systems can be created and saves restored.
                All basemode instructions have been tested with the CV.BRD diag.
                The virtual memory has been fully tested with the VM.MMM diag.
-               UTX needs better support for operator console.  There are still
-               some random panics/halts.  More testing is still needed.
 
-Other MPX verion support:
+Other MPX verions support:
                I am still looking for an MPX 3.X user or master SDT tape.  I have
                much of the source, but no loadable code to create a bootable system.
                Please keep looking for anyone who can provide these tapes or a
-               disk image of a bootable system.
+               disk image of a bootable MPX3.X system.
 
 James C. Bevier
-01/23/2021 
+02/13/2021 
 

--- a/SEL32/sel32_clk.c
+++ b/SEL32/sel32_clk.c
@@ -44,16 +44,16 @@ t_stat rtc_show_freq (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 t_stat rtc_help(FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, CONST char *cptr);
 const char *rtc_desc(DEVICE *dptr);
 
-extern int  irq_pend;               /* go scan for pending int or I/O */
-extern uint32 INTS[];               /* interrupt control flags */
-extern uint32 SPAD[];               /* computer SPAD */
-extern uint32 M[];                  /* system memory */
-extern uint32  outbusy;             /* output waiting on timeout */
-extern uint32  inbusy;              /* input waiting on timeout */
+extern int  irq_pend;                       /* go scan for pending int or I/O */
+extern uint32 INTS[];                       /* interrupt control flags */
+extern uint32 SPAD[];                       /* computer SPAD */
+extern uint32 M[];                          /* system memory */
+extern uint32  outbusy;                     /* output waiting on timeout */
+extern uint32  inbusy;                      /* input waiting on timeout */
 
-int32 rtc_pie = 0;                  /* rtc pulse ie */
-int32 rtc_tps = 60;                 /* rtc ticks/sec */
-int32 rtc_lvl = 0x18;               /* rtc interrupt level */
+int32 rtc_pie = 0;                          /* rtc pulse ie */
+int32 rtc_tps = 60;                         /* rtc ticks/sec */
+int32 rtc_lvl = 0x18;                       /* rtc interrupt level */
 
 /* Clock data structures
    rtc_dev      RTC device descriptor
@@ -90,12 +90,12 @@ MTAB rtc_mod[] = {
 DEVICE rtc_dev = {
     "RTC", &rtc_unit, rtc_reg, rtc_mod,
     1, 8, 8, 1, 8, 8,
-    NULL, NULL, &rtc_reset,         /* examine, deposit, reset */
-    NULL, NULL, NULL,               /* boot, attach, detach */
-    NULL, DEV_DEBUG|DEV_DIS|DEV_DISABLE, 0, dev_debug,  /* dib, dev flags, debug flags, debug */
-//  NULL, DEV_DEBUG|DEV_DISABLE, 0, dev_debug,  /* dib, dev flags, debug flags, debug */
-    NULL, NULL, &rtc_help,          /* ?, ?, help */
-    NULL, NULL, &rtc_desc,          /* ?, ?, description */
+    NULL, NULL, &rtc_reset,                 /* examine, deposit, reset */
+    NULL, NULL, NULL,                       /* boot, attach, detach */
+    /* dib, dev flags, debug flags, debug */
+    NULL, DEV_DEBUG|DEV_DIS|DEV_DISABLE, 0, dev_debug,
+    NULL, NULL, &rtc_help,                  /* ?, ?, help */
+    NULL, NULL, &rtc_desc,                  /* ?, ?, description */
     };
 
 /* The real time clock runs continuously; therefore, it only has
@@ -115,24 +115,24 @@ t_stat rtc_srv (UNIT *uptr)
         sim_debug(DEBUG_CMD, &rtc_dev,
             "RT Clock int INTS[%02x] %08x SPAD[%02x] %08x\n",
             rtc_lvl, INTS[rtc_lvl], rtc_lvl+0x80, SPAD[rtc_lvl+0x80]);
-        if (((INTS[rtc_lvl] & INTS_ENAB) ||         /* make sure enabled */
+        if (((INTS[rtc_lvl] & INTS_ENAB) ||     /* make sure enabled */
             (SPAD[rtc_lvl+0x80] & SINT_ENAB)) &&    /* in spad too */
             (((INTS[rtc_lvl] & INTS_ACT) == 0) ||   /* and not active */
             ((SPAD[rtc_lvl+0x80] & SINT_ACT) == 0))) { /* in spad too */
             /* HACK for console I/O stopping */
             /* This reduces the number of console I/O stopping errors */
             /* need to find real cause of I/O stopping on clock interrupt */
-            if ((outbusy==0) && (inbusy==0))        /* skip interrupt if con I/O in busy wait */
-                INTS[rtc_lvl] |= INTS_REQ;          /* request the interrupt */
-            irq_pend = 1;                           /* make sure we scan for int */
+            if ((outbusy==0) && (inbusy==0))    /* skip interrupt if con I/O in busy wait */
+                INTS[rtc_lvl] |= INTS_REQ;  /* request the interrupt */
+            irq_pend = 1;                   /* make sure we scan for int */
         }
         sim_debug(DEBUG_CMD, &rtc_dev,
             "RT Clock int INTS[%02x] %08x SPAD[%02x] %08x\n",
             rtc_lvl, INTS[rtc_lvl], rtc_lvl+0x80, SPAD[rtc_lvl+0x80]);
     }
-//  temp = sim_rtcn_calb(rtc_tps, TMR_RTC);         /* timer 0 for RTC */
-    sim_rtcn_calb(rtc_tps, TMR_RTC);                /* timer 0 for RTC */
-    sim_activate_after(uptr, 1000000/rtc_tps);      /* reactivate 16666 tics / sec */
+//  temp = sim_rtcn_calb(rtc_tps, TMR_RTC); /* timer 0 for RTC */
+    sim_rtcn_calb(rtc_tps, TMR_RTC);        /* timer 0 for RTC */
+    sim_activate_after(uptr, 1000000/rtc_tps);  /* reactivate 16666 tics / sec */
     return SCPE_OK;
 }
 
@@ -142,47 +142,47 @@ t_stat rtc_srv (UNIT *uptr)
 /* level = interrupt level */
 void rtc_setup(uint32 ss, uint32 level)
 {
-    uint32 addr = SPAD[0xf1] + (level<<2);          /* vector address in SPAD */
+    uint32 addr = SPAD[0xf1] + (level<<2);  /* vector address in SPAD */
 
-    rtc_lvl = level;                                /* save the interrupt level */
-    addr = M[addr>>2];                              /* get the interrupt context block addr */
-    if (ss == 1) {                                  /* starting? */
-        INTS[level] |= INTS_ENAB;                   /* make sure enabled */
-        SPAD[level+0x80] |= SINT_ENAB;              /* in spad too */
-        sim_activate(&rtc_unit, 20);                /* start us off */
+    rtc_lvl = level;                        /* save the interrupt level */
+    addr = M[addr>>2];                      /* get the interrupt context block addr */
+    if (ss == 1) {                          /* starting? */
+        INTS[level] |= INTS_ENAB;           /* make sure enabled */
+        SPAD[level+0x80] |= SINT_ENAB;      /* in spad too */
+        sim_activate(&rtc_unit, 20);        /* start us off */
         sim_debug(DEBUG_CMD, &rtc_dev,
             "RT Clock setup enable int %02x rtc_pie %01x ss %01x\n",
             rtc_lvl, rtc_pie, ss);
     } else {
-        INTS[level] &= ~INTS_ENAB;                  /* make sure disabled */
-        SPAD[level+0x80] &= ~SINT_ENAB;             /* in spad too */
-        INTS[level] &= ~INTS_ACT;                   /* make sure request not active */
-        SPAD[level+0x80] &= ~SINT_ACT;              /* in spad too */
+        INTS[level] &= ~INTS_ENAB;          /* make sure disabled */
+        SPAD[level+0x80] &= ~SINT_ENAB;     /* in spad too */
+        INTS[level] &= ~INTS_ACT;           /* make sure request not active */
+        SPAD[level+0x80] &= ~SINT_ACT;      /* in spad too */
         sim_debug(DEBUG_CMD, &rtc_dev,
             "RT Clock setup disable int %02x rtc_pie %01x ss %01x\n",
             rtc_lvl, rtc_pie, ss);
     }
-    rtc_pie = ss;                                   /* set new state */
+    rtc_pie = ss;                           /* set new state */
 }
 
 /* Clock reset */
 t_stat rtc_reset(DEVICE *dptr)
 {
-    rtc_pie = 0;                                    /* disable pulse */
+    rtc_pie = 0;                            /* disable pulse */
     /* initialize clock calibration */
-    sim_activate (&rtc_unit, rtc_unit.wait);        /* activate unit */
+    sim_activate (&rtc_unit, rtc_unit.wait);    /* activate unit */
     return SCPE_OK;
 }
 
 /* Set frequency */
 t_stat rtc_set_freq(UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-    if (cptr)                                       /* if chars, bad */
-        return SCPE_ARG;                            /* ARG error */
+    if (cptr)                               /* if chars, bad */
+        return SCPE_ARG;                    /* ARG error */
     if ((val != 50) && (val != 60) && (val != 100) && (val != 120))
-        return SCPE_IERR;                           /* scope error */
-    rtc_tps = val;                                  /* set the new frequency */
-    return SCPE_OK;                                 /* we done */
+        return SCPE_IERR;                   /* scope error */
+    rtc_tps = val;                          /* set the new frequency */
+    return SCPE_OK;                         /* we done */
 }
 
 /* Show frequency */
@@ -217,16 +217,16 @@ const char *rtc_desc(DEVICE *dptr)
 /************************************************************************/
 
 /* Interval Timer support */
-int32 itm_src = 0;                                  /* itm source freq 0=itm 1=rtc */
-int32 itm_pie = 0;                                  /* itm pulse enable */
-int32 itm_run = 0;                                  /* itm is running */
-int32 itm_cmd = 0;                                  /* itm last user cmd */
-int32 itm_cnt = 0;                                  /* itm reload pulse count */
-int32 itm_tick_size_x_100 = 3840;                   /* itm 26042 ticks/sec = 38.4 us per tic */
-int32 itm_lvl = 0x5f;                               /* itm interrupt level */
-int32 itm_strt = 0;                                 /* clock start time in usec */
-int32 itm_load = 0;                                 /* clock loaded */
-int32 itm_big = 26042 * 6000;                       /* about 100 minutes */
+int32 itm_src = 0;                          /* itm source freq 0=itm 1=rtc */
+int32 itm_pie = 0;                          /* itm pulse enable */
+int32 itm_run = 0;                          /* itm is running */
+int32 itm_cmd = 0;                          /* itm last user cmd */
+int32 itm_cnt = 0;                          /* itm reload pulse count */
+int32 itm_tick_size_x_100 = 3840;           /* itm 26042 ticks/sec = 38.4 us per tic */
+int32 itm_lvl = 0x5f;                       /* itm interrupt level */
+int32 itm_strt = 0;                         /* clock start time in usec */
+int32 itm_load = 0;                         /* clock loaded */
+int32 itm_big = 26042 * 6000;               /* about 100 minutes */
 t_stat itm_srv (UNIT *uptr);
 t_stat itm_set_freq (UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 t_stat itm_reset (DEVICE *dptr);
@@ -266,11 +266,11 @@ MTAB itm_mod[] = {
 DEVICE itm_dev = {
     "ITM", &itm_unit, itm_reg, itm_mod,
     1, 8, 8, 1, 8, 8,
-    NULL, NULL, &itm_reset,         /* examine, deposit, reset */
-    NULL, NULL, NULL,               /* boot, attach, detach */
-    NULL, DEV_DEBUG, 0, dev_debug,  /* dib, dev flags, debug flags, debug */
-    NULL, NULL, &itm_help,          /* ?, ?, help */
-    NULL, NULL, &itm_desc,          /* ?, ?, description */
+    NULL, NULL, &itm_reset,                 /* examine, deposit, reset */
+    NULL, NULL, NULL,                       /* boot, attach, detach */
+    NULL, DEV_DEBUG, 0, dev_debug,          /* dib, dev flags, debug flags, debug */
+    NULL, NULL, &itm_help,                  /* ?, ?, help */
+    NULL, NULL, &itm_desc,                  /* ?, ?, description */
     };
 
 /* The interval timer downcounts the value it is loaded with and
@@ -283,48 +283,48 @@ DEVICE itm_dev = {
 /* cause interrupt */
 t_stat itm_srv (UNIT *uptr)
 {
-    if (itm_pie) {                                  /* interrupt enabled? */
+    if (itm_pie) {                          /* interrupt enabled? */
         time_t result = time(NULL);
         sim_debug(DEBUG_CMD, &itm_dev,
             "Intv Timer expired status %08x lev %02x cnt %x @ time %08x\n",
             INTS[itm_lvl], itm_lvl, itm_cnt, (uint32)result);
-        if (((INTS[itm_lvl] & INTS_ENAB) ||         /* make sure enabled */
+        if (((INTS[itm_lvl] & INTS_ENAB) || /* make sure enabled */
             (SPAD[itm_lvl+0x80] & SINT_ENAB)) &&    /* in spad too */
             (((INTS[itm_lvl] & INTS_ACT) == 0) ||   /* and not active */
             ((SPAD[itm_lvl+0x80] & SINT_ACT) == 0))) { /* in spad too */
-            INTS[itm_lvl] |= INTS_REQ;              /* request the interrupt */
-            irq_pend = 1;                           /* make sure we scan for int */
+            INTS[itm_lvl] |= INTS_REQ;      /* request the interrupt */
+            irq_pend = 1;                   /* make sure we scan for int */
         }
-        sim_cancel (&itm_unit);                     /* cancel current timer */
-        itm_run = 0;                                /* timer is no longer running */
+        sim_cancel (&itm_unit);             /* cancel current timer */
+        itm_run = 0;                        /* timer is no longer running */
         /* if cmd BIT29 is set, reload & restart */
         if ((INTS[itm_lvl] & INTS_ENAB) && (itm_cmd & 0x04) && (itm_cnt != 0)) {
             sim_debug(DEBUG_CMD, &itm_dev,
                 "Intv Timer reload on expired int %02x value %08x\n",
                 itm_lvl, itm_cnt);
             /* restart timer with value from user */
-            if (itm_src)                            /* use specified src freq */
+            if (itm_src)                    /* use specified src freq */
                 sim_activate_after_abs_d(&itm_unit, ((double)itm_cnt*350000)/rtc_tps);
 //DIAG          sim_activate_after_abs_d(&itm_unit, ((double)itm_cnt*400000)/rtc_tps);
 //DIAG          sim_activate_after_abs_d(&itm_unit, ((double)itm_cnt*1000000)/rtc_tps);
             else
                 sim_activate_after_abs_d(&itm_unit, ((double)itm_cnt*itm_tick_size_x_100)/100.0);
-            itm_run = 1;                            /* show timer running */
-            itm_load = itm_cnt;                     /* save loaded value */
-            itm_strt = 0;                           /* no negative start time */
+            itm_run = 1;                    /* show timer running */
+            itm_load = itm_cnt;             /* save loaded value */
+            itm_strt = 0;                   /* no negative start time */
         } else {
-            int32 cnt = itm_big;                    /* 0x65ba TRY 1,000,000/38.4 10 secs */
-            itm_strt = cnt;                         /* get negative start time */
+            int32 cnt = itm_big;            /* 0x65ba TRY 1,000,000/38.4 10 secs */
+            itm_strt = cnt;                 /* get negative start time */
             sim_debug(DEBUG_CMD, &itm_dev,
                 "Intv Timer reload for neg cnts on expired int %02x value %08x\n",
                 itm_lvl, cnt);
             /* restart timer with large value for negative timer value simulation */
-            if (itm_src)                            /* use specified src freq */
+            if (itm_src)                    /* use specified src freq */
                 sim_activate_after_abs_d(&itm_unit, ((double)cnt*1000000)/rtc_tps);
             else
                 sim_activate_after_abs_d(&itm_unit, ((double)cnt*itm_tick_size_x_100) / 100.0);
-            itm_run = 1;                            /* show timer running */
-            itm_load = cnt;                         /* save loaded value */
+            itm_run = 1;                    /* show timer running */
+            itm_load = cnt;                 /* save loaded value */
         }
     }
     return SCPE_OK;
@@ -355,238 +355,257 @@ int32 itm_rdwr(uint32 cmd, int32 cnt, uint32 level)
 {
     uint32  temp;
 
-    cmd &= 0x7f;                                    /* just need the cmd */
-    itm_cmd = cmd;                                  /* save last cmd */
+    cmd &= 0x7f;                            /* just need the cmd */
+    itm_cmd = cmd;                          /* save last cmd */
     switch (cmd) {
-    case 0x20:                                      /* stop timer */
+    case 0x20:                              /* stop timer */
         /* stop the timer and save the curr value for later */
-        temp = itm_load;                            /* use last loaded value */
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%2x kill value %08x (%08d) itm_load %08x\n",
+        temp = itm_load;                    /* use last loaded value */
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%2x kill value %08x (%08d) itm_load %08x\n",
             cmd, cnt, cnt, temp);
-        if (itm_run) {                              /* if we were running save curr cnt */
+        if (itm_run) {                      /* if we were running save curr cnt */
             /* read timer value */
             temp = (uint32)(100.0*sim_activate_time_usecs(&itm_unit)/itm_tick_size_x_100);
-            sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%2x temp value %08x (%d)\n", cmd, temp, temp);
-            if (itm_strt) {                         /* see if running neg */
+            sim_debug(DEBUG_CMD, &itm_dev,
+                "Intv 0x%2x temp value %08x (%d)\n", cmd, temp, temp);
+            if (itm_strt) {                 /* see if running neg */
                 /* we only get here if timer ran out and no reload value */
                 /* get simulated negative start time in counts */
-                temp = temp - itm_strt;             /* make into a negative number */
+                temp = temp - itm_strt;     /* make into a negative number */
             } 
         }
-        sim_cancel (&itm_unit);                     /* cancel itc */
-        itm_run = 0;                                /* timer is not running */
-        itm_cnt = 0;                                /* no count reset value */
-        itm_load = temp;                            /* last loaded value */
-        itm_strt = 0;                               /* not restarted neg */
-        return 0;                                   /* does not matter, no value returned  */
+        sim_cancel (&itm_unit);             /* cancel itc */
+        itm_run = 0;                        /* timer is not running */
+        itm_cnt = 0;                        /* no count reset value */
+        itm_load = temp;                    /* last loaded value */
+        itm_strt = 0;                       /* not restarted neg */
+        return 0;                           /* does not matter, no value returned  */
         break;
 
-    case 0x29:                                      /* load timer with new value and start lo rate */
-    case 0x28:                                      /* load timer with new value and start hi rate */
-    case 0x2a:                                      /* load timer with new value and use RTC */
-    case 0x2b:                                      /* load timer with new value and start hi rate */
-    case 0x38:                                      /* load timer with new value and start hi rate */
-    case 0x39:                                      /* load timer with new value and start lo rate */
-    case 0x3a:                                      /* load timer with new value and start hi rate */
-    case 0x3b:                                      /* load timer with new value and start lo rate */
-        if (itm_run)                                /* if we were running stop timer */
-            sim_cancel (&itm_unit);                 /* cancel timer */
-        itm_run = 0;                                /* stop timer running */
-        if (cmd & 0x10) {                           /* clock to start? */
+    case 0x29:                              /* load new value and start lo rate */
+    case 0x28:                              /* load new value and start hi rate */
+    case 0x2a:                              /* load new value and use RTC */
+    case 0x2b:                              /* load new value and start hi rate */
+    case 0x38:                              /* load new value and start hi rate */
+    case 0x39:                              /* load new value and start lo rate */
+    case 0x3a:                              /* load new value and start hi rate */
+    case 0x3b:                              /* load new value and start lo rate */
+        if (itm_run)                        /* if we were running stop timer */
+            sim_cancel (&itm_unit);         /* cancel timer */
+        itm_run = 0;                        /* stop timer running */
+        if (cmd & 0x10) {                   /* clock to start? */
             /* start timer with value from user */
             /* if bits 30-31 == 20, use RTC freq */
-            itm_src = (cmd>>1)&1;                   /* set src */
-            if (itm_src)                            /* use specified src freq */
+            itm_src = (cmd>>1)&1;           /* set src */
+            if (itm_src)                    /* use specified src freq */
                 /* use clock frequency */
                 sim_activate_after_abs_d(&itm_unit, ((double)cnt*1000000)/rtc_tps);
             else
                 /* use interval timer freq */
-                sim_activate_after_abs_d(&itm_unit, ((double)cnt*itm_tick_size_x_100)/100.0);
-            itm_run = 1;                            /* set timer running */
+//MPX3X         sim_activate_after_abs_d(&itm_unit, ((double)cnt*itm_tick_size_x_100)/100.0);
+                sim_activate_after_abs_d(&itm_unit, ((double)(cnt+1)*itm_tick_size_x_100)/100.0);
+            itm_run = 1;                    /* set timer running */
         }
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%02x init value %08x (%08d)\n", cmd, cnt, cnt);
-        itm_cnt = 0;                                /* no count reset value */
-        itm_load = cnt;                             /* now loaded */
-        itm_strt = 0;                               /* not restarted neg */
-        return 0;                                   /* does not matter, no value returned  */
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%02x init value %08x (%08d)\n", cmd, cnt, cnt);
+        itm_cnt = 0;                        /* no count reset value */
+        itm_load = cnt;                     /* now loaded */
+        itm_strt = 0;                       /* not restarted neg */
+        return 0;                           /* does not matter, no value returned  */
         break;
 
-    case 0x70:                                      /* start timer with curr value*/
-    case 0x71:                                      /* start timer with curr value */
-    case 0x72:                                      /* start timer with RTC value*/
-    case 0x74:                                      /* start timer with curr value*/
-    case 0x75:                                      /* start timer with curr value */
-    case 0x76:                                      /* start timer with RTC value*/
-    case 0x30:                                      /* start timer with curr value*/
-    case 0x31:                                      /* start timer with curr value*/
-    case 0x32:                                      /* start timer with RTC value*/
-    case 0x34:                                      /* start timer with curr value*/
-    case 0x35:                                      /* start timer with curr value */
-    case 0x36:                                      /* start timer with RTC value*/
-    case 0x37:                                      /* start timer with curr value */
-        temp = itm_load;                            /* get last loaded value */
-        if (itm_run) {                              /* if we were running save curr cnt */
+    case 0x70:                              /* start timer with curr value*/
+    case 0x71:                              /* start timer with curr value */
+    case 0x72:                              /* start timer with RTC value*/
+    case 0x74:                              /* start timer with curr value*/
+    case 0x75:                              /* start timer with curr value */
+    case 0x76:                              /* start timer with RTC value*/
+    case 0x30:                              /* start timer with curr value*/
+    case 0x31:                              /* start timer with curr value*/
+    case 0x32:                              /* start timer with RTC value*/
+    case 0x34:                              /* start timer with curr value*/
+    case 0x35:                              /* start timer with curr value */
+    case 0x36:                              /* start timer with RTC value*/
+    case 0x37:                              /* start timer with curr value */
+        temp = itm_load;                    /* get last loaded value */
+        if (itm_run) {                      /* if we were running save curr cnt */
             /* read timer value */
             temp = (uint32)(100.0*sim_activate_time_usecs(&itm_unit)/itm_tick_size_x_100);
-            sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%2x temp value %08x (%d)\n", cmd, temp, temp);
-            if (itm_strt) {                         /* see if running neg */
+            sim_debug(DEBUG_CMD, &itm_dev,
+                "Intv 0x%2x temp value %08x (%d)\n", cmd, temp, temp);
+            if (itm_strt) {                 /* see if running neg */
                 /* we only get here if timer ran out and no reload value */
                 /* get simulated negative start time in counts */
-                temp = temp - itm_strt;             /* make into a negative number */
+                temp = temp - itm_strt;     /* make into a negative number */
             } 
-            sim_cancel (&itm_unit);                 /* cancel timer */
+            sim_cancel (&itm_unit);         /* cancel timer */
         }
         /* start timer with current or user value, reload on zero time */
-        cnt = temp;                                 /* use current value */
+        cnt = temp;                         /* use current value */
         /* if bits 30-31 == 20, use RTC freq */
-        itm_src = (cmd>>1)&1;                       /* set src */
-        if (itm_src)                                /* use specified src freq */
+        itm_src = (cmd>>1)&1;               /* set src */
+        if (itm_src)                        /* use specified src freq */
 //DIAG      sim_activate_after_abs_d(&itm_unit, ((double)cnt*400000)/rtc_tps);
             sim_activate_after_abs_d(&itm_unit, ((double)cnt*1000000)/rtc_tps);
         else
             sim_activate_after_abs_d(&itm_unit, ((double)cnt*itm_tick_size_x_100)/100.0);
-        itm_run = 1;                                /* set timer running */
+        itm_run = 1;                        /* set timer running */
 
-        if (cmd & 0x04)                             /* do we reload on zero? */
-            itm_cnt = cnt;                          /* count reset value */
+        if (cmd & 0x04)                     /* do we reload on zero? */
+            itm_cnt = cnt;                  /* count reset value */
         else
-            itm_cnt = 0;                            /* no count reset value */
-        itm_strt = 0;                               /* not restarted neg */
-        itm_load = cnt;                             /* now loaded */
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%02x return value %08x (%08d)\n", cmd, temp, temp);
-        return temp;                                /* return curr count */
+            itm_cnt = 0;                    /* no count reset value */
+        itm_strt = 0;                       /* not restarted neg */
+        itm_load = cnt;                     /* now loaded */
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%02x return value %08x (%08d)\n", cmd, temp, temp);
+        return temp;                        /* return curr count */
         break;
 
-    case 0x3c:                                      /* load timer with new value and start */
-    case 0x3d:                                      /* load timer with new value and start */
+    case 0x3c:                              /* load timer with new value and start */
+    case 0x3d:                              /* load timer with new value and start */
     /* load timer with new value and start using RTC as source */
-    case 0x3e:                                      /* load timer with new value and start RTC*/
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%2x init value %08x (%d)\n", cmd, cnt, cnt);
-        sim_cancel (&itm_unit);                     /* cancel timer */
+    case 0x3e:                              /* load timer with new value and start RTC*/
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%2x init value %08x (%d)\n", cmd, cnt, cnt);
+        sim_cancel (&itm_unit);             /* cancel timer */
         /* if bits 30-31 == 20, use RTC freq */
-        itm_src = (cmd>>1)&1;                       /* set src */
-        if (itm_src)                                /* use specified src freq */
+        itm_src = (cmd>>1)&1;               /* set src */
+        if (itm_src)                        /* use specified src freq */
             sim_activate_after_abs_d(&itm_unit, ((double)cnt*700000)/rtc_tps);
         else
             sim_activate_after_abs_d(&itm_unit, ((double)cnt*itm_tick_size_x_100)/100.0);
-        itm_run = 1;                                /* set timer running */
+        itm_run = 1;                        /* set timer running */
 
-        if (cmd & 0x04)                             /* do we reload on zero? */
-            itm_cnt = cnt;                          /* count reset value */
-        itm_strt = 0;                               /* not restarted neg */
-        itm_load = cnt;                             /* now loaded */
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%02x return value %08x (%08d)\n", cmd, cnt, cnt);
-        return 0;                                   /* does not matter, no value returned  */
+        if (cmd & 0x04)                     /* do we reload on zero? */
+            itm_cnt = cnt;                  /* count reset value */
+        itm_strt = 0;                       /* not restarted neg */
+        itm_load = cnt;                     /* now loaded */
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%02x return value %08x (%08d)\n", cmd, cnt, cnt);
+        return 0;                           /* does not matter, no value returned  */
         break;
 
-    case 0x40:                                      /* read the current timer value */
+    case 0x40:                              /* read the current timer value */
         /* return current count value from timer */
-        temp = itm_load;                            /* get last loaded value */
-        if (itm_run) {                              /* if we were running save curr cnt */
+        temp = itm_load;                    /* get last loaded value */
+        if (itm_run) {                      /* if we were running save curr cnt */
             /* read timer value */
             temp = (uint32)(100.0*sim_activate_time_usecs(&itm_unit)/itm_tick_size_x_100);
-            sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%2x read value %08x (%d)\n", cmd, temp, temp);
-            if (itm_strt) {                         /* see if running neg */
+            sim_debug(DEBUG_CMD, &itm_dev,
+                "Intv 0x%2x read value %08x (%d)\n", cmd, temp, temp);
+            if (itm_strt) {                 /* see if running neg */
                 /* we only get here if timer ran out and no reload value */
                 /* get simulated negative start time in counts */
-                temp = temp - itm_strt;             /* make into a negative number */
+                temp = temp - itm_strt;     /* make into a negative number */
             } 
         }
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x40 return value %08x (%d)\n", temp, temp);
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x40 return value %08x (%d)\n", temp, temp);
         return temp;
         break;
 
-    case 0x60:                                      /* read and stop timer */
+    case 0x60:                              /* read and stop timer */
         /* get timer value and stop timer */
-        temp = itm_load;                            /* get last loaded value */
-        if (itm_run) {                              /* if we were running save curr cnt */
+        temp = itm_load;                    /* get last loaded value */
+        if (itm_run) {                      /* if we were running save curr cnt */
             /* read timer value */
             temp = (uint32)(100.0*sim_activate_time_usecs(&itm_unit)/itm_tick_size_x_100);
-            sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%2x read value %08x (%d)\n", cmd, temp, temp);
-            if (itm_strt) {                         /* see if running neg */
+            sim_debug(DEBUG_CMD, &itm_dev,
+                "Intv 0x%2x read value %08x (%d)\n", cmd, temp, temp);
+            if (itm_strt) {                 /* see if running neg */
                 /* we only get here if timer ran out and no reload value */
                 /* get simulated negative start time in counts */
-                temp = temp - itm_strt;             /* make into a negative number */
+                temp = temp - itm_strt;     /* make into a negative number */
             } 
-            sim_cancel (&itm_unit);                 /* cancel timer */
+            sim_cancel (&itm_unit);         /* cancel timer */
         }
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%2x temp value %08x (%d)\n", cmd, temp, temp);
-        itm_run = 0;                                /* stop timer running */
-        itm_cnt = 0;                                /* no reload count value */
-        itm_load = temp;                            /* current loaded value */
-        itm_strt = 0;                               /* not restarted neg */
-        return temp;                                /* return current count value */
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%2x temp value %08x (%d)\n", cmd, temp, temp);
+        itm_run = 0;                        /* stop timer running */
+        itm_cnt = 0;                        /* no reload count value */
+        itm_load = temp;                    /* current loaded value */
+        itm_strt = 0;                       /* not restarted neg */
+        return temp;                        /* return current count value */
         break;
 
-    case 0x6a:                                      /* read value & load new one */
-    case 0x68:                                      /* read value & load new one */
-    case 0x69:                                      /* read value & load new one */
+    case 0x6a:                              /* read value & load new one */
+    case 0x68:                              /* read value & load new one */
+    case 0x69:                              /* read value & load new one */
         /* get timer value and load new value, do not start timer */
-        temp = itm_load;                            /* get last loaded value */
-        if (itm_run) {                              /* if we were running save curr cnt */
+        temp = itm_load;                    /* get last loaded value */
+        if (itm_run) {                      /* if we were running save curr cnt */
             /* read timer value */
             temp = (uint32)(100.0*sim_activate_time_usecs(&itm_unit)/itm_tick_size_x_100);
-            sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%2x read value %08x (%d)\n", cmd, temp, temp);
-            if (itm_strt) {                         /* see if running neg */
+            sim_debug(DEBUG_CMD, &itm_dev,
+                "Intv 0x%2x read value %08x (%d)\n", cmd, temp, temp);
+            if (itm_strt) {                 /* see if running neg */
                 /* we only get here if timer ran out and no reload value */
                 /* get simulated negative start time in counts */
-                temp = temp - itm_strt;             /* make into a negative number */
+                temp = temp - itm_strt;     /* make into a negative number */
             } 
-            sim_cancel (&itm_unit);                 /* cancel timer */
+            sim_cancel (&itm_unit);         /* cancel timer */
         }
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%02x temp value %08x (%08d)\n", cmd, temp, temp);
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%02x init value %08x (%08d)\n", cmd, cnt, cnt);
-        itm_src = (cmd>>1)&1;                       /* set src */
-        itm_run = 0;                                /* stop timer running */
-        itm_cnt = 0;                                /* no count reset value */
-        itm_strt = 0;                               /* not restarted neg */
-        itm_load = cnt;                             /* now loaded */
-        return temp;                                /* return current count value */
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%02x temp value %08x (%08d)\n", cmd, temp, temp);
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%02x init value %08x (%08d)\n", cmd, cnt, cnt);
+        itm_src = (cmd>>1)&1;               /* set src */
+        itm_run = 0;                        /* stop timer running */
+        itm_cnt = 0;                        /* no count reset value */
+        itm_strt = 0;                       /* not restarted neg */
+        itm_load = cnt;                     /* now loaded */
+        return temp;                        /* return current count value */
         break;
 
-    case 0x7d:                                      /* read the current timer value */
-    case 0x78:                                      /* read the current timer value */
-    case 0x79:                                      /* read the current timer value */
-    case 0x7a:                                      /* read the current timer value */
-    case 0x7b:                                      /* read the current timer value */
-    case 0x7c:                                      /* read the current timer value */
-    case 0x7e:                                      /* read the current timer value */
-    case 0x7f:                                      /* read the current timer value */
+    case 0x7d:                              /* read the current timer value */
+    case 0x78:                              /* read the current timer value */
+    case 0x79:                              /* read the current timer value */
+    case 0x7a:                              /* read the current timer value */
+    case 0x7b:                              /* read the current timer value */
+    case 0x7c:                              /* read the current timer value */
+    case 0x7e:                              /* read the current timer value */
+    case 0x7f:                              /* read the current timer value */
         /* get timer value, load new value and start timer */
-        temp = itm_load;                            /* get last loaded value */
-        if (itm_run) {                              /* if we were running save curr cnt */
+        temp = itm_load;                    /* get last loaded value */
+        if (itm_run) {                      /* if we were running save curr cnt */
             /* read timer value */
             temp = (uint32)(100.0*sim_activate_time_usecs(&itm_unit)/itm_tick_size_x_100);
-            sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%2x read value %08x (%d)\n", cmd, temp, temp);
-            if (itm_strt) {                         /* see if running neg */
+            sim_debug(DEBUG_CMD, &itm_dev,
+                "Intv 0x%2x read value %08x (%d)\n", cmd, temp, temp);
+            if (itm_strt) {                 /* see if running neg */
                 /* we only get here if timer ran out and no reload value */
                 /* get simulated negative start time in counts */
-                temp = temp - itm_strt;             /* make into a negative number */
+                temp = temp - itm_strt;     /* make into a negative number */
             } 
-            sim_cancel (&itm_unit);                 /* cancel timer */
+//          sim_cancel (&itm_unit);         /* cancel timer */
         }
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%02x temp value %08x (%08d)\n", cmd, temp, temp);
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv 0x%02x init value %08x (%08d)\n", cmd, cnt, cnt);
-        sim_cancel (&itm_unit);                     /* cancel timer */
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%02x temp value %08x (%08d)\n", cmd, temp, temp);
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv 0x%02x init value %08x (%08d)\n", cmd, cnt, cnt);
+        sim_cancel (&itm_unit);             /* cancel timer */
         /* start timer to fire after cnt ticks */
-        itm_src = (cmd>>1)&1;                       /* set src */
-        if (itm_src)                                /* use specified src freq */
+        itm_src = (cmd>>1)&1;               /* set src */
+        if (itm_src)                        /* use specified src freq */
             sim_activate_after_abs_d(&itm_unit, ((double)cnt*1000000)/rtc_tps);
         else
             sim_activate_after_abs_d(&itm_unit, ((double)cnt*itm_tick_size_x_100)/100.0);
-        itm_cnt = 0;                                /* no count reset value */
-        if (cmd & 0x04)                             /* reload on int? */
-            itm_cnt = cnt;                          /* set reload count value */
-        itm_run = 1;                                /* set timer running */
-        itm_strt = 0;                               /* not restarted neg */
-        itm_load = cnt;                             /* now loaded */
-        return temp;                                /* return current count value */
+        itm_cnt = 0;                        /* no count reset value */
+        if (cmd & 0x04)                     /* reload on int? */
+            itm_cnt = cnt;                  /* set reload count value */
+        itm_run = 1;                        /* set timer running */
+        itm_strt = 0;                       /* not restarted neg */
+        itm_load = cnt;                     /* now loaded */
+        return temp;                        /* return current count value */
         break;
     default:
-        sim_debug(DEBUG_CMD, &itm_dev, "Intv unknown cmd %02x level %02x\n", cmd, level);
+        sim_debug(DEBUG_CMD, &itm_dev,
+            "Intv unknown cmd %02x level %02x\n", cmd, level);
         break;
     }
-    return 0;                                       /* does not matter, no value returned  */
+    return 0;                               /* does not matter, no value returned  */
 }
 
 /* Clock interrupt start/stop */
@@ -595,51 +614,51 @@ int32 itm_rdwr(uint32 cmd, int32 cnt, uint32 level)
 /* level = interrupt level */
 void itm_setup(uint32 ss, uint32 level)
 {
-    itm_lvl = level;                                /* save the interrupt level */
-    itm_load = 0;                                   /* not loaded */
-    itm_src = 0;                                    /* use itm for freq */
-    itm_strt = 0;                                   /* not restarted neg */
-    itm_run = 0;                                    /* not running */
-    itm_cnt = 0;                                    /* no count reset value */
-    sim_cancel (&itm_unit);                         /* not running yet */
-    if (ss == 1) {                                  /* starting? */
-        INTS[level] |= INTS_ENAB;                   /* make sure enabled */
-        SPAD[level+0x80] |= SINT_ENAB;              /* in spad too */
+    itm_lvl = level;                        /* save the interrupt level */
+    itm_load = 0;                           /* not loaded */
+    itm_src = 0;                            /* use itm for freq */
+    itm_strt = 0;                           /* not restarted neg */
+    itm_run = 0;                            /* not running */
+    itm_cnt = 0;                            /* no count reset value */
+    sim_cancel (&itm_unit);                 /* not running yet */
+    if (ss == 1) {                          /* starting? */
+        INTS[level] |= INTS_ENAB;           /* make sure enabled */
+        SPAD[level+0x80] |= SINT_ENAB;      /* in spad too */
         sim_debug(DEBUG_CMD, &itm_dev,
             "Intv Timer setup enable int %02x value %08x itm_pie %01x ss %01x\n",
             itm_lvl, itm_cnt, itm_pie, ss);
     } else {
-        INTS[level] &= ~INTS_ENAB;                  /* make sure disabled */
-        SPAD[level+0x80] &= ~SINT_ENAB;             /* in spad too */
+        INTS[level] &= ~INTS_ENAB;          /* make sure disabled */
+        SPAD[level+0x80] &= ~SINT_ENAB;     /* in spad too */
         sim_debug(DEBUG_CMD, &itm_dev,
             "Intv Timer setup disable int %02x value %08x itm_pie %01x ss %01x\n",
             itm_lvl, itm_cnt, itm_pie, ss);
     }
-    itm_pie = ss;                                   /* set new state */
+    itm_pie = ss;                           /* set new state */
 }
 
 /* Clock reset */
 t_stat itm_reset (DEVICE *dptr)
 {
-    itm_pie = 0;                                    /* disable pulse */
-    itm_run = 0;                                    /* not running */
-    itm_load = 0;                                   /* not loaded */
-    itm_src = 0;                                    /* use itm for freq */
-    itm_strt = 0;                                   /* not restarted neg */
-    itm_cnt = 0;                                    /* no count reset value */
-    sim_cancel (&itm_unit);                         /* not running yet */
+    itm_pie = 0;                            /* disable pulse */
+    itm_run = 0;                            /* not running */
+    itm_load = 0;                           /* not loaded */
+    itm_src = 0;                            /* use itm for freq */
+    itm_strt = 0;                           /* not restarted neg */
+    itm_cnt = 0;                            /* no count reset value */
+    sim_cancel (&itm_unit);                 /* not running yet */
     return SCPE_OK;
 }
 
 /* Set frequency */
 t_stat itm_set_freq (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
-    if (cptr)                                       /* if chars, bad */
-        return SCPE_ARG;                            /* ARG error */
+    if (cptr)                               /* if chars, bad */
+        return SCPE_ARG;                    /* ARG error */
     if ((val != 3840) && (val != 7680))
-        return SCPE_IERR;                           /* scope error */
-    itm_tick_size_x_100 = val;                      /* set the new frequency */
-    return SCPE_OK;                                 /* we done */
+        return SCPE_IERR;                   /* scope error */
+    itm_tick_size_x_100 = val;              /* set the new frequency */
+    return SCPE_OK;                         /* we done */
 }
 
 /* Show frequency */

--- a/SEL32/sel32_com.c
+++ b/SEL32/sel32_com.c
@@ -30,157 +30,157 @@
 #if NUM_DEVS_COM > 0
 
 /* Constants */
-#define COM_LINES       8                               /* max lines */
-#define COM_LINES_DFLT  8                               /* default lines */
+#define COM_LINES       8                   /* max lines */
+#define COM_LINES_DFLT  8                   /* default lines */
 #define COM_INIT_POLL   8000
 #define COML_WAIT       500
 #define COM_WAIT        500
-#define COM_NUMLIN      com_desc.lines                  /* curr # lines */
+#define COM_NUMLIN      com_desc.lines      /* curr # lines */
 
-#define COMC            0                               /* channel thread */
-#define COMI            1                               /* input thread */
+#define COMC            0                   /* channel thread */
+#define COMI            1                   /* input thread */
 
 /* Line status */
-#define COML_XIA        0x01                            /* xmt intr armed */
-#define COML_XIR        0x02                            /* xmt intr req */
-#define COML_REP        0x04                            /* rcv enable pend */
-#define COML_RBP        0x10                            /* rcv break pend */
+#define COML_XIA        0x01                /* xmt intr armed */
+#define COML_XIR        0x02                /* xmt intr req */
+#define COML_REP        0x04                /* rcv enable pend */
+#define COML_RBP        0x10                /* rcv break pend */
 
 /* Channel state */
-#define COMC_IDLE       0                               /* idle */
-#define COMC_INIT       1                               /* init */
-#define COMC_RCV        2                               /* receive */
-#define COMC_END        3                               /* end */
+#define COMC_IDLE       0                   /* idle */
+#define COMC_INIT       1                   /* init */
+#define COMC_RCV        2                   /* receive */
+#define COMC_END        3                   /* end */
 
-uint8 com_rbuf[COM_LINES];                              /* rcv buf */
-uint8 com_xbuf[COM_LINES];                              /* xmt buf */
-uint8 com_sta[COM_LINES];                               /* status */
-uint32 com_lstat[COM_LINES][2] = { 0 };                 /* 8 bytes of line settings status */
-uint32 com_tps = 2;                                     /* polls/second */
-uint32 com_scan = 0;                                    /* scanner */
-uint32 com_slck = 0;                                    /* scanner locked */
-uint32 comc_cmd = COMC_IDLE;                            /* channel state */
+uint8 com_rbuf[COM_LINES];                  /* rcv buf */
+uint8 com_xbuf[COM_LINES];                  /* xmt buf */
+uint8 com_sta[COM_LINES];                   /* status */
+uint32 com_lstat[COM_LINES][2] = { 0 };     /* 8 bytes of line settings status */
+uint32 com_tps = 2;                         /* polls/second */
+uint32 com_scan = 0;                        /* scanner */
+uint32 com_slck = 0;                        /* scanner locked */
+uint32 comc_cmd = COMC_IDLE;                /* channel state */
 
-TMLN com_ldsc[COM_LINES] = { 0 };                       /* line descrs */
-TMXR com_desc = { COM_LINES_DFLT, 0, 0, com_ldsc };     /* com descr */
+TMLN com_ldsc[COM_LINES] = { 0 };           /* line descrs */
+TMXR com_desc = { COM_LINES_DFLT, 0, 0, com_ldsc }; /* com descr */
 
 /* Held in u3 is the device command and status */
-#define COM_INCH    0x00    /* Initialize channel command */
-#define COM_WR      0x01    /* Write terminal */
-#define COM_RD      0x02    /* Read terminal */
-#define COM_NOP     0x03    /* No op command */
-#define COM_SNS     0x04    /* Sense command */
-#define COM_WRSCM   0x05    /* Write w/Sub chan monitor */
-#define COM_RDECHO  0x06    /* Read with Echo */
-#define COM_RDFC    0x0A    /* Read w/flow control */
-#define COM_DEFSC   0x0B    /* Define special char */
-#define COM_WRHFC   0x0D    /* Write hardware flow control */
-#define COM_RDTR    0x13    /* Reset DTR (ADVR) */
-#define COM_SDTR    0x17    /* Set DTR (ADVF) */
-#define COM_RRTS    0x1B    /* Reset RTS */
-#define COM_SRTS    0x1F    /* Set RTS */
-#define COM_RBRK    0x33    /* Reset BREAK */
-#define COM_SBRK    0x37    /* Set BREAK */
-#define COM_RDHFC   0x8E    /* Read w/hardware flow control only */
-#define COM_SACE    0xFF    /* Set ACE parameters */
+#define COM_INCH    0x00                    /* Initialize channel command */
+#define COM_WR      0x01                    /* Write terminal */
+#define COM_RD      0x02                    /* Read terminal */
+#define COM_NOP     0x03                    /* No op command */
+#define COM_SNS     0x04                    /* Sense command */
+#define COM_WRSCM   0x05                    /* Write w/Sub chan monitor */
+#define COM_RDECHO  0x06                    /* Read with Echo */
+#define COM_RDFC    0x0A                    /* Read w/flow control */
+#define COM_DEFSC   0x0B                    /* Define special char */
+#define COM_WRHFC   0x0D                    /* Write hardware flow control */
+#define COM_RDTR    0x13                    /* Reset DTR (ADVR) */
+#define COM_SDTR    0x17                    /* Set DTR (ADVF) */
+#define COM_RRTS    0x1B                    /* Reset RTS */
+#define COM_SRTS    0x1F                    /* Set RTS */
+#define COM_RBRK    0x33                    /* Reset BREAK */
+#define COM_SBRK    0x37                    /* Set BREAK */
+#define COM_RDHFC   0x8E                    /* Read w/hardware flow control only */
+#define COM_SACE    0xFF                    /* Set ACE parameters */
 
-#define COM_MSK     0xFF    /* Command mask */
+#define COM_MSK     0xFF                    /* Command mask */
 
 /* Status held in u3 */
 /* controller/unit address in upper 16 bits */
-#define COM_INPUT   0x0100  /* Input ready for unit */
-#define COM_CR      0x0200  /* Output at beginning of line */
-#define COM_REQ     0x0400  /* Request key pressed */
-#define COM_EKO     0x0800  /* Echo input character */
-#define COM_OUTPUT  0x1000  /* Output ready for unit */
-#define COM_READ    0x2000  /* Read mode selected */
+#define COM_INPUT   0x0100                  /* Input ready for unit */
+#define COM_CR      0x0200                  /* Output at beginning of line */
+#define COM_REQ     0x0400                  /* Request key pressed */
+#define COM_EKO     0x0800                  /* Echo input character */
+#define COM_OUTPUT  0x1000                  /* Output ready for unit */
+#define COM_READ    0x2000                  /* Read mode selected */
 
 /* ACE data kept in u4 */
 
 /* in u5 packs sense byte 0, 1, 2 and 3 */
 /* Sense byte 0 */
-#define SNS_CMDREJ  0x80000000  /* Command reject */
-#define SNS_INTVENT 0x40000000  /* Unit intervention required (N/U) */
-#define SNS_BOCHK   0x20000000  /* Bus out check (IOP parity error */
-#define SNS_EQUIPCK 0x10000000  /* Equipment check (device error) */
-#define SNS_DATACK  0x08000000  /* Data check */
-#define SNS_OVERRN  0x04000000  /* Overrun (N/U) */
-#define SNS_NUB01   0x02000000  /* Zero (N/U) */
-#define SNS_NUB02   0x01000000  /* Zero (N/U) */
+#define SNS_CMDREJ  0x80000000              /* Command reject */
+#define SNS_INTVENT 0x40000000              /* Unit intervention required (N/U) */
+#define SNS_BOCHK   0x20000000              /* Bus out check (IOP parity error */
+#define SNS_EQUIPCK 0x10000000              /* Equipment check (device error) */
+#define SNS_DATACK  0x08000000              /* Data check */
+#define SNS_OVERRN  0x04000000              /* Overrun (N/U) */
+#define SNS_NUB01   0x02000000              /* Zero (N/U) */
+#define SNS_NUB02   0x01000000              /* Zero (N/U) */
 /* Sense byte 1 */
-#define SNS_ASCIICD 0x00800000  /* ASCII control char detected interrupt */
-#define SNS_SPCLCD  0x00400000  /* Special char detected interrupt */
-#define SNS_ETX     0x00200000  /* ETX interrupt */
-#define SNS_BREAK   0x00100000  /* BREAK interrupt */
-#define SNS_ACEFE   0x00080000  /* ACE framing error interrupt */
-#define SNS_ACEPEI  0x00040000  /* ACE parity error interrupt */
-#define SNS_ACEOVR  0x00020000  /* ACE overrun error interrupt */
-#define SNS_RING    0x00010000  /* Ring character interrupt */
+#define SNS_ASCIICD 0x00800000              /* ASCII control char detected interrupt */
+#define SNS_SPCLCD  0x00400000              /* Special char detected interrupt */
+#define SNS_ETX     0x00200000              /* ETX interrupt */
+#define SNS_BREAK   0x00100000              /* BREAK interrupt */
+#define SNS_ACEFE   0x00080000              /* ACE framing error interrupt */
+#define SNS_ACEPEI  0x00040000              /* ACE parity error interrupt */
+#define SNS_ACEOVR  0x00020000              /* ACE overrun error interrupt */
+#define SNS_RING    0x00010000              /* Ring character interrupt */
 /* Sense byte 2  Modem status */
-#define SNS_RLSDS   0x00008000  /* Received line signal detect status */
-#define SNS_RINGST  0x00004000  /* Ring indicator line status */
-#define SNS_DSRS    0x00002000  /* DSR Data set ready line status */
-#define SNS_CTSS    0x00001000  /* CTS Clear to send line status */
-#define SNS_DELTA   0x00000800  /* Delta receive line signal detect failure interrupt */
-#define SNS_MRING   0x00000400  /* RI Modem ring interrupt */
-#define SNS_DELDSR  0x00000200  /* Delta data set ready interrupt */
-#define SNS_DELCLR  0x00000100  /* Ring character interrupt */
+#define SNS_RLSDS   0x00008000              /* Received line signal detect status */
+#define SNS_RINGST  0x00004000              /* Ring indicator line status */
+#define SNS_DSRS    0x00002000              /* DSR Data set ready line status */
+#define SNS_CTSS    0x00001000              /* CTS Clear to send line status */
+#define SNS_DELTA   0x00000800              /* Delta receive line signal detect failure interrupt */
+#define SNS_MRING   0x00000400              /* RI Modem ring interrupt */
+#define SNS_DELDSR  0x00000200              /* Delta data set ready interrupt */
+#define SNS_DELCLR  0x00000100              /* Ring character interrupt */
 /* Sense byte 3  Modem Control/Operation status */
-#define SNS_HALFD   0x00000080  /* Half-duplix operation set */
-#define SNS_MRINGE  0x00000040  /* Modem ring enabled (1) */
-#define SNS_ACEDEF  0x00000020  /* ACE parameters defined */
-#define SNS_DIAGM   0x00000010  /* Diagnostic mode set */
-#define SNS_AUXOL2  0x00000008  /* Auxiliary output level 2 */
-#define SNS_AUXOL1  0x00000004  /* Auxiliary output level 1 */
-#define SNS_RTS     0x00000002  /* RTS Request to send set */
-#define SNS_DTR     0x00000001  /* DTR Data terminal ready set */
+#define SNS_HALFD   0x00000080              /* Half-duplix operation set */
+#define SNS_MRINGE  0x00000040              /* Modem ring enabled (1) */
+#define SNS_ACEDEF  0x00000020              /* ACE parameters defined */
+#define SNS_DIAGM   0x00000010              /* Diagnostic mode set */
+#define SNS_AUXOL2  0x00000008              /* Auxiliary output level 2 */
+#define SNS_AUXOL1  0x00000004              /* Auxiliary output level 1 */
+#define SNS_RTS     0x00000002              /* RTS Request to send set */
+#define SNS_DTR     0x00000001              /* DTR Data terminal ready set */
 /* Sense byte 4  ACE Parameters status */
-#define SNS_ACEDLE  0x80000000  /* Divisor latch enable 0=dis, 1=enb */
-#define SNS_ACEBS   0x40000000  /* Break set 0=reset, 1=set */
-#define SNS_ACEFP   0x20000000  /* Forced parity 0=odd, 1=even */
-#define SNS_ACEP    0x10000000  /* Parity 0=odd, 1=even */
-#define SNS_ACEPE   0x08000000  /* Parity enable 0=dis, 1=enb */
-#define SNS_ACESTOP 0x04000000  /* Stop bit 0=1, 1=1.5 or 2 */
-#define SNS_ACECLEN 0x02000000  /* Character length 00=5, 01=6, 11=7, 11=8 */
-#define SNS_ACECL2  0x01000000  /* 2nd bit for above */
+#define SNS_ACEDLE  0x80000000              /* Divisor latch enable 0=dis, 1=enb */
+#define SNS_ACEBS   0x40000000              /* Break set 0=reset, 1=set */
+#define SNS_ACEFP   0x20000000              /* Forced parity 0=odd, 1=even */
+#define SNS_ACEP    0x10000000              /* Parity 0=odd, 1=even */
+#define SNS_ACEPE   0x08000000              /* Parity enable 0=dis, 1=enb */
+#define SNS_ACESTOP 0x04000000              /* Stop bit 0=1, 1=1.5 or 2 */
+#define SNS_ACECLEN 0x02000000              /* Character length 00=5, 01=6, 11=7, 11=8 */
+#define SNS_ACECL2  0x01000000              /* 2nd bit for above */
 /* Sense byte 5  Baud rate */
-#define SNS_NUB50   0x00800000  /* Zero N/U */
-#define SNS_NUB51   0x00400000  /* Zero N/U */
-#define SNS_RINGCR  0x00200000  /* Ring or wakeup character recognition 0=enb, 1=dis */
-#define SNS_DIAGL   0x00100000  /* Set diagnostic loopback */
-#define SNS_BAUD    0x000F0000  /* Baud rate bits 4-7 */
-#define BAUD50      0x00000000  /* 50 baud */
-#define BAUD75      0x00010000  /* 75 baud */
-#define BAUD110     0x00020000  /* 110 baud */
-#define BAUD114     0x00030000  /* 134 baud */
-#define BAUD150     0x00040000  /* 150 baud */
-#define BAUD300     0x00050000  /* 300 baud */
-#define BAUD600     0x00060000  /* 600 baud */
-#define BAUD1200    0x00070000  /* 1200 baud */
-#define BAUD1800    0x00080000  /* 1800 baud */
-#define BAUD2000    0x00090000  /* 2000 baud */
-#define BAUD2400    0x000A0000  /* 2400 baud */
-#define BAUD3600    0x000B0000  /* 3600 baud */
-#define BAUD4800    0x000C0000  /* 4800 baud */
-#define BAUD7200    0x000D0000  /* 7200 baud */
-#define BAUD9600    0x000E0000  /* 9600 baud */
-#define BAUD19200   0x000F0000  /* 19200 baud */
+#define SNS_NUB50   0x00800000              /* Zero N/U */
+#define SNS_NUB51   0x00400000              /* Zero N/U */
+#define SNS_RINGCR  0x00200000              /* Ring or wakeup character recognition 0=enb, 1=dis */
+#define SNS_DIAGL   0x00100000              /* Set diagnostic loopback */
+#define SNS_BAUD    0x000F0000              /* Baud rate bits 4-7 */
+#define BAUD50      0x00000000              /* 50 baud */
+#define BAUD75      0x00010000              /* 75 baud */
+#define BAUD110     0x00020000              /* 110 baud */
+#define BAUD114     0x00030000              /* 134 baud */
+#define BAUD150     0x00040000              /* 150 baud */
+#define BAUD300     0x00050000              /* 300 baud */
+#define BAUD600     0x00060000              /* 600 baud */
+#define BAUD1200    0x00070000              /* 1200 baud */
+#define BAUD1800    0x00080000              /* 1800 baud */
+#define BAUD2000    0x00090000              /* 2000 baud */
+#define BAUD2400    0x000A0000              /* 2400 baud */
+#define BAUD3600    0x000B0000              /* 3600 baud */
+#define BAUD4800    0x000C0000              /* 4800 baud */
+#define BAUD7200    0x000D0000              /* 7200 baud */
+#define BAUD9600    0x000E0000              /* 9600 baud */
+#define BAUD19200   0x000F0000              /* 19200 baud */
 /* Sense byte 6  Firmware ID, Revision Level */
-#define SNS_FID     0x00006200  /* ID part 1 */
+#define SNS_FID     0x00006200              /* ID part 1 */
 /* Sense byte 7  Firmware ID, Revision Level */
-#define SNS_REV     0x0000004f  /* ID part 2 plus 4 bit rev # */
+#define SNS_REV     0x0000004f              /* ID part 2 plus 4 bit rev # */
 
 /* ACE information in u4 */
-#define ACE_WAKE    0x0000FF00  /* 8 bit wake-up character */
+#define ACE_WAKE    0x0000FF00              /* 8 bit wake-up character */
 
 /* in u5 packs sense byte 0,1 and 3 */
 /* Sense byte 0 */
-#define SNS_CMDREJ  0x80000000    /* Command reject */
-#define SNS_INTVENT 0x40000000    /* Unit intervention required */
+#define SNS_CMDREJ  0x80000000              /* Command reject */
+#define SNS_INTVENT 0x40000000              /* Unit intervention required */
 /* sense byte 3 */
-#define SNS_RDY     0x80        /* device ready */
-#define SNS_ONLN    0x40        /* device online */
-#define SNS_DSR     0x04        /* data set ready */
+#define SNS_RDY     0x80                    /* device ready */
+#define SNS_ONLN    0x40                    /* device online */
+#define SNS_DSR     0x04                    /* data set ready */
 
 /* u6 */
 
@@ -188,6 +188,8 @@ uint16      com_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd);
 uint16      com_haltio(UNIT *uptr);
 void        com_ini(UNIT *, t_bool);
 void        coml_ini(UNIT *, t_bool);
+uint16      coml_rschnlio(UNIT *uptr);
+uint16      com_rschnlio(UNIT *uptr);
 t_stat      comc_srv(UNIT *uptr);
 t_stat      como_srv(UNIT *uptr);
 t_stat      comi_srv(UNIT *uptr);
@@ -246,7 +248,7 @@ DIB             com_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    com_rschnlio,   /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     NULL,           /* uint16 (*iocl_io)(CHANP *chp, int32 tic_ok)) */  /* Process IOCL */
     com_ini,        /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     com_unit,       /* UNIT* units */                           /* Pointer to units structure */
@@ -314,7 +316,8 @@ UNIT            coml_unit[] = {
     {UDATA(&como_srv, TT_MODE_UC|UNIT_COML, 0), COML_WAIT, UNIT_ADDR(0x7ECF)},       /* F */
 };
 
-//DIB coml_dib = { NULL, com_startcmd, NULL, NULL, NULL, coml_ini, coml_unit, coml_chp, COM_LINES*2, 0x0f, 0x7E00};
+//DIB coml_dib = { NULL, com_startcmd, NULL, NULL, NULL, coml_ini,
+//coml_unit, coml_chp, COM_LINES*2, 0x0f, 0x7E00};
 DIB             coml_dib = {
     NULL,           /* uint16 (*pre_io)(UNIT *uptr, uint16 chan)*/  /* Pre Start I/O */
     com_startcmd,   /* uint16 (*start_cmd)(UNIT *uptr, uint16 chan, uint8 cmd)*/ /* Start command */
@@ -322,7 +325,7 @@ DIB             coml_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    coml_rschnlio,  /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     NULL,           /* uint16 (*iocl_io)(CHANP *chp, int32 tic_ok)) */  /* Process IOCL */
     coml_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     coml_unit,      /* UNIT* units */                           /* Pointer to units structure */
@@ -368,6 +371,20 @@ void coml_ini(UNIT *uptr, t_bool f)
 {
     /* maybe do someting here on master channel init */
     uptr->u5 = SNS_RDY|SNS_ONLN;            /* status is online & ready */
+    uptr->u3 &= LMASK;                      /* leave only chsa */
+    sim_cancel(uptr);                       /* stop any timer */
+}
+
+/* handle rschnlio cmds for coml */
+uint16  coml_rschnlio(UNIT *uptr) {
+    DEVICE  *dptr = get_dev(uptr);
+    uint16  chsa = GET_UADDR(uptr->u3);
+    int     cmd = uptr->u3 & COM_MSK;
+
+    sim_debug(DEBUG_EXP, dptr,
+        "coml_rschnl chsa %04x cmd = %02x\n", chsa, cmd);
+    coml_ini(uptr, 0);                      /* reset the unit */
+    return SCPE_OK;
 }
 
 /* 8-line serial routines */
@@ -376,9 +393,20 @@ void com_ini(UNIT *uptr, t_bool f)
     DEVICE *dptr = get_dev(uptr);
 
     sim_debug(DEBUG_CMD, dptr, "COM init device %s controller 0x7e00\n", dptr->name);
-//01sim_activate(uptr, 1000);               /* time increment */
     sim_cancel(uptr);                       /* stop input poll */
     sim_activate(uptr, 1000);               /* start input poll */
+}
+
+/* handle rschnlio cmds for com */
+uint16  com_rschnlio(UNIT *uptr) {
+    DEVICE  *dptr = get_dev(uptr);
+    uint16  chsa = GET_UADDR(uptr->u3);
+    int     cmd = uptr->u3 & COM_MSK;
+
+    sim_debug(DEBUG_EXP, dptr,
+        "com_rschnl chsa %04x cmd = %02x\n", chsa, cmd);
+    com_ini(uptr, 0);                       /* reset the unit */
+    return SCPE_OK;
 }
 
 /* called from sel32_chan to start an I/O operation */
@@ -388,33 +416,33 @@ uint16  com_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
     int         unit = (uptr - dptr->units);
     uint8       ch;
 
-    if ((uptr->u3 & COM_MSK) != 0) {    /* is unit busy */
-        return SNS_BSY;                 /* yes, return busy */
+    if ((uptr->u3 & COM_MSK) != 0) {        /* is unit busy */
+        return SNS_BSY;                     /* yes, return busy */
     }
 
     sim_debug(DEBUG_CMD, dptr, "CMD unit %04x chan %04x cmd %02x\n", unit, chan, cmd);
 
     /* process the commands */
     switch (cmd & 0xFF) {
-    case COM_INCH:      /* 00 */        /* INCH command */
+    case COM_INCH:      /* 00 */            /* INCH command */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: CMD INCH\n", chan);
-        uptr->u3 &= LMASK;              /* leave only chsa */
-        uptr->u3 |= (0x7f & COM_MSK);   /* save 0x7f as INCH cmd command */
-        uptr->u5 = SNS_RDY|SNS_ONLN;    /* status is online & ready */
-        sim_activate(uptr, 20);         /* start us up */
+        uptr->u3 &= LMASK;                  /* leave only chsa */
+        uptr->u3 |= (0x7f & COM_MSK);       /* save 0x7f as INCH cmd command */
+        uptr->u5 = SNS_RDY|SNS_ONLN;        /* status is online & ready */
+        sim_activate(uptr, 20);             /* start us up */
         break;
 
     /* write commands must use address 8-f */
-    case COM_WR:        /* 0x01 */      /* Write command */
-    case COM_WRSCM:     /* 0x05 */      /* Write w/sub channel monitor */
-    case COM_WRHFC:     /* 0x0D */      /* Write w/hardware flow control */
+    case COM_WR:        /* 0x01 */          /* Write command */
+    case COM_WRSCM:     /* 0x05 */          /* Write w/sub channel monitor */
+    case COM_WRHFC:     /* 0x0D */          /* Write w/hardware flow control */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd WRITE %02x\n", chan, cmd);
 
-        uptr->u3 &= LMASK;              /* leave only chsa */
-        uptr->u3 |= (cmd & COM_MSK);    /* save command */
-        uptr->u5 = SNS_RDY|SNS_ONLN;    /* status is online & ready */
-        sim_activate(uptr, 150);        /* TRY 08-13-18 */
-        return 0;                       /* no status change */
+        uptr->u3 &= LMASK;                  /* leave only chsa */
+        uptr->u3 |= (cmd & COM_MSK);        /* save command */
+        uptr->u5 = SNS_RDY|SNS_ONLN;        /* status is online & ready */
+        sim_activate(uptr, 150);            /* TRY 08-13-18 */
+        return 0;                           /* no status change */
         break;
 
     /* read commands must use address 0-7 */
@@ -423,36 +451,36 @@ uint16  com_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
     /* bit 1 A=1 ASCII control character  detect (7-char mode only) */
     /* bit 2 S=1 Special character detect (7-char mode only) */
     /* bit 3 P=1 Purge input buffer */
-    case COM_RD:        /* 0x02 */      /* Read command */
-    case COM_RDECHO:    /* 0x06 */      /* Read command w/ECHO */
-    case 0x46:          /* 0x46 */      /* Read command w/ECHO & ASCII */
-    case 0x56:          /* 0x56 */      /* Read command w/ECHO & ASCII & Purge input */
+    case COM_RD:        /* 0x02 */          /* Read command */
+    case COM_RDECHO:    /* 0x06 */          /* Read command w/ECHO */
+    case 0x46:          /* 0x46 */          /* Read command w/ECHO & ASCII */
+    case 0x56:          /* 0x56 */          /* Read command w/ECHO & ASCII & Purge input */
     /* if bit 0 set for COM_RDFC, use DTR for flow, else use RTS for flow control */
-    case COM_RDFC:      /* 0x0A */      /* Read command w/flow control */
-    case COM_RDHFC:     /* 0x8E */      /* Read command w/hardware flow control only */
+    case COM_RDFC:      /* 0x0A */          /* Read command w/flow control */
+    case COM_RDHFC:     /* 0x8E */          /* Read command w/hardware flow control only */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd read\n", chan);
-        uptr->u3 &= LMASK;              /* leave only chsa */
-        uptr->u3 |= (cmd & COM_MSK);    /* save command */
-        if ((cmd & 0x06) == COM_RDECHO) /* echo command? */
-            uptr->u3 |= COM_EKO;        /* save echo status */
-        uptr->u3 |= COM_READ;           /* show read mode */
-        uptr->u5 = SNS_RDY|SNS_ONLN;    /* status is online & ready */
+        uptr->u3 &= LMASK;                  /* leave only chsa */
+        uptr->u3 |= (cmd & COM_MSK);        /* save command */
+        if ((cmd & 0x06) == COM_RDECHO)     /* echo command? */
+            uptr->u3 |= COM_EKO;            /* save echo status */
+        uptr->u3 |= COM_READ;               /* show read mode */
+        uptr->u5 = SNS_RDY|SNS_ONLN;        /* status is online & ready */
         sim_debug(DEBUG_CMD, dptr,
             "com_startcmd %04x: input cnt = %04x\n", chan, coml_chp[unit].ccw_count);
         return 0;
         break;
 
-    case COM_NOP:       /* 0x03 */      /* NOP has do nothing */
+    case COM_NOP:       /* 0x03 */          /* NOP has do nothing */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd %02x NOP\n", chan, cmd);
-        uptr->u5 = SNS_RDY|SNS_ONLN;    /* status is online & ready */
-        uptr->u3 &= LMASK;              /* leave only chsa */
-        uptr->u3 |= (cmd & COM_MSK);    /* save command */
-        sim_activate(uptr, 20);         /* start us up */
+        uptr->u5 = SNS_RDY|SNS_ONLN;        /* status is online & ready */
+        uptr->u3 &= LMASK;                  /* leave only chsa */
+        uptr->u3 |= (cmd & COM_MSK);        /* save command */
+        sim_activate(uptr, 20);             /* start us up */
         break;
 
-    case COM_SNS:       /* 0x04 */      /* Sense (8 bytes) */
-        com_lstat[unit][0] = 0;         /* Clear status wd 0 */
-        com_lstat[unit][1] = 0;         /* Clear status wd 1 */
+    case COM_SNS:       /* 0x04 */          /* Sense (8 bytes) */
+        com_lstat[unit][0] = 0;             /* Clear status wd 0 */
+        com_lstat[unit][1] = 0;             /* Clear status wd 1 */
         /* value 4 is Data Set Ready */
         /* value 5 is Data carrier detected n/u */
         sim_debug(DEBUG_CMD, dptr,
@@ -461,17 +489,17 @@ uint16  com_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
         ch = (com_lstat[unit][0] >> 24) & 0xff;
         chan_write_byte(GET_UADDR(uptr->u3), &ch);  /* write status */
 
-        com_lstat[unit][0] |= (SNS_RING);           /* set char detect status */
-        com_lstat[unit][0] |= (SNS_ASCIICD);        /* set char detect status */
+        com_lstat[unit][0] |= (SNS_RING);   /* set char detect status */
+        com_lstat[unit][0] |= (SNS_ASCIICD);    /* set char detect status */
         ch = (com_lstat[unit][0] >> 16) & 0xff;
         chan_write_byte(GET_UADDR(uptr->u3), &ch);  /* write status */
 
         com_lstat[unit][0] |= (SNS_CTSS|SNS_DSRS);  /* set CTS & DSR status */
-        com_lstat[unit][0] |= (SNS_MRING);          /* set char detect status */
+        com_lstat[unit][0] |= (SNS_MRING);  /* set char detect status */
         ch = (com_lstat[unit][0] >> 8) & 0xff;
         chan_write_byte(GET_UADDR(uptr->u3), &ch);  /* write status */
 
-        com_lstat[unit][0] |= (SNS_DTR);            /* set DTR status */
+        com_lstat[unit][0] |= (SNS_DTR);    /* set DTR status */
         ch = (com_lstat[unit][0] >> 0) & 0xff;
         chan_write_byte(GET_UADDR(uptr->u3), &ch);  /* write status */
 
@@ -490,53 +518,53 @@ uint16  com_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
         sim_debug(DEBUG_CMD, dptr,
             "com_startcmd Cmd SENSE return chan %04x u5-status %04x ls0 %08x ls1 %08x\n",
             chan, uptr->u5, com_lstat[unit][0], com_lstat[unit][1]);
-        return SNS_CHNEND|SNS_DEVEND;   /* good return */
+        return SNS_CHNEND|SNS_DEVEND;       /* good return */
         break;
 
-    case COM_DEFSC:     /* 0x0B */      /* Define special char */
+    case COM_DEFSC:     /* 0x0B */          /* Define special char */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd %02x DEFSC\n", chan, cmd);
         if (chan_read_byte(GET_UADDR(uptr->u3), &ch)) {  /* read char from memory */
             /* nothing to read, error */
             return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* good return */
         }
-        uptr->u5 = ~SNS_RTS;            /* Request to send not ready */
-        return SNS_CHNEND|SNS_DEVEND;   /* good return */
+        uptr->u5 = ~SNS_RTS;                /* Request to send not ready */
+        return SNS_CHNEND|SNS_DEVEND;       /* good return */
         break;
 
-    case COM_RRTS:      /* 0x1B */      /* Reset RTS */
+    case COM_RRTS:      /* 0x1B */          /* Reset RTS */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd %02x RRTS\n", chan, cmd);
-        uptr->u5 &= ~SNS_RTS;           /* Request to send not ready */
-        return SNS_CHNEND|SNS_DEVEND;   /* good return */
+        uptr->u5 &= ~SNS_RTS;               /* Request to send not ready */
+        return SNS_CHNEND|SNS_DEVEND;       /* good return */
         break;
 
-    case COM_SRTS:      /* 0x1F */      /* Set RTS */
+    case COM_SRTS:      /* 0x1F */          /* Set RTS */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd %02x SRTS\n", chan, cmd);
-        uptr->u5 |= SNS_RTS;            /* Requestd to send ready */
-        return SNS_CHNEND|SNS_DEVEND;   /* good return */
+        uptr->u5 |= SNS_RTS;                /* Requestd to send ready */
+        return SNS_CHNEND|SNS_DEVEND;       /* good return */
         break;
 
-    case COM_RBRK:      /* 0x33 */      /* Reset BREAK */
+    case COM_RBRK:      /* 0x33 */          /* Reset BREAK */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd %02x RBRK\n", chan, cmd);
-        uptr->u5 &= ~SNS_BREAK;         /* Request to send not ready */
-        return SNS_CHNEND|SNS_DEVEND;   /* good return */
+        uptr->u5 &= ~SNS_BREAK;             /* Request to send not ready */
+        return SNS_CHNEND|SNS_DEVEND;       /* good return */
         break;
 
-    case COM_SBRK:      /* 0x37 */      /* Set BREAK */
+    case COM_SBRK:      /* 0x37 */          /* Set BREAK */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd %02x SBRK\n", chan, cmd);
-        uptr->u5 |= SNS_BREAK;          /* Requestd to send ready */
-        return SNS_CHNEND|SNS_DEVEND;   /* good return */
+        uptr->u5 |= SNS_BREAK;              /* Requestd to send ready */
+        return SNS_CHNEND|SNS_DEVEND;       /* good return */
         break;
 
-    case COM_RDTR:      /* 0x13 */      /* Reset DTR (ADVR) */
+    case COM_RDTR:      /* 0x13 */          /* Reset DTR (ADVR) */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd %02x RDTR\n", chan, cmd);
-        uptr->u5 &= ~SNS_DTR;           /* Data terminal not ready */
-        return SNS_CHNEND|SNS_DEVEND;   /* good return */
+        uptr->u5 &= ~SNS_DTR;               /* Data terminal not ready */
+        return SNS_CHNEND|SNS_DEVEND;       /* good return */
         break;
 
-    case COM_SDTR:      /* 0x17 */      /* Set DTR (ADVF) */
+    case COM_SDTR:      /* 0x17 */          /* Set DTR (ADVF) */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd %02x SDTR\n", chan, cmd);
-        uptr->u5 |= SNS_DTR;            /* Data terminal ready */
-        return SNS_CHNEND|SNS_DEVEND;   /* good return */
+        uptr->u5 |= SNS_DTR;                /* Data terminal ready */
+        return SNS_CHNEND|SNS_DEVEND;       /* good return */
         break;
 
 #if 0
@@ -584,28 +612,28 @@ uint16  com_startcmd(UNIT *uptr, uint16 chan, uint8 cmd)
             /* nothing to read, error */
             return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* good return */
         }
-        uptr->u4 = ((uint32)ch)<<24;                /* byte 0 of ACE data */
+        uptr->u4 = ((uint32)ch)<<24;        /* byte 0 of ACE data */
         if (chan_read_byte(GET_UADDR(uptr->u3), &ch)) { /* read char 1 */
             /* nothing to read, error */
             return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* good return */
         }
-        uptr->u4 |= ((uint32)ch)<<16;               /* byte 1 of ACE data */
+        uptr->u4 |= ((uint32)ch)<<16;       /* byte 1 of ACE data */
         if (chan_read_byte(GET_UADDR(uptr->u3), &ch)) { /* read char 2 */
             /* nothing to read, error */
             return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;   /* good return */
         }
-        uptr->u4 |= ((uint32)ch)<<8;                /* byte 2 of ACE data */
+        uptr->u4 |= ((uint32)ch)<<8;        /* byte 2 of ACE data */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd %02x ACE bytes %08x\n",
             chan, cmd, uptr->u4);
-        return SNS_CHNEND|SNS_DEVEND;               /* good return */
+        return SNS_CHNEND|SNS_DEVEND;       /* good return */
         break;
 
 
-    default:                                        /* invalid command */
-        uptr->u5 |= SNS_CMDREJ;                     /* command rejected */
+    default:                                /* invalid command */
+        uptr->u5 |= SNS_CMDREJ;             /* command rejected */
         sim_debug(DEBUG_CMD, dptr, "com_startcmd %04x: Cmd Invald %02x status %02x\n",
             chan, cmd, uptr->u5);
-        return SNS_CHNEND|STATUS_PCHK;              /* program check */
+        return SNS_CHNEND|STATUS_PCHK;      /* program check */
         break;
     }
 
@@ -623,76 +651,75 @@ t_stat comi_srv(UNIT *uptr)
     uint8   ch;
     DEVICE *dptr = get_dev(uptr);
     int32   newln, ln, c;
-    uint16  chsa = GET_UADDR(uptr->u3);                 /* get channel/sub-addr */
+    uint16  chsa = GET_UADDR(uptr->u3);     /* get channel/sub-addr */
     int     cmd = uptr->u3 & 0xff;
-//  uint32  cln = (uptr - coml_unit) & 0x7;             /* use line # 0-7 for 8-15 */
 
-    ln = uptr - com_unit;                               /* line # */
+    ln = uptr - com_unit;                   /* line # */
     /* handle NOP and INCH cmds */
     sim_debug(DEBUG_CMD, dptr, "comi_srv entry chsa %04x line %02x cmd %02x\n", chsa, ln, cmd);
-    if (cmd == COM_NOP || cmd == 0x7f) {                /* check for NOP or INCH */
-        uptr->u3 &= LMASK;                              /* leave only chsa */
+    if (cmd == COM_NOP || cmd == 0x7f) {    /* check for NOP or INCH */
+        uptr->u3 &= LMASK;                  /* leave only chsa */
         sim_debug(DEBUG_CMD, dptr, "comi_srv NOP or INCH done chsa %04x line %02x cmd %02x\n",
             chsa, ln, cmd);
-        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);          /* done */
-        return SCPE_OK;                                 /* return */
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* done */
+        return SCPE_OK;                     /* return */
     }
 
     /* handle SACE, 3 char already read, so we are done */
-    if (cmd == COM_SACE) {                              /* check for SACE 0xff */
-        uptr->u3 &= LMASK;                              /* leave only chsa */
+    if (cmd == COM_SACE) {                  /* check for SACE 0xff */
+        uptr->u3 &= LMASK;                  /* leave only chsa */
         sim_debug(DEBUG_CMD, &com_dev,
             "comi_srv SACE done chsa %04x line %02x cmd %02x ACE %08x\n",
             chsa, ln, cmd, uptr->u4);
-        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);          /* done */
-        return SCPE_OK;                                 /* return */
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* done */
+        return SCPE_OK;                     /* return */
     }
 
-    ln = uptr - com_unit;                               /* line # */
-    if ((com_unit[COMC].flags & UNIT_ATT) == 0){        /* attached? */
+    ln = uptr - com_unit;                   /* line # */
+    if ((com_unit[COMC].flags & UNIT_ATT) == 0){    /* attached? */
         return SCPE_OK;
     }
-    newln = tmxr_poll_conn(&com_desc);                  /* look for connect */
-    if (newln >= 0) {                                   /* rcv enb pending? */
+    newln = tmxr_poll_conn(&com_desc);      /* look for connect */
+    if (newln >= 0) {                       /* rcv enb pending? */
         uint16  chsa = GET_UADDR(coml_unit[newln].u3);  /* get channel/sub-addr */
-        com_ldsc[newln].rcve = 1;                       /* enable rcv */
-        com_ldsc[newln].xmte = 1;                       /* enable xmt for output line */
-        com_sta[newln] &= ~COML_REP;                    /* clr pending */
+        com_ldsc[newln].rcve = 1;           /* enable rcv */
+        com_ldsc[newln].xmte = 1;           /* enable xmt for output line */
+        com_sta[newln] &= ~COML_REP;        /* clr pending */
         /* send attention to OS here for this channel */
         /* need to get chsa here for the channel */
         set_devwake(chsa, SNS_ATTN|SNS_DEVEND|SNS_CHNEND);  /* tell user */
     }
     /* poll all devices for input */
-    tmxr_poll_rx(&com_desc);                            /* poll for input */
-    for (ln = 0; ln < COM_NUMLIN; ln++) {               /* loop thru lines */
-        UNIT    *comlp = coml_unit+ln;                  /* get uptr for coml line */
-        int     cmd = comlp->u3 & 0xff;                 /* get the active cmd */
-        uint16  chsa = GET_UADDR(comlp->u3);            /* get channel/sub-addr */
-        if (com_ldsc[ln].conn) {                        /* connected? */
+    tmxr_poll_rx(&com_desc);                /* poll for input */
+    for (ln = 0; ln < COM_NUMLIN; ln++) {   /* loop thru lines */
+        UNIT    *comlp = coml_unit+ln;      /* get uptr for coml line */
+        int     cmd = comlp->u3 & 0xff;     /* get the active cmd */
+        uint16  chsa = GET_UADDR(comlp->u3);    /* get channel/sub-addr */
+        if (com_ldsc[ln].conn) {            /* connected? */
             if ((c = tmxr_getc_ln(&com_ldsc[ln]))) {    /* get char */
-                ch = c;                                 /* just the char */
+                ch = c;                     /* just the char */
                 /* echo the char out */
-                tmxr_putc_ln(&com_ldsc[ln], ch);        /* output char */
-                tmxr_poll_tx(&com_desc);                /* poll xmt */
-                if (c & SCPE_BREAK)                     /* break? */
-                    com_sta[ln] |= COML_RBP;            /* set rcv brk */
-                else {                                  /* normal char */
-                    com_sta[ln] &= ~COML_RBP;           /* clr rcv brk */
+                tmxr_putc_ln(&com_ldsc[ln], ch);    /* output char */
+                tmxr_poll_tx(&com_desc);    /* poll xmt */
+                if (c & SCPE_BREAK)         /* break? */
+                    com_sta[ln] |= COML_RBP;    /* set rcv brk */
+                else {                      /* normal char */
+                    com_sta[ln] &= ~COML_RBP;   /* clr rcv brk */
                     c = sim_tt_inpcvt(c, TT_GET_MODE(coml_unit[ln].flags));
-                    com_rbuf[ln] = c;                   /* save char */
-                    if ((cmd & COM_RD) == COM_RD) {     /* read active? */
-                        ch = c;                         /* clean the char */
-                        if (ch == '\n')                 /* convert newline */
-                            ch = '\r';                  /* to C/R */
+                    com_rbuf[ln] = c;       /* save char */
+                    if ((cmd & COM_RD) == COM_RD) { /* read active? */
+                        ch = c;             /* clean the char */
+                        if (ch == '\n')     /* convert newline */
+                            ch = '\r';      /* to C/R */
                         /* write byte to memory */
                         if (chan_write_byte(chsa, &ch)) {
                             /* done, reading chars */
-                            comlp->u3 &= LMASK;         /* nothing left, clear cmd */
+                            comlp->u3 &= LMASK; /* nothing left, clear cmd */
                             chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* we done */
                         } else {
                             /* more to go, continue */
-                            if (ch == '\r') {           /* see if done */
-                                comlp->u3 &= LMASK;     /* nothing left, clear cmd */
+                            if (ch == '\r') {   /* see if done */
+                                comlp->u3 &= LMASK; /* nothing left, clear cmd */
                                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* we done */
                             }
                         }
@@ -705,87 +732,87 @@ t_stat comi_srv(UNIT *uptr)
                             set_devwake(chsa, SNS_ATTN|SNS_DEVEND|SNS_CHNEND);  /* tell user */
                         }
                     }
-                }                                       /* end else char */
-            }                                           /* end if char */
-        }                                               /* end if conn */
+                }                           /* end else char */
+            }                               /* end if char */
+        }                                   /* end if conn */
         else
-            com_sta[ln] &= ~COML_RBP;                   /* disconnected */
-    }                                                   /* end for */
-    return sim_clock_coschedule(uptr, 200);             /* continue poll */
+            com_sta[ln] &= ~COML_RBP;       /* disconnected */
+    }                                       /* end for */
+    return sim_clock_coschedule(uptr, 200); /* continue poll */
 }
 
 /* Unit service - output transfers */
 t_stat como_srv(UNIT *uptr)
 {
     DEVICE *dptr = get_dev(uptr);
-    uint16  chsa = GET_UADDR(uptr->u3);                 /* get channel/sub-addr */
-    uint32  ln = (uptr - coml_unit) & 0x7;              /* use line # 0-7 for 8-15 */
+    uint16  chsa = GET_UADDR(uptr->u3);     /* get channel/sub-addr */
+    uint32  ln = (uptr - coml_unit) & 0x7;  /* use line # 0-7 for 8-15 */
     uint32  done;
-    int     cmd = uptr->u3 & 0xff;                      /* get active cmd */
+    int     cmd = uptr->u3 & 0xff;          /* get active cmd */
     uint8   ch;
 
     /* handle NOP and INCH cmds */
     sim_debug(DEBUG_CMD, dptr, "como_srv entry chsa %04x line %04x cmd %02x\n", chsa, ln, cmd);
-    if (cmd == COM_NOP || cmd == 0x7f) {                /* check for NOP or INCH */
-        uptr->u3 &= LMASK;                              /* leave only chsa */
+    if (cmd == COM_NOP || cmd == 0x7f) {    /* check for NOP or INCH */
+        uptr->u3 &= LMASK;                  /* leave only chsa */
         sim_debug(DEBUG_CMD, &com_dev, "como_srv NOP or INCH done chsa %04x line %04x cmd %02x\n",
             chsa, ln, cmd);
-        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);          /* done */
-        return SCPE_OK;                                 /* return */
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* done */
+        return SCPE_OK;                     /* return */
     }
 
     /* handle SACE, 3 char already read, so we are done */
-    if (cmd == COM_SACE) {                              /* check for SACE 0xff */
-        uptr->u3 &= LMASK;                              /* leave only chsa */
+    if (cmd == COM_SACE) {                  /* check for SACE 0xff */
+        uptr->u3 &= LMASK;                  /* leave only chsa */
         sim_debug(DEBUG_CMD, &com_dev,
             "como_srv SACE done chsa %04x line %02x cmd %02x ACE %08x\n",
             chsa, ln, cmd, uptr->u4);
-        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);          /* done */
-        return SCPE_OK;                                 /* return */
+        chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* done */
+        return SCPE_OK;                     /* return */
     }
 
     sim_debug(DEBUG_CMD, dptr, "como_srv entry 1 chsa %04x line %04x cmd %02x\n", chsa, ln, cmd);
     if (cmd) {
         /* get a user byte from memory */
-        done = chan_read_byte(chsa, &ch);               /* get byte from memory */
+        done = chan_read_byte(chsa, &ch);   /* get byte from memory */
         if (done)
-            uptr->u3 &= LMASK;                          /* leave only chsa */
+            uptr->u3 &= LMASK;              /* leave only chsa */
     } else
         return SCPE_OK;
 
-    if (com_dev.flags & DEV_DIS) {                      /* disabled */
+    if (com_dev.flags & DEV_DIS) {          /* disabled */
         sim_debug(DEBUG_CMD, dptr, "como_srv chsa %04x line %04x DEV_DIS set\n", chsa, ln);
             if (done) {
                 sim_debug(DEBUG_CMD, dptr, "como_srv Write DONE %04x status %04x\n",
                     ln, SNS_CHNEND|SNS_DEVEND);
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* done */
             }
-            return SCPE_OK;                             /* return */
+            return SCPE_OK;                 /* return */
     }
     sim_debug(DEBUG_CMD, dptr, "como_srv poll chsa %04x line %04x DEV_DIS set\n", chsa, ln);
 
-    if (com_ldsc[ln].conn) {                            /* connected? */
-        if (com_ldsc[ln].xmte) {                        /* xmt enabled? */
-            if (done) {                                 /* are we done writing */
+    if (com_ldsc[ln].conn) {                /* connected? */
+        if (com_ldsc[ln].xmte) {            /* xmt enabled? */
+            if (done) {                     /* are we done writing */
 endit:
-                uptr->u3 &= LMASK;                      /* nothing left, command complete */
+                uptr->u3 &= LMASK;          /* nothing left, command complete */
                 sim_debug(DEBUG_CMD, dptr, "com_srvo write %04x: chnend|devend\n", ln);
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* done */
                 return SCPE_OK;
             }
             /* send the next char out */
-            tmxr_putc_ln(&com_ldsc[ln], ch);            /* output char */
+            tmxr_putc_ln(&com_ldsc[ln], ch);    /* output char */
             sim_debug(DEBUG_CMD, dptr, "com_srvo writing char 0x%02x to ln %04x\n", ch, ln);
-            tmxr_poll_tx(&com_desc);                    /* poll xmt */
-            sim_activate(uptr, uptr->wait);             /* wait */
+            tmxr_poll_tx(&com_desc);        /* poll xmt */
+            sim_activate(uptr, uptr->wait); /* wait */
             return SCPE_OK;
-        } else {                                        /* buf full */
-            if (done)                                   /* are we done writing */
-                goto endit;                             /* done */
+        } else {                            /* buf full */
+            if (done)                       /* are we done writing */
+                goto endit;                 /* done */
             /* just dump the char */
             sim_debug(DEBUG_CMD, dptr, "com_srvo write dumping char 0x%02x on line %04x\n", ch, ln);
-            tmxr_poll_tx(&com_desc);                    /* poll xmt */
-            sim_activate(uptr, uptr->wait);             /* wait */
+            tmxr_poll_tx(&com_desc);        /* poll xmt */
+            sim_activate(uptr, uptr->wait); /* wait */
             return SCPE_OK;
         }
     } else {
@@ -793,10 +820,10 @@ endit:
         if (done) {
             sim_debug(DEBUG_CMD, dptr, "com_srvo write dump DONE line %04x status %04x\n",
                 ln, SNS_CHNEND|SNS_DEVEND);
-            uptr->u3 &= LMASK;                          /* nothing left, command complete */
-            chan_end(chsa, SNS_CHNEND|SNS_DEVEND);      /* done */
+            uptr->u3 &= LMASK;              /* nothing left, command complete */
+            chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* done */
         }
-        sim_activate(uptr, uptr->wait);                 /* wait */
+        sim_activate(uptr, uptr->wait);     /* wait */
         return SCPE_OK;
     }
 }
@@ -806,13 +833,13 @@ t_stat com_reset (DEVICE *dptr)
 {
     int32 i;
 
-    if (com_dev.flags & DEV_DIS)                        /* master disabled? */
-        com_dev.flags |= DEV_DIS;                       /* disable lines */
+    if (com_dev.flags & DEV_DIS)            /* master disabled? */
+        com_dev.flags |= DEV_DIS;           /* disable lines */
     else
         com_dev.flags &= ~DEV_DIS;
-    if (com_unit[COMC].flags & UNIT_ATT)                /* master att? */
-        sim_clock_coschedule(&com_unit[0], 200);        /* activate */
-    for (i = 0; i < COM_LINES; i++)                     /* reset lines */
+    if (com_unit[COMC].flags & UNIT_ATT)    /* master att? */
+        sim_clock_coschedule(&com_unit[0], 200);    /* activate */
+    for (i = 0; i < COM_LINES; i++)         /* reset lines */
         com_reset_ln(i);
     return SCPE_OK;
 }
@@ -824,11 +851,11 @@ t_stat com_attach(UNIT *uptr, CONST char *cptr)
     DEVICE  *dptr = get_dev(uptr);
     t_stat  r;
 
-    r = tmxr_attach(&com_desc, uptr, cptr);     /* attach */
-    if (r != SCPE_OK)                           /* error? */
-        return r;                               /* return error */
+    r = tmxr_attach(&com_desc, uptr, cptr); /* attach */
+    if (r != SCPE_OK)                       /* error? */
+        return r;                           /* return error */
     sim_debug(DEBUG_CMD, dptr, "com_srv comc is now attached\n");
-    sim_activate(uptr, 0);                      /* start poll at once */
+    sim_activate(uptr, 0);                  /* start poll at once */
     return SCPE_OK;
 }
 
@@ -838,10 +865,10 @@ t_stat com_detach(UNIT *uptr)
     int32 i;
     t_stat r;
 
-    r = tmxr_detach(&com_desc, uptr);           /* detach */
-    for (i = 0; i < COM_LINES; i++)             /* disable rcv */
-        com_reset_ln(i);                        /* reset the line */
-    sim_cancel(uptr);                           /* stop poll, cancel timer */
+    r = tmxr_detach(&com_desc, uptr);       /* detach */
+    for (i = 0; i < COM_LINES; i++)         /* disable rcv */
+        com_reset_ln(i);                    /* reset the line */
+    sim_cancel(uptr);                       /* stop poll, cancel timer */
     return r;
 }
 
@@ -850,8 +877,8 @@ void com_reset_ln (int32 ln)
 {
     sim_cancel(&coml_unit[ln]);
     com_sta[ln] = 0;
-    com_rbuf[ln] = 0;               /* clear read buffer */
-    com_xbuf[ln] = 0;               /* clear write buffer */
+    com_rbuf[ln] = 0;                       /* clear read buffer */
+    com_xbuf[ln] = 0;                       /* clear write buffer */
     com_ldsc[ln].rcve = 0;
     return;
 }

--- a/SEL32/sel32_disk.c
+++ b/SEL32/sel32_disk.c
@@ -392,6 +392,7 @@ uint16  disk_iocl(CHANP *chp, int32 tic_ok);
 t_stat  disk_srv(UNIT *uptr);
 t_stat  disk_boot(int32 unitnum, DEVICE *dptr);
 void    disk_ini(UNIT *, t_bool);
+uint16  disk_rschnlio(UNIT *uptr);
 t_stat  disk_reset(DEVICE *);
 t_stat  disk_attach(UNIT *, CONST char *);
 t_stat  disk_detach(UNIT *);
@@ -452,7 +453,7 @@ DIB             dda_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    disk_rschnlio,  /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     disk_iocl,      /* uint16 (*iocl_io)(CHANP *chp, int32 tik_ok)) */  /* Process IOCL */
     disk_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     dda_unit,       /* UNIT* units */                           /* Pointer to units structure */
@@ -498,7 +499,7 @@ DIB             ddb_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    disk_rschnlio,  /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     disk_iocl,      /* uint16 (*iocl_io)(CHANP *chp, int32 tic_ok)) */  /* Process IOCL */
     disk_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     ddb_unit,       /* UNIT* units */                           /* Pointer to units structure */
@@ -601,7 +602,9 @@ uint32 get_dmatrk(UNIT *uptr, uint32 star, uint8 buf[])
 
     /* get track number */
     tstart = (cyl * HDS(type)) + trk;
-    sim_debug(DEBUG_EXP, dptr, "get_dmatrk RTL cyl %4x(%d) trk %x sec# %06x\n",
+//  sim_debug(DEBUG_EXP, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
+        "get_dmatrk RTL cyl %4x(%d) trk %x sec# %06x\n",
         cyl, cyl, trk, tstart);
 
     /* calc offset in file to track label */
@@ -615,7 +618,9 @@ uint32 get_dmatrk(UNIT *uptr, uint32 star, uint8 buf[])
                 buf[i] = tkl_label[unit].tkl[cn].label[i];
             found = cn;
             tkl_label[unit].tkl[cn].age++;
-            sim_debug(DEBUG_EXP, dptr, "get_dpatrk found in Cache to %06x\n", offset);
+//          sim_debug(DEBUG_EXP, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
+                "get_dpatrk found in Cache to %06x\n", offset);
             break;
         }
     }
@@ -623,17 +628,20 @@ uint32 get_dmatrk(UNIT *uptr, uint32 star, uint8 buf[])
     /* see if found in cache */
     if (found == -1) {
         /* file offset in bytes */
-        sim_debug(DEBUG_EXP, dptr, "get_dpatrk RTL SEEK on seek to %06x\n", offset);
+//      sim_debug(DEBUG_EXP, dptr,
+        sim_debug(DEBUG_DETAIL, dptr,
+            "get_dpatrk RTL SEEK on seek to %06x\n", offset);
 
         /* seek to the location where we will r/w track label */
         if ((sim_fseek(uptr->fileref, offset, SEEK_SET)) != 0) {  /* do seek */
-            sim_debug(DEBUG_EXP, dptr, "get_dpatrk RTL, Error on seek to %04x\n", offset);
+            sim_debug(DEBUG_EXP, dptr,
+                "get_dpatrk RTL, Error on seek to %04x\n", offset);
             return 0;
         }
 
         /* read in a track label from disk */
         if ((len=sim_fread(buf, 1, 30, uptr->fileref)) != 30) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "get_dpatrk Error %08x on read %04x of diskfile cyl %04x hds %02x sec 00\n",
                 len, 30, cyl, trk);
             return 0;
@@ -788,9 +796,6 @@ loop:
     case DSK_IHA: case DSK_WTL: case DSK_RTL: case DSK_RAP: case DSK_TESS:  
     case DSK_FNSK: case DSK_REL: case DSK_RES: case DSK_POR: case DSK_TIC:
     case DSK_REC:
-        /* reset status to on cyl & ready */
-//      uptr->SNS2 = (SNS_UNR|SNS_ONC|SNS_USEL);
-//      uptr->SNS2 = 0;
     case DSK_SNS:   
         break;
     default:
@@ -800,8 +805,6 @@ loop:
             "disk_iocl bad cmd chan_status[%04x] %04x\n", chan, chp->chan_status);
         return 1;                               /* error return */
     }
-
-//28chp->ccw_count = word2 & 0xffff;            /* get 16 bit byte count from IOCD WD 2 */
 
     if (chp->chan_info & INFO_SIOCD) {          /* see if 1st IOCD in channel prog */
         /* 1st command can not be a TIC or NOP */
@@ -824,7 +827,6 @@ loop:
                     "disk_iocl tic cmd bad address chan %02x tic caw %06x IOCD wd 1 %08x\n",
                     chan, chp->chan_caw, word1);
                 chp->chan_status |= STATUS_PCHK; /* program check for invalid tic */
-//              chp->chan_caw = word1;          /* get new IOCD address */
                 chp->chan_caw = word1 & MASK24; /* get new IOCD address */
                 uptr->SNS |= SNS_CMDREJ;        /* cmd rejected status */
                 uptr->SNS |= SNS_INAD;          /* invalid address status */
@@ -837,7 +839,6 @@ loop:
                 chan, chp->chan_caw, word1);
             goto loop;                          /* restart the IOCD processing */
         }
-//      chp->chan_caw = word1;                  /* get new IOCD address */
         chp->chan_caw = word1 & MASK24;         /* get new IOCD address */
         chp->chan_status |= STATUS_PCHK;        /* program check for invalid tic */
         uptr->SNS |= SNS_CMDREJ;                /* cmd rejected status */
@@ -897,7 +898,8 @@ loop:
             return 1;                           /* if none, error */
         }
 
-        sim_debug(DEBUG_XIO, dptr,
+//      sim_debug(DEBUG_XIO, dptr,
+        sim_debug(DEBUG_DETAIL, dptr,
             "disk_iocl @%06x before start_cmd chan %04x status %04x count %04x SNS %08x\n",
             chp->chan_caw, chan, chp->chan_status, chp->ccw_count, uptr->u5);
 
@@ -907,7 +909,8 @@ loop:
         chp->chan_status = (chp->chan_status & 0xff00) | devstat;
         chp->chan_info &= ~INFO_SIOCD;          /* show not first IOCD in channel prog */
 
-        sim_debug(DEBUG_XIO, dptr,
+//      sim_debug(DEBUG_XIO, dptr,
+        sim_debug(DEBUG_DETAIL, dptr,
             "disk_iocl @%06x after start_cmd chan %04x status %08x count %04x\n",
             chp->chan_caw, chan, chp->chan_status, chp->ccw_count);
 
@@ -938,14 +941,16 @@ loop:
         if (chp->chan_status & (STATUS_DEND|STATUS_CEND)) {
             uint16  chsa = GET_UADDR(uptr->u3); /* get channel & sub address */
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* show I/O complete */
-            sim_debug(DEBUG_XIO, dptr,
+//          sim_debug(DEBUG_XIO, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "disk_iocl @%06x FIFO #%1x cmd complete chan %04x status %04x count %04x\n",
                 chp->chan_caw, FIFO_Num(chsa), chan, chp->chan_status, chp->ccw_count);
         }
     }
     /* the device processor returned OK (0), so wait for I/O to complete */
     /* nothing happening, so return */
-    sim_debug(DEBUG_XIO, dptr,
+//  sim_debug(DEBUG_XIO, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "disk_iocl @%06x return, chan %04x status %04x count %04x irq_pend %1x\n",
         chp->chan_caw, chan, chp->chan_status, chp->ccw_count, irq_pend);
     return 0;                                   /* good return */
@@ -958,23 +963,26 @@ uint16 disk_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
     int32       unit = (uptr - dptr->units);
     CHANP       *chp = find_chanp_ptr(chsa);    /* find the chanp pointer */
 
-    sim_debug(DEBUG_CMD, dptr,
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "disk_startcmd chsa %04x unit %02x cmd %02x CMD %08x\n",
         chsa, unit, cmd, uptr->CMD);
     if ((uptr->flags & UNIT_ATT) == 0) {        /* unit attached status */
-        sim_debug(DEBUG_CMD, dptr, "disk_startcmd unit %02x not attached\n", unit);
+        sim_debug(DEBUG_EXP, dptr, "disk_startcmd unit %02x not attached\n", unit);
         uptr->SNS |= SNS_INTVENT;               /* unit intervention required */
         if (cmd != DSK_SNS)                     /* we are completed with unit check status */
             return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;
     }
 
     if ((uptr->CMD & DSK_CMDMSK) != 0) {
-        sim_debug(DEBUG_CMD, dptr, "disk_startcmd unit %02x busy\n", unit);
+        sim_debug(DEBUG_EXP, dptr, "disk_startcmd unit %02x busy\n", unit);
         uptr->CMD |= DSK_BUSY;                  /* Flag we are busy */
         return SNS_BSY;
     }
     uptr->SNS2 |= SNS_USEL;                     /* unit selected */
-    sim_debug(DEBUG_CMD, dptr, "disk_startcmd CMD continue unit=%02x cmd %02x iocla %06x cnt %04x\n",
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
+        "disk_startcmd CMD continue unit=%02x cmd %02x iocla %06x cnt %04x\n",
         unit, cmd, chp->chan_caw, chp->ccw_count);
 
     /* Unit is online, so process a command */
@@ -1045,7 +1053,7 @@ uint16 disk_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
         break;
     }
 
-    sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_EXP, dptr,
         "disk_startcmd done with bad disk cmd %02x chsa %04x SNS %08x\n",
         cmd, chsa, uptr->SNS);
     uptr->SNS |= SNS_CMDREJ;                    /* cmd rejected */
@@ -1059,34 +1067,38 @@ uint16  disk_haltio(UNIT *uptr) {
     int         cmd = uptr->CMD & DSK_CMDMSK;
     CHANP       *chp = find_chanp_ptr(chsa);    /* find the chanp pointer */
 
-    sim_debug(DEBUG_EXP, dptr, "disk_haltio enter chsa %04x cmd = %02x\n", chsa, cmd);
+//  sim_debug(DEBUG_EXP, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
+        "disk_haltio enter chsa %04x cmd = %02x\n", chsa, cmd);
 
     /* terminate any input command */
     /* UTX wants SLI bit, but no unit exception */
     /* status must not have an error bit set */
     /* otherwise, UTX will panic with "bad status" */
-    if ((uptr->CMD & DSK_CMDMSK) != 0) {    /* is unit busy */
-        sim_debug(DEBUG_CMD, dptr,
-            "disk_haltio HIO chsa %04x cmd = %02x ccw_count %02x\n", chsa, cmd, chp->ccw_count);
+    if ((uptr->CMD & DSK_CMDMSK) != 0) {        /* is unit busy */
+//      sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
+            "disk_haltio HIO chsa %04x cmd = %02x ccw_count %02x\n",
+            chsa, cmd, chp->ccw_count);
         /* stop any I/O and post status and return error status */
-//      chp->chan_byte = BUFF_EMPTY;        /* there is no data to read/store */
-//      chp->ccw_count = 0;                 /* zero the count */
-        chp->ccw_flags &= ~(FLAG_DC|FLAG_CC);/* stop any chaining */
-        uptr->CMD &= LMASK;                 /* make non-busy */
-        uptr->SNS2 |= (SNS_ONC|SNS_UNR);    /* on cylinder & ready */
-        sim_cancel(uptr);                   /* clear the input timer */
-        sim_debug(DEBUG_CMD, dptr,
+        chp->ccw_flags &= ~(FLAG_DC|FLAG_CC);   /* stop any chaining */
+        uptr->CMD &= LMASK;                     /* make non-busy */
+        uptr->SNS2 |= (SNS_ONC|SNS_UNR);        /* on cylinder & ready */
+        sim_cancel(uptr);                       /* clear the input timer */
+//      sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
             "disk_haltio HIO I/O stop chsa %04x cmd = %02x CHS %08x STAR %08x\n",
             chsa, cmd, uptr->CHS, uptr->STAR);
 //1204  chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* force end */
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITEXP);  /* force end */
         return SCPE_IOERR;
     }
-    uptr->CMD &= LMASK;                     /* make non-busy */
-    uptr->SNS2 |= (SNS_ONC|SNS_UNR);        /* on cylinder & ready */
-    sim_debug(DEBUG_CMD, dptr,
+    uptr->CMD &= LMASK;                         /* make non-busy */
+    uptr->SNS2 |= (SNS_ONC|SNS_UNR);            /* on cylinder & ready */
+//  sim_debug(DEBUG_EXP, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "disk_haltio HIO I/O not busy chsa %04x cmd = %02x\n", chsa, cmd);
-    return SCPE_OK;                         /* not busy */
+    return SCPE_OK;                             /* not busy */
 }
 
 /* Handle processing of disk requests. */
@@ -1101,7 +1113,7 @@ t_stat disk_srv(UNIT *uptr)
     int             unit = (uptr - dptr->units);
     int             len = chp->ccw_count;
     int             i,j,k;
-    uint32          mema, ecc, cecc;                /* memory address / ecc */
+    uint32          mema, ecc, cecc;            /* memory address / ecc */
     uint8           ch;
     uint16          ssize = disk_type[type].ssiz * 4;   /* disk sector size in bytes */
     uint32          tstart;
@@ -1109,7 +1121,8 @@ t_stat disk_srv(UNIT *uptr)
     uint8           buf[1024];
     uint8           buf2[1024];
 
-    sim_debug(DEBUG_CMD, dptr,
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "disk_srv entry unit %02x CMD %08x chsa %04x count %04x %x/%x/%x \n",
         unit, uptr->CMD, chsa, chp->ccw_count,
         STAR2CYL(uptr->CHS), (uptr->CHS >> 8)&0xff, (uptr->CHS&0xff));
@@ -1122,7 +1135,8 @@ t_stat disk_srv(UNIT *uptr)
         }
     }
 
-    sim_debug(DEBUG_CMD, dptr,
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "disk_srv cmd=%02x chsa %04x count %04x\n", cmd, chsa, chp->ccw_count);
 
     switch (cmd) {
@@ -1331,12 +1345,12 @@ iha_error:
         }
         /* create offset and mask */
         ecc = dmle_ecc32(obuf, ssize);          /* calc ecc for original sector */
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "disk_srv DEC old obuf data %02x%02x%02x%02x %02x%02x%02x%02x\n",
                 obuf[1016], obuf[1017], obuf[1018], obuf[1019],
                 obuf[1020], obuf[1021], obuf[1022], obuf[1023]);
         cecc = dmle_ecc32(bbuf, ssize);         /* calc ecc for bad sector */
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "disk_srv DEC bad bbuf data %02x%02x%02x%02x %02x%02x%02x%02x\n",
                 bbuf[1016], bbuf[1017], bbuf[1018], bbuf[1019],
                 bbuf[1020], bbuf[1021], bbuf[1022], bbuf[1023]);
@@ -1402,7 +1416,7 @@ iha_error:
 
         /* count must be 12 or 14, if not prog check */
         if (len != 12 && len != 14) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "disk_srv Sense bad count unit=%02x count%04x\n", unit, len);
             uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND|STATUS_PCHK|STATUS_LENGTH);
@@ -1539,7 +1553,7 @@ iha_error:
             unit, buf[0], buf[1], buf[2], buf[3]);
 
         if (len > 4) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "disk_srv SEEK bad count unit %02x count %04x\n", unit, len);
             uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND|STATUS_PCHK|STATUS_LENGTH);
@@ -1552,7 +1566,7 @@ iha_error:
                 if (chp->chan_status & STATUS_PCHK) /* test for memory error */
                     uptr->SNS |= SNS_INAD;      /* invalid address */
                 if (i == 0) {
-                    sim_debug(DEBUG_DETAIL, dptr,
+                    sim_debug(DEBUG_EXP, dptr,
                         "disk_srv seek error unit=%02x star %02x %02x %02x %02x\n",
                         unit, buf[0], buf[1], buf[2], buf[3]);
                     /* we have error, bail out */
@@ -1626,9 +1640,9 @@ iha_error:
         /* calc the new sector address of data */
         /* calculate file position in bytes of requested sector */
         /* set new STAR value using new values */
-/*05*/  uptr->STAR = CHS2STAR(cyl, trk, sec);
+        uptr->STAR = CHS2STAR(cyl, trk, sec);
         /* file offset in bytes to std or alt track */
-/*05*/  tstart = STAR2SEC(uptr->STAR, SPT(type), SPC(type)) * SSB(type);
+        tstart = STAR2SEC(uptr->STAR, SPT(type), SPC(type)) * SSB(type);
 
         sim_debug(DEBUG_DETAIL, dptr,
             "disk_srv seek start %04x cyl %04x trk %02x sec %02x CHS %08x\n",
@@ -1813,7 +1827,6 @@ iha_error:
         /* now read sector label data */
         len = chp->ccw_count;
         for (i = 0; i < len; i++) {
-//0906  for (i = 0; i < 30; i++) {
             if (chan_read_byte(chsa, &buf[i])) {
                 if (chp->chan_status & STATUS_PCHK) /* test for memory error */
                     uptr->SNS |= SNS_INAD;      /* invalid address */
@@ -1829,7 +1842,6 @@ iha_error:
         }
         sim_debug(DEBUG_DETAIL, dptr, "\n");
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
-//      chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
 //      return SCPE_OK;
         break;
 
@@ -1898,7 +1910,7 @@ iha_error:
 
             /* read in a sector of data from disk */
             if ((len=sim_fread(buf, 1, ssize, uptr->fileref)) != ssize) {
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "Error %08x on read %04x of diskfile cyl %04x hds %02x sec %02x\n",
                     len, ssize, ((uptr->CHS)>>16)&0xffff, ((uptr->CHS)>>8)&0xff, (uptr->CHS)&0xff);
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -1909,8 +1921,8 @@ iha_error:
             sim_debug(DEBUG_CMD, dptr,
                 "disk_srv after READ chsa %04x buffer %06x count %04x\n",
                 chsa, chp->ccw_addr, chp->ccw_count);
-            sim_debug(DEBUG_CMD, dptr,
-                "hsdp_srv READ data %02x%02x%02x%02x %02x%02x%02x%02x "
+            sim_debug(DEBUG_DETAIL, dptr,
+                "disk_srv READ data %02x%02x%02x%02x %02x%02x%02x%02x "
                 "%02x%02x%02x%02x %02x%02x%02x%02x\n",
                 buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
                 buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15]);
@@ -1923,7 +1935,7 @@ iha_error:
                 if (chan_write_byte(chsa, &ch)) {   /* put a byte to memory */
                     if (chp->chan_status & STATUS_PCHK) /* test for memory error */
                         uptr->SNS |= SNS_INAD;  /* invalid address */
-                    sim_debug(DEBUG_CMD, dptr,
+                    sim_debug(DEBUG_EXP, dptr,
                         "DISK Read %04x bytes leaving %04x from diskfile %04x/%02x/%02x\n",
                         i, chp->ccw_count, ((uptr->CHS)>>16)&0xffff,
                         ((uptr->CHS)>>8)&0xff, (uptr->CHS)&0xff);
@@ -1939,17 +1951,17 @@ iha_error:
             /* get current sector offset */
             j = STAR2SEC(tempt, SPT(type), SPC(type));  /* current sector */
             i = ((CYL(type) - 3) * HDS(type)) * SPT(type);  /* diag start */
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "disk_srv after READ j %04x i %04x j-i %04x CAP %06x DIAG %06x\n",
                 j, i, j-i, CAP(type), (((CYL(type) - 3) * HDS(type)) * SPT(type)));    /* diag start */
             if (j >= i) {                       /* only do diag sectors */
                 cecc = dmle_ecc32(buf, ssize);  /* calc ecc for sector */
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_DETAIL, dptr,
                     "ECC j %02x i %02x data calc Old %08x Cur %08x cyl %04x hds %02x sec %02x\n",
                     j, i, decc[j-i], cecc, STAR2CYL(tempt), ((tempt) >> 8)&0xff, (tempt&0xff));
                 if ((decc[j-i] != 0) && (cecc != decc[j-i])) {     /* test against old */
                     /* checksum error */
-                    sim_debug(DEBUG_CMD, dptr,
+                    sim_debug(DEBUG_EXP, dptr,
                         "ECC j %02x i %02x data error Old %08x New %08x cyl %04x hds %02x sec %02x\n",
                         j, i, decc[j-i], cecc, STAR2CYL(tempt), ((tempt) >> 8)&0xff, (tempt&0xff));
                     uptr->SNS |= SNS_ECCD;      /* data ECC error */
@@ -1996,7 +2008,7 @@ iha_error:
             /* see if over end of disk */
             if (tstart >= (uint32)CAP(type)) {
                 /* EOM reached, abort */
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "DISK Read reached EOM for read from disk @ /%04x/%02x/%02x\n",
                     STAR2CYL(uptr->CHS), (uptr->CHS >> 8)&0xff, (uptr->CHS&0xff));
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -2061,7 +2073,8 @@ iha_error:
             if ((tempt == 0) && (uptr->STAR != 0)) {
                 /* we have error */
                 sim_debug(DEBUG_EXP, dptr,
-                    "disk_srv WRITE get_dmatrk return error tempt %06x tstart %06x\n", tempt, tstart);
+                    "disk_srv WRITE get_dmatrk return error tempt %06x tstart %06x\n",
+                    tempt, tstart);
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
                 uptr->SNS |= SNS_DADE;          /* set error status */
                 uptr->SNS2 |= (SNS_SKER|SNS_SEND);
@@ -2106,7 +2119,7 @@ iha_error:
                     /* if error on reading 1st byte, we are done writing */
                     if ((i == 0) || (chp->chan_status & STATUS_PCHK)) {
                         uptr->CMD &= LMASK;     /* remove old status bits & cmd */
-                        sim_debug(DEBUG_CMD, dptr,
+                        sim_debug(DEBUG_EXP, dptr,
                             "DISK Wrote %04x bytes to diskfile cyl %04x hds %02x sec %02x\n",
                             ssize, STAR2CYL(uptr->CHS), ((uptr->CHS) >> 8)&0xff, (uptr->CHS&0xff));
                         if (chp->chan_status & STATUS_PCHK) /* test for memory error */
@@ -2128,7 +2141,7 @@ iha_error:
 
             /* write the sector to disk */
             if ((i=sim_fwrite(buf2, 1, ssize, uptr->fileref)) != ssize) {
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "Error %08x on write %04x bytes to diskfile cyl %04x hds %02x sec %02x\n",
                     i, ssize, STAR2CYL(uptr->CHS), ((uptr->CHS) >> 8)&0xff, (uptr->CHS&0xff));
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -2137,26 +2150,26 @@ iha_error:
             }
 
             sim_debug(DEBUG_CMD, dptr,
-                "hsdp_srv after WRITE buffer %06x count %04x\n",
+                "disk_srv after WRITE buffer %06x count %04x\n",
                 chp->ccw_addr, chp->ccw_count);
-            sim_debug(DEBUG_CMD, dptr,
-                "hsdp_srv WRITE data %02x%02x%02x%02x %02x%02x%02x%02x "
+            sim_debug(DEBUG_DETAIL, dptr,
+                "disk_srv WRITE data %02x%02x%02x%02x %02x%02x%02x%02x "
                 "%02x%02x%02x%02x %02x%02x%02x%02x\n",
                 buf2[0], buf2[1], buf2[2], buf2[3], buf2[4], buf2[5], buf2[6], buf2[7],
                 buf2[8], buf2[9], buf2[10], buf2[11], buf2[12], buf2[13], buf2[14], buf2[15]);
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "disk_srv after WRITE CAP %06x DIAG %06x\n",
                 CAP(type), (((CYL(type) - 3) * HDS(type)) * SPT(type)));    /* diag start */
 
             /* get current sector offset */
             j = STAR2SEC(tempt, SPT(type), SPC(type));  /* current sector */
             i = ((CYL(type) - 3) * HDS(type)) * SPT(type);  /* diag start */
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "disk_srv after WRITE j %04x i %04x j-i %04x CAP %06x DIAG %06x\n",
                 j, i, j-i, CAP(type), (((CYL(type) - 3) * HDS(type)) * SPT(type)));    /* diag start */
             if (j >= i) {                       /* only do diag sectors */
                 cecc = dmle_ecc32(buf2, ssize); /* calc ecc for sector */
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_DETAIL, dptr,
                     "ECC j %02x i %02x data write Old %08x Cur %08x cyl %04x hds %02x sec %02x\n",
                     j, i, decc[j-i], cecc, STAR2CYL(tempt), ((tempt) >> 8)&0xff, (tempt&0xff));
                 decc[j-i] = cecc;               /* set new ecc */
@@ -2170,7 +2183,7 @@ iha_error:
                     bbuf[i] = buf2[i];          /* save bad buffer */
                 cecc = dmle_ecc32(buf2, ssize); /* calc ecc for sector */
                 ecc = 0;
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_DETAIL, dptr,
                     "Writing decc[%04x] ECC %08x cyl %04x hds %02x sec %02x\n",
                     j, cecc, STAR2CYL(uptr->CHS), ((uptr->CHS) >> 8)&0xff, (uptr->CHS&0xff));
                 /* set ECC value here */
@@ -2187,7 +2200,7 @@ iha_error:
                     ecc |= ((ch & 0xff) << ((3-i)*8));
                 }
                 tcyl++;                         /* show we have no more data to write */
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_DETAIL, dptr,
                     "Write decc[%04x] ECC=%08x from diags, calc ECC=%08x cyl %04x hds %02x sec %02x\n",
                     j, ecc, cecc, STAR2CYL(uptr->CHS), ((uptr->CHS) >> 8)&0xff, (uptr->CHS&0xff));
                 decc[j] = ecc;                  /* set new ecc from diag */
@@ -2212,7 +2225,7 @@ iha_error:
             /* see if over end of disk */
             if (tstart >= (uint32)CAP(type)) {
                 /* EOM reached, abort */
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "DISK Write reached EOM for write to disk @ %04x/%02x/%02x\n",
                     STAR2CYL(uptr->CHS), (uptr->CHS >> 8)&0xff, (uptr->CHS&0xff));
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -2254,7 +2267,8 @@ iha_error:
         len = chp->ccw_count;                   /* get number bytes to read */
         mema = uptr->CHS+(len/30);              /* save address */
 
-        sim_debug(DEBUG_DETAIL, dptr, "before RSL Sector %x len %x\n", uptr->CHS, len);
+        sim_debug(DEBUG_DETAIL, dptr,
+            "before RSL Sector %x len %x\n", uptr->CHS, len);
 
         /* read a 30 byte track label for each sector on track */
         /* for 16 sectors per track, that is 480 bytes */
@@ -2272,18 +2286,20 @@ iha_error:
             sec = uptr->CHS & 0xff;             /* get sec */
             seeksec = tstart;                   /* save sector number */
 
-            sim_debug(DEBUG_EXP, dptr, "disk_srv RSL cyl %04x trk %02x sec %02x sector# %06x\n",
+            sim_debug(DEBUG_EXP, dptr,
+                "disk_srv RSL cyl %04x trk %02x sec %02x sector# %06x\n",
                 cyl, trk, sec, seeksec);
 
             /* seek sector label area after end of track label area */
             tstart = CAPB(type) + (CYL(type)*HDS(type)*30) + (tstart*30);
 
             /* file offset in bytes to sector label */
-            sim_debug(DEBUG_EXP, dptr, "disk_srv RSL SEEK on seek to %08x\n", tstart);
+            sim_debug(DEBUG_EXP, dptr,
+                "disk_srv RSL SEEK on seek to %08x\n", tstart);
 
             /* seek to the location where we will read sector label */
             if ((sim_fseek(uptr->fileref, tstart, SEEK_SET)) != 0) {
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "Error seeking sector label area at sect %06x offset %08x\n",
                     seeksec, tstart);
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -2294,7 +2310,7 @@ iha_error:
 
             /* read in a sector label from disk */
             if (sim_fread(buf, 1, 30, uptr->fileref) != 30) {
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "Error %08x on read %04x of diskfile cyl %04x hds %02x sec %02x\n",
                     len, 30, ((uptr->CHS)>>16)&0xffff, ((uptr->CHS)>>8)&0xff, (uptr->CHS)&0xff);
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -2397,18 +2413,18 @@ iha_error:
             sec = uptr->CHS & 0xff;             /* get sec */
             seeksec = tstart;                   /* save sector number */
 
-            sim_debug(DEBUG_EXP, dptr, "disk_srv WSL cyl %04x trk %02x sec %02x sector# %06x\n",
+            sim_debug(DEBUG_CMD, dptr, "disk_srv WSL cyl %04x trk %02x sec %02x sector# %06x\n",
                 cyl, trk, sec, seeksec);
 
             /* seek sector label area after end of track label area */
             tstart = CAPB(type) + (CYL(type)*HDS(type)*30) + (tstart*30);
 
             /* file offset in bytes to sector label */
-            sim_debug(DEBUG_EXP, dptr, "disk_srv WSL SEEK on seek to %08x\n", tstart);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv WSL SEEK on seek to %08x\n", tstart);
 
             /* seek to the location where we will write sector label */
             if ((sim_fseek(uptr->fileref, tstart, SEEK_SET)) != 0) {
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "Error seeking sector label area at sect %06x offset %08x\n",
                     seeksec, tstart);
                 uptr->CHS = mema;               /* restore address */
@@ -2420,7 +2436,7 @@ iha_error:
 
             /* write sector label to disk */
             if (sim_fwrite(buf, 1, 30, uptr->fileref) != 30) {
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "Error %08x on write %04x of diskfile cyl %04x hds %02x sec %02x\n",
                     len, 30, ((uptr->CHS)>>16)&0xffff, ((uptr->CHS)>>8)&0xff, (uptr->CHS)&0xff);
                 uptr->CHS = mema;               /* restore address */
@@ -2471,14 +2487,14 @@ iha_error:
 
         /* get track number */
         tstart = (cyl * HDS(type)) + trk;
-        sim_debug(DEBUG_EXP, dptr, "disk_srv RTL cyl %4x(%d) trk %x sec# %06x\n",
+        sim_debug(DEBUG_CMD, dptr, "disk_srv RTL cyl %4x(%d) trk %x sec# %06x\n",
             cyl, cyl, trk, tstart);
 
         /* calc offset in file to track label */
         tstart = CAPB(type) + (tstart * 30);
 
         /* file offset in bytes */
-        sim_debug(DEBUG_EXP, dptr, "disk_srv RTL SEEK on seek to %06x\n", tstart);
+        sim_debug(DEBUG_CMD, dptr, "disk_srv RTL SEEK on seek to %06x\n", tstart);
 
         /* seek to the location where we will r/w track label */
         if ((sim_fseek(uptr->fileref, tstart, SEEK_SET)) != 0) {  /* do seek */
@@ -2490,7 +2506,7 @@ iha_error:
 
         /* read in a track label from disk */
         if ((len=sim_fread(buf, 1, 30, uptr->fileref)) != 30) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "Error %08x on read %04x of diskfile cyl %04x hds %02x sec %02x\n",
                 len, 30, ((uptr->CHS)>>16)&0xffff, ((uptr->CHS)>>8)&0xff, (uptr->CHS)&0xff);
             uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
@@ -2534,7 +2550,7 @@ iha_error:
         /* Write track zero to set disk geometry */
         /* write 30 bytes, b0-b1=cyl, b1=trk, b2=sec */
 
-        sim_debug(DEBUG_EXP, dptr, "disk_srv WTL start cnt %04x CHS %08x\n",
+        sim_debug(DEBUG_DETAIL, dptr, "disk_srv WTL start cnt %04x CHS %08x\n",
             chp->ccw_count, uptr->CHS);
 
         /* get file offset in sectors */
@@ -2549,14 +2565,14 @@ iha_error:
 
         /* get track number */
         tstart = (cyl * HDS(type)) + trk;
-        sim_debug(DEBUG_EXP, dptr, "disk_srv WTL cyl %4x trk %x track# %06x CHS %08x\n",
+        sim_debug(DEBUG_CMD, dptr, "disk_srv WTL cyl %4x trk %x track# %06x CHS %08x\n",
             cyl, trk, tstart, uptr->CHS);
 
         /* calc offset in file to track label */
         tstart = CAPB(type) + (tstart * 30);
 
         /* file offset in bytes */
-        sim_debug(DEBUG_EXP, dptr, "disk_srv WTL SEEK on seek to %06x\n", tstart);
+        sim_debug(DEBUG_CMD, dptr, "disk_srv WTL SEEK on seek to %06x\n", tstart);
 
         /* seek to the location where we will write track label */
         if ((sim_fseek(uptr->fileref, tstart, SEEK_SET)) != 0) {  /* do seek */
@@ -2595,7 +2611,7 @@ iha_error:
 
         /* write out a track label to disk */
         if ((len=sim_fwrite(buf, 1, 30, uptr->fileref)) != 30) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "Error %08x on write %04x of diskfile cyl %04x hds %02x sec %02x\n",
                 len, 30, ((uptr->CHS)>>16)&0xffff, ((uptr->CHS)>>8)&0xff, (uptr->CHS)&0xff);
             uptr->CHS = mema;                   /* restore address */
@@ -2626,7 +2642,7 @@ iha_error:
         break;
 
     default:
-        sim_debug(DEBUG_CMD, dptr, "invalid command %02x unit %02x\n", cmd, unit);
+        sim_debug(DEBUG_EXP, dptr, "invalid command %02x unit %02x\n", cmd, unit);
         uptr->SNS |= SNS_CMDREJ;
         uptr->CMD &= LMASK;                     /* remove old status bits & cmd */
         chan_end(chsa, SNS_CHNEND|STATUS_PCHK); /* return Prog Check */
@@ -2638,11 +2654,25 @@ iha_error:
     return SCPE_OK;
 }
 
+/* handle rschnlio cmds for disk */
+uint16  disk_rschnlio(UNIT *uptr) {
+    DEVICE  *dptr = get_dev(uptr);
+    uint16  chsa = GET_UADDR(uptr->CMD);
+    int     cmd = uptr->CMD & DSK_CMDMSK;
+
+    sim_debug(DEBUG_EXP, dptr,
+        "disk_rschnl chsa %04x cmd = %02x\n", chsa, cmd);
+    disk_ini(uptr, 0);                          /* reset the unit */
+    return SCPE_OK;
+}
+
 /* initialize the disk */
 void disk_ini(UNIT *uptr, t_bool f)
 {
     DEVICE  *dptr = get_dev(uptr);
+    int     unit = (uptr - dptr->units);        /* get the UNIT number */
     int     i = GET_TYPE(uptr->flags);
+    int     cn;
 
     /* start out at sector 0 */
     uptr->CHS = 0;                              /* set CHS to cyl/hd/sec = 0 */
@@ -2650,8 +2680,15 @@ void disk_ini(UNIT *uptr, t_bool f)
     uptr->CMD &= LMASK;                         /* remove old status bits & cmd */
     /* total sectors on disk */
     uptr->capac = CAP(i);                       /* size in sectors */
+    sim_cancel(uptr);                           /* stop any timers */
+    /* reset track cache */
+    for (cn=0; cn<TRK_CACHE; cn++) {
+        tkl_label[unit].tkl[cn].track = 0;
+        tkl_label[unit].tkl[cn].age = 0;
+    }
 
-    sim_debug(DEBUG_EXP, &dda_dev, "DMA init device %s on unit DMA%04x cap %x %d\n",
+    sim_debug(DEBUG_EXP, dptr,
+        "DMA init device %s on unit DMA%04x cap %x %d\n",
         dptr->name, GET_UADDR(uptr->CMD), uptr->capac, uptr->capac);
 }
 
@@ -2685,13 +2722,13 @@ int disk_label(UNIT *uptr) {
     int         type = GET_TYPE(uptr->flags);
     DEVICE      *dptr = get_dev(uptr);
     uint32      trk, cyl, sec;
-    uint32      ssize = SSB(type);                  /* disk sector size in bytes */
-    uint32      tsize = SPT(type);                  /* get track size in sectors */
-    uint32      tot_tracks = TRK(type);             /* total tracks on disk */
-    uint32      tot_sectors = CAP(type);            /* total number of sectors on disk */
-    uint32      cap = CAP(type);                    /* disk capacity in sectors */
-    uint32      CHS;                                /* cyl, hds, sec format */
-    uint8       label[34];                          /* track/sector label */
+    uint32      ssize = SSB(type);              /* disk sector size in bytes */
+    uint32      tsize = SPT(type);              /* get track size in sectors */
+    uint32      tot_tracks = TRK(type);         /* total tracks on disk */
+    uint32      tot_sectors = CAP(type);        /* total number of sectors on disk */
+    uint32      cap = CAP(type);                /* disk capacity in sectors */
+    uint32      CHS;                            /* cyl, hds, sec format */
+    uint8       label[34];                      /* track/sector label */
     int32       i, j;
                 /* get sector address of vendor defect table VDT */
                 /* put data = 0xf0000000 0xf4000000 */
@@ -2702,14 +2739,17 @@ int disk_label(UNIT *uptr) {
     int32       daddr = (CYL(type)-4) * SPC(type) + (HDS(type)-2) * SPT(type);
                 /* get sector address of utx flaw map sec 1 pointer */
                 /* use this address for sec 1 label pointer */
-//28int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
+#ifndef NOT_NEEDED_0128
     int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-4) * SPT(type);
+#else
+    int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
+#endif
 
     /* write 30 byte track labels for all tracks on disk */
     /* tot_tracks entries will be created starting at end of disk */
     /* seek first sector after end of disk data */
     if ((sim_fseek(uptr->fileref, CAPB(type), SEEK_SET)) != 0) {
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
             "Error seeking track label area at sect %06x offset %06x\n",
             CAP(type), CAPB(type));
         return 1;
@@ -2721,44 +2761,44 @@ int disk_label(UNIT *uptr) {
         for (j = 0; j < 30; j++)
             label[j] = 0;
 
-        sec = i * SPT(type);                        /* get track address in sectors */
+        sec = i * SPT(type);                    /* get track address in sectors */
         /* convert sector number to CHS value for label */
-        CHS = disksec2star(sec, type);              /* get current CHS value */
+        CHS = disksec2star(sec, type);          /* get current CHS value */
 
         /* set buf data to current CHS values */
-        if (CHS == 0) {                             /* write last address on trk 0 */
-            cyl = CYL(type)-1;                      /* lcyl  cyl upper 8 bits */
-            trk = HDS(type)-1;                      /* ltkn  trk */
-            sec = SPT(type)-1;                      /* lid   sector ID */
+        if (CHS == 0) {                         /* write last address on trk 0 */
+            cyl = CYL(type)-1;                  /* lcyl  cyl upper 8 bits */
+            trk = HDS(type)-1;                  /* ltkn  trk */
+            sec = SPT(type)-1;                  /* lid   sector ID */
         } else {
             /* write current address on other tracks */
-            cyl = (CHS >> 16) & 0xffff;             /* get the cylinder */
-            trk = (CHS >> 8) & 0xff;                /* get the track */
-            sec = (CHS) & 0xff;                     /* get the sector */
+            cyl = (CHS >> 16) & 0xffff;         /* get the cylinder */
+            trk = (CHS >> 8) & 0xff;            /* get the track */
+            sec = (CHS) & 0xff;                 /* get the sector */
         }
 
         sim_debug(DEBUG_CMD, dptr, "disk_format WTL STAR %08x disk geom %08x\n",
             CHS, GEOM(type));
 
         /* set buf data to current STAR values */
-        label[0] = (cyl >> 8) & 0xff;               /* lcyl  cyl upper 8 bits */
-        label[1] = cyl & 0xff;                      /* lcyl  cyl lower 8 bits */
-        label[2] = trk & 0xff;                      /* ltkn  trk */
-        label[3] = sec & 0xff;                      /* lid   sector ID */
-        label[4] = 0x80;                            /* show good sector */
-        if (i == (tot_tracks-1)) {                  /* last track? */
-            label[3] = 0xff;                        /* lid   show as last track label */
-            label[4] |= 0x04;                       /* set last track flag */
+        label[0] = (cyl >> 8) & 0xff;           /* lcyl  cyl upper 8 bits */
+        label[1] = cyl & 0xff;                  /* lcyl  cyl lower 8 bits */
+        label[2] = trk & 0xff;                  /* ltkn  trk */
+        label[3] = sec & 0xff;                  /* lid   sector ID */
+        label[4] = 0x80;                        /* show good sector */
+        if (i == (tot_tracks-1)) {              /* last track? */
+            label[3] = 0xff;                    /* lid   show as last track label */
+            label[4] |= 0x04;                   /* set last track flag */
         }
 
-        sim_debug(DEBUG_DETAIL, dptr,
+        sim_debug(DEBUG_CMD, dptr,
             "disk_format WTL star %02x %02x %02x %02x\n",
             label[0], label[1], label[2], label[3]);
 
         /* daddr has dmap value for track zero label */
-        if (CHS == 0) {                             /* only write dmap address in trk 0 */
+        if (CHS == 0) {                         /* only write dmap address in trk 0 */
             /* output diag defect map address of disk */
-            label[12] = (daddr >> 24) & 0xff;       /* ldeallp DMAP pointer */
+            label[12] = (daddr >> 24) & 0xff;   /* ldeallp DMAP pointer */
             label[13] = (daddr >> 16) & 0xff;
             label[14] = (daddr >> 8) & 0xff;
             label[15] = (daddr) & 0xff;
@@ -2768,15 +2808,15 @@ int disk_label(UNIT *uptr) {
         }
 
         /* write vaddr to track label for dmap */
-        if ((i*SPT(type)) == daddr) {               /* get track address in sectors */
+        if ((i*SPT(type)) == daddr) {           /* get track address in sectors */
             /* output vendor defect map address of disk */
-            label[12] = (vaddr >> 24) & 0xff;       /* Vaddr pointer */
+            label[12] = (vaddr >> 24) & 0xff;   /* Vaddr pointer */
             label[13] = (vaddr >> 16) & 0xff;
             label[14] = (vaddr >> 8) & 0xff;
             label[15] = (vaddr) & 0xff;
-            printf("hsdp_format WTL vaddr@daddr %08x -> %08x\r\n", vaddr, daddr);
-            sim_debug(DEBUG_DETAIL, dptr,
-                "hsdp_format WTL vaddr@daddr %08x -> %08x\n", vaddr, daddr);
+            printf("disk_format WTL vaddr@daddr %08x -> %08x\r\n", vaddr, daddr);
+            sim_debug(DEBUG_CMD, dptr,
+                "disk_format WTL vaddr@daddr %08x -> %08x\n", vaddr, daddr);
         }
         /* if this is removed, utx is unable to create newfs */
         /* get preposterous size 0 error message */
@@ -2785,7 +2825,7 @@ int disk_label(UNIT *uptr) {
         /* uaddr has umap value for track zero label */
         if (CHS == 0) {                         /* only write dmap address in trk 0 */
             /* output umap address */
-            label[16] = (uaddr >> 24) & 0xff;       /* lumapp DMAP pointer */
+            label[16] = (uaddr >> 24) & 0xff;   /* lumapp DMAP pointer */
             label[17] = (uaddr >> 16) & 0xff;
             label[18] = (uaddr >> 8) & 0xff;
             label[19] = (uaddr) & 0xff;
@@ -2802,7 +2842,7 @@ int disk_label(UNIT *uptr) {
         label[28] = HDS(type) & 0xff;
 
         if ((sim_fwrite((char *)&label, sizeof(uint8), 30, uptr->fileref)) != 30) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "Error writing track label to sect %06x offset %06x\n",
                 cap+(i*tsize), cap*ssize+(i*tsize*ssize));
             return 1;
@@ -2814,7 +2854,7 @@ int disk_label(UNIT *uptr) {
     /* plus the track label area size. Seek first sector after end */
     /* of disk track label area */
     if ((sim_fseek(uptr->fileref, CAPB(type)+TRK(type)*30, SEEK_SET)) != 0) {
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
             "Error seeking sector label area at sect %06x offset %06x\n",
             CAP(type)+TRK(type), CAPB(type)+TRK(type)*30);
         return 1;
@@ -2828,25 +2868,25 @@ int disk_label(UNIT *uptr) {
     /* write sector labels */
     for (i=0; i<(int)tot_sectors; i++) {
 
-        CHS = disksec2star(i, type);                /* get current CHS value */
+        CHS = disksec2star(i, type);            /* get current CHS value */
 
         /* set buf data to current CHS values */
         /* write current address on other tracks */
-        cyl = (CHS >> 16) & 0xffff;                 /* get the cylinder */
-        trk = (CHS >> 8) & 0xff;                    /* get the track */
-        sec = (CHS) & 0xff;                         /* get the sector */
+        cyl = (CHS >> 16) & 0xffff;             /* get the cylinder */
+        trk = (CHS >> 8) & 0xff;                /* get the track */
+        sec = (CHS) & 0xff;                     /* get the sector */
 
         sim_debug(DEBUG_CMD, dptr, "disk_format WSL STAR %08x disk geom %08x\n",
             CHS, GEOM(type));
 
         /* set buf data to current STAR values */
-        label[0] = (cyl >> 8) & 0xff;               /* lcyl  cyl upper 8 bits */
-        label[1] = cyl & 0xff;                      /* lcyl  cyl lower 8 bits */
-        label[2] = trk & 0xff;                      /* ltkn  trk */
-        label[3] = sec & 0xff;                      /* lid   sector ID */
-        label[4] = 0x80;                            /* show good sector */
+        label[0] = (cyl >> 8) & 0xff;           /* lcyl  cyl upper 8 bits */
+        label[1] = cyl & 0xff;                  /* lcyl  cyl lower 8 bits */
+        label[2] = trk & 0xff;                  /* ltkn  trk */
+        label[3] = sec & 0xff;                  /* lid   sector ID */
+        label[4] = 0x80;                        /* show good sector */
 
-        sim_debug(DEBUG_DETAIL, dptr,
+        sim_debug(DEBUG_CMD, dptr,
             "disk_format WSL star %02x %02x %02x %02x\n",
             label[0], label[1], label[2], label[3]);
 
@@ -2857,15 +2897,15 @@ int disk_label(UNIT *uptr) {
 
         /* if this is written, UTX will not be able to do a newfs */
         /* gets preposterous size 0 error */
-#ifdef TRYING_121720
+#ifdef XXXX_121720
         /* uaddr has umap value for sector one label */
-        if (CHS == 1) {                             /* only write dmap address in trk 0 */
+        if (CHS == 1) {                         /* only write dmap address in trk 0 */
             /* output last sector address of disk */
-            label[12] = (uaddr >> 24) & 0xff;       /* lumapp UMAP pointer */
+            label[12] = (uaddr >> 24) & 0xff;   /* lumapp UMAP pointer */
             label[13] = (uaddr >> 16) & 0xff;
             label[14] = (uaddr >> 8) & 0xff;
             label[15] = (uaddr) & 0xff;
-            sim_debug(DEBUG_DETAIL, dptr,
+            sim_debug(DEBUG_CMD, dptr,
                 "disk_format WSL uaddr star %02x %02x %02x %02x\n",
                 label[12], label[13], label[14], label[15]);
         } 
@@ -2896,28 +2936,28 @@ int disk_label(UNIT *uptr) {
         fprintf (stderr, "Error on seek to 0\r\n");
         return 1;
     }
-    return SCPE_OK;                                 /* good to go */
+    return SCPE_OK;                             /* good to go */
 }
 
 /* create the disk file for the specified device */
 int disk_format(UNIT *uptr) {
     int         type = GET_TYPE(uptr->flags);
     DEVICE      *dptr = get_dev(uptr);
-    uint32      ssize = SSB(type);                  /* disk sector size in bytes */
-    uint32      tsize = SPT(type);                  /* get track size in sectors */
-    uint32      csize = SPC(type);                  /* get cylinder size in sectors */
-    uint32      cyl = CYL(type);                    /* get # cylinders */
-    uint32      cap = CAP(type);                    /* disk capacity in sectors */
-    uint32      cylv = cyl;                         /* number of cylinders */
+    uint32      ssize = SSB(type);              /* disk sector size in bytes */
+    uint32      tsize = SPT(type);              /* get track size in sectors */
+    uint32      csize = SPC(type);              /* get cylinder size in sectors */
+    uint32      cyl = CYL(type);                /* get # cylinders */
+    uint32      cap = CAP(type);                /* disk capacity in sectors */
+    uint32      cylv = cyl;                     /* number of cylinders */
     uint8       *buff;
     int32       i;
 
                 /* last sector address of disk (cyl * hds * spt) - 1 */
-    uint32      laddr = CAP(type) - 1;              /* last sector of disk */
+    uint32      laddr = CAP(type) - 1;          /* last sector of disk */
 
 #ifndef NOT_NEEDED_0128
                 /* last track address of disk (cyl * hds * spt) - spt */
-    uint32      ltaddr = CAP(type)-SPT(type);       /* last track of disk */
+    uint32      ltaddr = CAP(type)-SPT(type);   /* last track of disk */
 #endif
 
                 /* get sector address of vendor defect table VDT */
@@ -2937,9 +2977,11 @@ int disk_format(UNIT *uptr) {
 
                 /* get sector address of utx flaw map sec 1 pointer */
                 /* use this address for sec 1 label pointer */
-//28int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
+#ifndef NOT_NEEDED_0128
     int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-4) * SPT(type);
-
+#else
+    int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
+#endif
 
                 /* vendor flaw map in vaddr */
     uint32      vmap[2] = {0xf0000004, 0xf4000000};
@@ -2982,9 +3024,9 @@ int disk_format(UNIT *uptr) {
     /* write zeros to each track of the disk */
     for (cyl = 0; cyl < cylv; cyl++) {
         if ((sim_fwrite(buff, 1, csize*ssize, uptr->fileref)) != csize*ssize) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "Error on write to diskfile cyl %04x\n", cyl);
-            free(buff);                             /* free cylinder buffer */
+            free(buff);                         /* free cylinder buffer */
             buff = 0;
             return 1;
         }
@@ -2993,7 +3035,7 @@ int disk_format(UNIT *uptr) {
     }
     fputc('\r', stderr);
     fputc('\n', stderr);
-    free(buff);                                     /* free cylinder buffer */
+    free(buff);                                 /* free cylinder buffer */
     buff = 0;
 
     /* byte swap the buffers for dmap and umap */
@@ -3018,13 +3060,13 @@ int disk_format(UNIT *uptr) {
 
     /* write dmap data to last sector on disk */
     if ((sim_fseek(uptr->fileref, laddr*ssize, SEEK_SET)) != 0) { /* seek last sector */
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
         "Error on last sector seek to sect %06x offset %06x\n",
         cap-1, (cap-1)*ssize);
         return 1;
     }
     if ((sim_fwrite((char *)&dmap, sizeof(uint32), 4, uptr->fileref)) != 4) {
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
         "Error writing DMAP to sect %06x offset %06x\n",
         cap-1, (cap-1)*ssize);
         return 1;
@@ -3032,7 +3074,7 @@ int disk_format(UNIT *uptr) {
 
     /* seek to vendor label area VMAP */
     if ((sim_fseek(uptr->fileref, vaddr*ssize, SEEK_SET)) != 0) { /* seek VMAP */
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
         "Error on vendor map seek to sect %06x offset %06x\n",
         vaddr, vaddr*ssize);
         return 1;
@@ -3079,25 +3121,25 @@ int disk_format(UNIT *uptr) {
         SPT(type), SPT(type));
     printf("writing to vmap sec %x (%d) bytes %x (%d)\r\n",
         vaddr, vaddr, (vaddr)*ssize, (vaddr)*ssize);
-#ifndef NOT_NEEDED_0128
-    printf("writing to flaw map sec %x (%d) bytes %x (%d)\r\n",
-        faddr, faddr, (faddr)*ssize, (faddr)*ssize);
-#endif
-    printf("writing dmap to %x %d %x %d dmap to %x %d %x %d\r\n",
+    printf("writing to dmap sec %x (%d) %x (%d) dmap to %x (%d) %x (%d)\r\n",
        cap-1, cap-1, (cap-1)*ssize, (cap-1)*ssize,
        daddr, daddr, daddr*ssize, daddr*ssize);
+#ifndef NOT_NEEDED_0128
+    printf("writing to fmap sec %x (%d) bytes %x (%d)\r\n",
+        faddr, faddr, (faddr)*ssize, (faddr)*ssize);
+#endif
     printf("writing to umap sec %x (%d) bytes %x (%d)\r\n",
         uaddr, uaddr, (uaddr)*ssize, (uaddr)*ssize);
 
     /* create labels for disk */
-    i = disk_label(uptr);                           /* label disk */
+    i = disk_label(uptr);                       /* label disk */
 
     /* seek home again */
     if ((sim_fseek(uptr->fileref, 0, SEEK_SET)) != 0) { /* seek home */
         fprintf (stderr, "Error on seek to 0\r\n");
         return 1;
     }
-    return i;                                       /* good or error */
+    return i;                                   /* good or error */
 }
 
 /* attach the selected file to the disk */
@@ -3109,13 +3151,13 @@ t_stat disk_attach(UNIT *uptr, CONST char *file)
     DEVICE          *dptr = get_dev(uptr);
     DIB             *dibp = 0;
     t_stat          r,s;
-    uint32          ssize;                          /* sector size in bytes */
+    uint32          ssize;                      /* sector size in bytes */
     uint32          info, good;
     uint8           buff[1024];
     int             i, j;
 
                     /* last sector address of disk (cyl * hds * spt) - 1 */
-    uint32          laddr = CAP(type) - 1;          /* last sector of disk */
+    uint32          laddr = CAP(type) - 1;      /* last sector of disk */
                     /* get sector address of utx diag map (DMAP) track 0 pointer */
                     /* put data = 0xf0000000 + (cyl-1), 0x8a000000 + daddr, */
                     /* 0x9a000000 + (cyl-1), 0xf4000000 */
@@ -3124,25 +3166,25 @@ t_stat disk_attach(UNIT *uptr, CONST char *file)
     uint32          dmap[4] = {0xf0000000 | (CAP(type)-1), 0x8a000000 | daddr,
                         0x9a000000 | (CAP(type)-1), 0xf4000000};
 
-    for (i=0; i<4; i++) {                           /* byte swap data for last sector */
+    for (i=0; i<4; i++) {                       /* byte swap data for last sector */
         dmap[i] = (((dmap[i] & 0xff) << 24) | ((dmap[i] & 0xff00) << 8) |
             ((dmap[i] & 0xff0000) >> 8) | ((dmap[i] >> 24) & 0xff));
     }
 
     /* see if valid disk entry */
-    if (disk_type[type].name == 0) {                /* does the assigned disk have a name */
-        detach_unit(uptr);                          /* no, reject */
-        return SCPE_FMT;                            /* error */
+    if (disk_type[type].name == 0) {            /* does the assigned disk have a name */
+        detach_unit(uptr);                      /* no, reject */
+        return SCPE_FMT;                        /* error */
     }
 
     /* have simulator attach the file to the unit */
     if ((r = attach_unit(uptr, file)) != SCPE_OK)
         return r;
 
-    uptr->capac = CAP(type);                        /* disk capacity in sectors */
-    ssize = SSB(type);                              /* get sector size in bytes */
+    uptr->capac = CAP(type);                    /* disk capacity in sectors */
+    ssize = SSB(type);                          /* get sector size in bytes */
     for (i=0; i<(int)ssize; i++)
-        buff[i] = 0;                                /* zero the buffer */
+        buff[i] = 0;                            /* zero the buffer */
 
     sim_debug(DEBUG_CMD, dptr,
         "Disk %s cyl %d hds %d sec %d ssiz %d capacity %d\n",
@@ -3156,20 +3198,20 @@ t_stat disk_attach(UNIT *uptr, CONST char *file)
     if ((sim_fseek(uptr->fileref, 0, SEEK_END)) != 0) {
         sim_debug(DEBUG_CMD, dptr, "UDP Disk attach SEEK end failed\n");
         printf("Disk attach SEEK end failed\r\n");
-        goto fmt;                                   /* not setup, go format */
+        goto fmt;                               /* not setup, go format */
     }
 
-    s = ftell(uptr->fileref);                       /* get current file position */
+    s = ftell(uptr->fileref);                   /* get current file position */
     if (s == 0) {
         sim_debug(DEBUG_CMD, dptr, "UDP Disk attach ftell failed s=%06d\n", s);
         printf("Disk attach ftell failed s=%06d\r\n", s);
-        goto fmt;                                   /* not setup, go format */
+        goto fmt;                               /* not setup, go format */
     }
 //  sim_debug(DEBUG_CMD, dptr, "UDP Disk attach ftell value s=%06d b=%06d CAP %06d\n", s/ssize, s, CAP(type));
 //  printf("Disk attach ftell value s=%06d b=%06d CAP %06d\r\n", s/ssize, s, CAP(type));
 
     if (((int)s/(int)ssize) < ((int)CAP(type))) {   /* full sized disk? */
-        j = (CAP(type) - (s/ssize));                /* get # sectors to write */
+        j = (CAP(type) - (s/ssize));            /* get # sectors to write */
         sim_debug(DEBUG_CMD, dptr,
             "Disk attach for MPX 1.X needs %04d more sectors added to disk\n", j);
         printf("Disk attach for MPX 1.X needs %04d more sectors added to disk\r\n", j);
@@ -3179,10 +3221,10 @@ t_stat disk_attach(UNIT *uptr, CONST char *file)
             if ((r = sim_fwrite(buff, sizeof(uint8), ssize, uptr->fileref) != ssize)) {
                 sim_debug(DEBUG_CMD, dptr, "Disk attach fread ret = %04d\n", r);
                 printf("Disk attach fread ret = %04d\r\n", r);
-                goto fmt;                           /* not setup, go format */
+                goto fmt;                       /* not setup, go format */
             }
         }
-        s = ftell(uptr->fileref);                   /* get current file position */
+        s = ftell(uptr->fileref);               /* get current file position */
         sim_debug(DEBUG_CMD, dptr,
             "Disk attach MPX 1.X file extended & sized secs %06d bytes %06d\n", s/ssize, s);
         printf("Disk attach MPX 1.X  file extended & sized secs %06d bytes %06d\r\n", s/ssize, s);
@@ -3243,7 +3285,7 @@ add_size:
     good = 0xf0000000 | (CAP(type)-1);
     /* check for 0xf0ssssss where ssssss is disk size-1 in sectors */
     if (info != good) {
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
             "Disk format error buf0 %02x buf1 %02x buf2 %02x buf3 %02x\n",
             buff[0], buff[1], buff[2], buff[3]);
         printf("Disk format error buf0 %02x buf1 %02x buf2 %02x buf3 %02x\r\n",
@@ -3251,16 +3293,16 @@ add_size:
 fmt:
         /* format the drive */
         if (disk_format(uptr)) {
-            detach_unit(uptr);                      /* if no space, error */
-            return SCPE_FMT;                        /* error */
+            detach_unit(uptr);                  /* if no space, error */
+            return SCPE_FMT;                    /* error */
         }
     }
 
 ldone:
     /* see if disk has labels already, seek to sector past end of disk  */
     if ((sim_fseek(uptr->fileref, CAP(type)*ssize, SEEK_SET)) != 0) { /* seek end */
-        detach_unit(uptr);                          /* detach if error */
-        return SCPE_FMT;                            /* error */
+        detach_unit(uptr);                      /* detach if error */
+        return SCPE_FMT;                        /* error */
     }
 
     i = SCPE_OK;
@@ -3273,39 +3315,44 @@ ldone:
             file, disk_type[type].name);
         printf("File %s attached to %s creating labels\r\n",
             file, disk_type[type].name);
-        i = disk_label(uptr);                       /* label disk */
+        i = disk_label(uptr);                   /* label disk */
         if (i != 0) {
-            detach_unit(uptr);                      /* detach if error */
-            return SCPE_FMT;                        /* error */
+            detach_unit(uptr);                  /* detach if error */
+            return SCPE_FMT;                    /* error */
         }
     } else {
         int32   uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-4) * SPT(type);
         /* uaddr has umap value for track zero label */
         /* output umap address */
-        buff[16] = (uaddr >> 24) & 0xff;            /* lumapp DMAP pointer */
+        buff[16] = (uaddr >> 24) & 0xff;        /* lumapp DMAP pointer */
         buff[17] = (uaddr >> 16) & 0xff;
         buff[18] = (uaddr >> 8) & 0xff;
         buff[19] = (uaddr) & 0xff;
         if ((sim_fseek(uptr->fileref, CAP(type)*ssize, SEEK_SET)) != 0) { /* seek end */
-            detach_unit(uptr);                      /* detach if error */
-            return SCPE_FMT;                        /* error */
+            detach_unit(uptr);                  /* detach if error */
+            return SCPE_FMT;                    /* error */
         }
         /* output updated umap address to track 0 for UTX21a */
         if ((sim_fwrite(buff, sizeof(uint8), 30, uptr->fileref)) != 30) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "Error writing back track 0 label to sect %06x offset %06x\n",
                 CAP(type), CAP(type)*ssize);
-            return SCPE_FMT;                        /* error */
+            return SCPE_FMT;                    /* error */
         }
     }
 
+    /* UTX map (NUMP) does not insert an F4 after the replacement tracks */
+    /* so do it after the tracks are defined to stop halt on bootup */
+    /* utxmap + 32 + 88 + (3*spare) + 1 */
+    /* spare count is at utxmap + 8w (32) */
+
     if ((sim_fseek(uptr->fileref, 0, SEEK_SET)) != 0) { /* seek home */
-        detach_unit(uptr);                          /* detach if error */
-        return SCPE_FMT;                            /* error */
+        detach_unit(uptr);                      /* detach if error */
+        return SCPE_FMT;                        /* error */
     }
 
     /* start out at sector 0 */
-    uptr->CHS = 0;                                  /* set CHS to cyl/hd/sec = 0 */
+    uptr->CHS = 0;                              /* set CHS to cyl/hd/sec = 0 */
 
     sim_debug(DEBUG_CMD, dptr,
         "UDP %s cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\n",
@@ -3323,15 +3370,15 @@ ldone:
 
     /* check for valid configured disk */
     /* must have valid DIB and Channel Program pointer */
-    dibp = (DIB *)dptr->ctxt;                       /* get the DIB pointer */
+    dibp = (DIB *)dptr->ctxt;                   /* get the DIB pointer */
     if ((dib_unit[chsa] == NULL) || (dibp == NULL) || (chp == NULL)) {
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
             "ERROR===ERROR\nUDP device %s not configured on system, aborting\n",
             dptr->name);
         printf("ERROR===ERROR\nUDP device %s not configured on system, aborting\r\n",
             dptr->name);
-        detach_unit(uptr);                          /* detach if error */
-        return SCPE_UNATT;                          /* error */
+        detach_unit(uptr);                      /* detach if error */
+        return SCPE_UNATT;                      /* error */
     }
     set_devattn(chsa, SNS_DEVEND);
     return SCPE_OK;
@@ -3339,27 +3386,29 @@ ldone:
 
 /* detach a disk device */
 t_stat disk_detach(UNIT *uptr) {
-    uptr->SNS = 0;                                  /* clear sense data */
-    uptr->CMD &= LMASK;                             /* remove old status bits & cmd */
-    return detach_unit(uptr);                       /* tell simh we are done with disk */
+    uptr->SNS = 0;                              /* clear sense data */
+    uptr->CMD &= LMASK;                         /* remove old status bits & cmd */
+    return detach_unit(uptr);                   /* tell simh we are done with disk */
 }
 
 /* boot from the specified disk unit */
 t_stat disk_boot(int32 unit_num, DEVICE *dptr) {
-    UNIT    *uptr = &dptr->units[unit_num];         /* find disk unit number */
+    UNIT    *uptr = &dptr->units[unit_num];     /* find disk unit number */
 
-    sim_debug(DEBUG_CMD, dptr, "Disk Boot dev/unit %x\n", GET_UADDR(uptr->CMD));
+    sim_debug(DEBUG_CMD, dptr,
+       "Disk Boot dev/unit %x\n", GET_UADDR(uptr->CMD));
 
     if ((uptr->flags & UNIT_ATT) == 0) {
-        sim_debug(DEBUG_EXP, dptr, "Disk Boot attach error dev/unit %04x\n",
+        sim_debug(DEBUG_EXP, dptr,
+            "Disk Boot attach error dev/unit %04x\n",
             GET_UADDR(uptr->CMD));
-        return SCPE_UNATT;                          /* attached? */
+        return SCPE_UNATT;                      /* attached? */
     }
-    SPAD[0xf4] = GET_UADDR(uptr->CMD);              /* put boot device chan/sa into spad */
-    SPAD[0xf8] = 0xF000;                            /* show as F class device */
+    SPAD[0xf4] = GET_UADDR(uptr->CMD);          /* put boot device chan/sa into spad */
+    SPAD[0xf8] = 0xF000;                        /* show as F class device */
 
     /* now boot the disk */
-    uptr->CMD &= LMASK;                             /* remove old status bits & cmd */
+    uptr->CMD &= LMASK;                         /* remove old status bits & cmd */
     return chan_boot(GET_UADDR(uptr->CMD), dptr);   /* boot the ch/sa */
 }
 
@@ -3369,18 +3418,18 @@ t_stat disk_set_type(UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 {
     int     i;
 
-    if (cptr == NULL)                               /* any disk name input? */
-        return SCPE_ARG;                            /* arg error */
-    if (uptr == NULL)                               /* valid unit? */
-        return SCPE_IERR;                           /* no, error */
-    if (uptr->flags & UNIT_ATT)                     /* is unit attached? */
-        return SCPE_ALATT;                          /* no, error */
+    if (cptr == NULL)                           /* any disk name input? */
+        return SCPE_ARG;                        /* arg error */
+    if (uptr == NULL)                           /* valid unit? */
+        return SCPE_IERR;                       /* no, error */
+    if (uptr->flags & UNIT_ATT)                 /* is unit attached? */
+        return SCPE_ALATT;                      /* no, error */
 
     /* now loop through the units and find named disk */
     for (i = 0; disk_type[i].name != 0; i++) {
         if (strcmp(disk_type[i].name, cptr) == 0) {
-            uptr->flags &= ~UNIT_TYPE;              /* clear the old UNIT type */
-            uptr->flags |= SET_TYPE(i);             /* set the new type */
+            uptr->flags &= ~UNIT_TYPE;          /* clear the old UNIT type */
+            uptr->flags |= SET_TYPE(i);         /* set the new type */
             /* set capacity of disk in sectors */
             uptr->capac = CAP(i);
             return SCPE_OK;
@@ -3413,9 +3462,9 @@ t_stat disk_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cp
     }
     fprintf (st, ".\nEach drive has the following storage capacity:\r\n");
     for (i = 0; disk_type[i].name != 0; i++) {
-        int32   size = CAPB(i);                     /* disk capacity in bytes */
-        size /= 1024;                               /* make KB */
-        size = (10 * size) / 1024;                  /* size in MB * 10 */
+        int32   size = CAPB(i);                 /* disk capacity in bytes */
+        size /= 1024;                           /* make KB */
+        size = (10 * size) / 1024;              /* size in MB * 10 */
         fprintf(st, "      %-8s %4d.%1d MB cyl %3d hds %3d sec %3d blk %3d\r\n",
             disk_type[i].name, size/10, size%10, CYL(i), HDS(i), SPT(i), SSB(i));
     }

--- a/SEL32/sel32_fltpt.c
+++ b/SEL32/sel32_fltpt.c
@@ -160,35 +160,35 @@ t_uint64 s_nord(t_uint64 reg, uint32 *exp) {
 /* normalize the memory value when adding number to zero */
 uint32 s_normfw(uint32 num, uint32 *cc) {
     uint32      ret;
-    int32       val;                /* temp word */
-    int32       exp;                /* exponent */
-    int32       CCs;                /* condition codes */
-    uint8       sign;               /* original sign */
+    int32       val;                    /* temp word */
+    int32       exp;                    /* exponent */
+    int32       CCs;                    /* condition codes */
+    uint8       sign;                   /* original sign */
 
-    if (num == 0) {                 /* make sure we have a number */
-        *cc = CC4BIT;               /* set the cc's */
-        return 0;                   /* return zero */
+    if (num == 0) {                     /* make sure we have a number */
+        *cc = CC4BIT;                   /* set the cc's */
+        return 0;                       /* return zero */
     }
     sign = 0;
 
     /* special case 0x80000000 (-0) to set CCs to 1011 * value to 0x80000001 */
     if (num == 0x80000000) {
-        CCs = CC1BIT|CC3BIT|CC4BIT; /* we have AE, exp overflow, neg frac */
-        ret = 0x80000001;           /* return max neg value */
+        CCs = CC1BIT|CC3BIT|CC4BIT;     /* we have AE, exp overflow, neg frac */
+        ret = 0x80000001;               /* return max neg value */
 
         /* return normalized number */
-        *cc = CCs;                  /* set the cc's */
-        return ret;                 /* return result */
+        *cc = CCs;                      /* set the cc's */
+        return ret;                     /* return result */
     }
 
     /* special case pos exponent & zero mantissa to be 0 */
     if (((num & 0x80000000) == 0) && ((num & 0xff000000) > 0) && ((num & 0x00ffffff) == 0)) {
-        ret = 0;                    /* 0 to any power is still 0 */
-        CCs = CC4BIT;               /* set zero CC */
+        ret = 0;                        /* 0 to any power is still 0 */
+        CCs = CC4BIT;                   /* set zero CC */
 
         /* return normalized number */
-        *cc = CCs;                  /* set the cc's */
-        return ret;                 /* return result */
+        *cc = CCs;                      /* set the cc's */
+        return ret;                     /* return result */
     }
 
     /* if we have 1xxx xxxx 0000 0000 0000 0000 0000 0000 */
@@ -199,49 +199,49 @@ uint32 s_normfw(uint32 num, uint32 *cc) {
         num = 0x80000000 | (nexp & 0x7f000000) | 0x00f00000;
     }
 
-    exp = (num & 0x7f000000) >> 24; /* get exponent */
-    if (num & 0x80000000) {         /* test for neg */
-        sign = 1;                   /* we are neq */
-        num = NEGATE32(num);        /* two's complement */
-        exp ^= 0x7f;                /* complement exponent */
+    exp = (num & 0x7f000000) >> 24;     /* get exponent */
+    if (num & 0x80000000) {             /* test for neg */
+        sign = 1;                       /* we are neq */
+        num = NEGATE32(num);            /* two's complement */
+        exp ^= 0x7f;                    /* complement exponent */
     }
-    val = num & 0x00ffffff;         /* get mantissa */
+    val = num & 0x00ffffff;             /* get mantissa */
 
     /* now make sure number is normalized */
     while ((val != 0) && ((val & 0x00f00000) == 0)) {
-        val <<= 4;                  /* move up a nibble */
-        exp--;                      /* and decrease exponent */
+        val <<= 4;                      /* move up a nibble */
+        exp--;                          /* and decrease exponent */
     }
 
-    if (exp < 0) {                  /* check for underflow */
-        CCs = CC1BIT;               /* we have underflow */
-        if (sign & 1)               /* we are neq */
-            CCs |= CC3BIT;          /* set neg CC */
+    if (exp < 0) {                      /* check for underflow */
+        CCs = CC1BIT;                   /* we have underflow */
+        if (sign & 1)                   /* we are neq */
+            CCs |= CC3BIT;              /* set neg CC */
         else
-            CCs |= CC2BIT;          /* set pos CC */
-        ret = 0;                    /* number too small, make 0 */
-        exp = 0;                    /* exponent too */
+            CCs |= CC2BIT;              /* set pos CC */
+        ret = 0;                        /* number too small, make 0 */
+        exp = 0;                        /* exponent too */
 
         /* return normalized number */
-        *cc = CCs;                  /* set the cc's */
-        return ret;                 /* return result */
+        *cc = CCs;                      /* set the cc's */
+        return ret;                     /* return result */
     }
 
     /* rebuild normalized number */
     val = ((val & 0x00ffffff) | ((exp & 0x7f) << 24));
-    if (sign & 1)                   /* we are neq */
-        val = NEGATE32(val);        /* two's complement */
+    if (sign & 1)                       /* we are neq */
+        val = NEGATE32(val);            /* two's complement */
     if (val == 0)
-        CCs = CC4BIT;               /* show zero */
-    else if (val & 0x80000000)      /* neqative? */
-        CCs = CC3BIT;               /* show negative */
+        CCs = CC4BIT;                   /* show zero */
+    else if (val & 0x80000000)          /* neqative? */
+        CCs = CC3BIT;                   /* show negative */
     else
-        CCs = CC2BIT;               /* show positive */
-    ret = val;                      /* return normalized number */
+        CCs = CC2BIT;                   /* show positive */
+    ret = val;                          /* return normalized number */
 
     /* return normalized number */
-    *cc = CCs;                      /* set the cc's */
-    return ret;                     /* return result */
+    *cc = CCs;                          /* set the cc's */
+    return ret;                         /* return result */
 }
 
 #ifdef FOR_DEBUG
@@ -278,7 +278,7 @@ double dfpval(t_uint64 wd64)
         dbl *= -1.0;                    /* if negative, return negative num */
     return dbl;                         /* return value */
 }
-#endif
+#endif /* FOR_DEBUG */
 
 /* normalize the memory value when adding number to zero */
 t_uint64 s_normfd(t_uint64 num, uint32 *cc) {
@@ -601,7 +601,8 @@ t_uint64 s_fltd(t_uint64 intv, uint32 *cc) {
         /* gt 0, fall through */
     }
 
-    while ((val) && ((val & 0xf000000000000000ll) == 0)) {    /* see if normalized */
+    /* see if normalized */
+    while ((val) && ((val & 0xf000000000000000ll) == 0)) {
         val <<= 4;                      /* zero, shift in next nibble */
         exp--;                          /* decr exp value */
     }
@@ -641,7 +642,7 @@ t_uint64 s_fltd(t_uint64 intv, uint32 *cc) {
 
     /* return temp for destination regs */
     *cc = CC;                           /* return CC's */
-    return ret;                        /* return result */
+    return ret;                         /* return result */
 }
 
 #define CMASK   0x10000000              /* carry mask */
@@ -1095,7 +1096,6 @@ setcc:
     return temp;                        /* return result */
 }
 
-//#define DEXMASK 0x7f00000000000000LL    /* double exponent mask */
 #define DMMASK  0x00ffffffffffffffLL    /* double mantissa mask */
 #define DCMASK  0x1000000000000000LL    /* double carry mask */
 #define DIBMASK 0x0fffffffffffffffLL    /* double fp nibble mask */
@@ -1502,7 +1502,6 @@ t_uint64 s_dvfd(t_uint64 reg, t_uint64 mem, uint32 *cc) {
 
     mem ^= DIBMASK;                     /* change sign of mem val to do add */
     mem++;                              /* comp & incr */
-
 
     res = 0;                            /* zero result for multiply */
     /* do divide by using shift & add (subt) */

--- a/SEL32/sel32_hsdp.c
+++ b/SEL32/sel32_hsdp.c
@@ -382,7 +382,7 @@ Byte 1 bits 7-15
 
 /* this attribute information is provided by the INCH command */
 /* for each device and is saved.  It is reconstructed from */
-/* the disk_t structure data for the assigned disk */
+/* the hsdp_t structure data for the assigned disk */
 /*
 bits 0-7 - Flags
         bits 0&1 - 00=Reserved, 01=MHD, 10=FHD, 11=MHD with FHD option
@@ -1824,8 +1824,8 @@ iha_error:
         /* see if we need to incr to next track for alt sec support */
         if (uptr->LSC != SPT(type)) {
             sim_debug(DEBUG_CMD, dptr,
-                "hsdp_srv LSC0 B4 test/incr cyl %04x trk %02x sec %02x\n",
-                (tstar>>16)&0xffff, (tstar>>8)&0xff, tstar&0xff);
+                "hsdp_srv LSC0 %02x B4 test/incr cyl %04x trk %02x sec %02x\n",
+                uptr->LSC, (tstar>>16)&0xffff, (tstar>>8)&0xff, tstar&0xff);
             if ((int)(tstar&0xff) >= (int)(SPT(type)-1)) {
                 tstar &= 0xffffff00;            /* clear sector number */
                 tstar += 0x00000100;            /* bump head # */
@@ -1835,8 +1835,8 @@ iha_error:
                 }
             }
             sim_debug(DEBUG_CMD, dptr,
-                "hsdp_srv LSC0 AF test/incr cyl %04x trk %02x sec %02x\n",
-                (tstar>>16)&0xffff, (tstar>>8)&0xff, tstar&0xff);
+                "hsdp_srv LSC0 %02x AF test/incr cyl %04x trk %02x sec %02x\n",
+                uptr->LSC, (tstar>>16)&0xffff, (tstar>>8)&0xff, tstar&0xff);
 //#define DO_DYNAMIC_DEBUG
 #ifdef DO_DYNAMIC_DEBUG
 //            cpu_dev.dctrl |= DEBUG_INST|DEBUG_TRAP|DEBUG_CMD|DEBUG_DETAIL;   /* start instruction trace */
@@ -1854,8 +1854,8 @@ iha_error:
             buf[3] >= uptr->LSC) {
 
             sim_debug(DEBUG_CMD, dptr,
-                "hsdp_srv seek ERROR cyl %04x trk %02x sec %02x unit=%02x\n",
-                cyl, trk, buf[3], unit);
+                "hsdp_srv seek ERROR LSC %02x cyl %04x trk %02x sec %02x unit=%02x\n",
+                uptr->LSC, cyl, trk, buf[3], unit);
 
             uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
             uptr->SNS |= SNS_DADE;              /* set error status */
@@ -2166,8 +2166,8 @@ iha_error:
             /* see if we need to incr to next track for alt sec support */
             if (uptr->LSC != SPT(type)) {
                 sim_debug(DEBUG_CMD, dptr,
-                    "hsdp_srv LSC B4 test/incr cyl %04x trk %02x sec %02x\n",
-                    (uptr->CHS>>16)&0xffff, (uptr->CHS>>8)&0xff, uptr->CHS&0xff);
+                    "hsdp_srv LSC %02x B4 test/incr cyl %04x trk %02x sec %02x\n",
+                    uptr->LSC, (uptr->CHS>>16)&0xffff, (uptr->CHS>>8)&0xff, uptr->CHS&0xff);
                 if ((uptr->CHS&0xff) >= (SPT(type)-1)) {
                     uptr->CHS &= 0xffffff00;    /* clear sector number */
                     uptr->CHS += 0x00000100;    /* bump head # */
@@ -2177,8 +2177,8 @@ iha_error:
                     }
                 }
                 sim_debug(DEBUG_CMD, dptr,
-                    "hsdp_srv LSC AF test/incr cyl %04x trk %02x sec %02x\n",
-                    (uptr->CHS>>16)&0xffff, (uptr->CHS>>8)&0xff, uptr->CHS&0xff);
+                    "hsdp_srv LSC %02x AF test/incr cyl %04x trk %02x sec %02x\n",
+                    uptr->LSC, (uptr->CHS>>16)&0xffff, (uptr->CHS>>8)&0xff, uptr->CHS&0xff);
             }
 
             /* get sector offset */
@@ -2404,8 +2404,8 @@ iha_error:
             /* see if we need to incr to next track for alt sec support */
             if (uptr->LSC != SPT(type)) {
                 sim_debug(DEBUG_CMD, dptr,
-                    "hsdp_srv LSC2 B4 test/incr cyl %04x trk %02x sec %02x\n",
-                    (uptr->CHS>>16)&0xffff, (uptr->CHS>>8)&0xff, uptr->CHS&0xff);
+                    "hsdp_srv LSC2 %02x B4 test/incr cyl %04x trk %02x sec %02x\n",
+                    uptr->LSC, (uptr->CHS>>16)&0xffff, (uptr->CHS>>8)&0xff, uptr->CHS&0xff);
                 if ((uptr->CHS&0xff) >= (SPT(type)-1)) {
                     uptr->CHS &= 0xffffff00;    /* clear sector number */
                     uptr->CHS += 0x00000100;    /* bump track # */
@@ -2415,8 +2415,8 @@ iha_error:
                     }
                 }
                 sim_debug(DEBUG_CMD, dptr,
-                    "hsdp_srv LSC2 AF test/incr cyl %04x trk %02x sec %02x\n",
-                    (uptr->CHS>>16)&0xffff, (uptr->CHS>>8)&0xff, uptr->CHS&0xff);
+                    "hsdp_srv LSC2 %02x AF test/incr cyl %04x trk %02x sec %02x\n",
+                    uptr->LSC, (uptr->CHS>>16)&0xffff, (uptr->CHS>>8)&0xff, uptr->CHS&0xff);
             }
 
             /* get sector offset */
@@ -2459,7 +2459,7 @@ iha_error:
     case DSK_RSL:                               /* RSL 0x32 */
         /* Read sector label zero to get disk geometry */
         /* write 30 bytes, b0-b1=cyl, b1=trk, b2=sec */
-        /* zero the Track Label Buffer */
+        /* zero the Sector Label Buffer */
         for (i = 0; i < 30; i++)
             buf[i] = 0;
 
@@ -2468,7 +2468,7 @@ iha_error:
 
         sim_debug(DEBUG_CMD, dptr, "before RSL Sector %x len %x\n", uptr->CHS, len);
 
-        /* read a 30 byte track label for each sector on track */
+        /* read a 30 byte sector label for each sector on track */
         /* for 16 sectors per track, that is 480 bytes */
         /* for 20 sectors per track, that is 600 bytes */
         for (j=0; j<SPT(type); j++) {
@@ -2823,8 +2823,8 @@ iha_error:
             uptr->LSC = buf[25];                /* save logical sector count from label */
         /* command done */
         uptr->CMD &= LMASK;                     /* remove old status bits & cmd */
-        sim_debug(DEBUG_CMD, dptr, "hsdp_srv cmd RTL done chsa %04x count %04x completed\n",
-            chsa, chp->ccw_count);
+        sim_debug(DEBUG_CMD, dptr, "hsdp_srv cmd RTL done LSC %02x chsa %04x count %04x completed\n",
+            uptr->LSC, chsa, chp->ccw_count);
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* return OK */
         break;
 
@@ -2940,16 +2940,35 @@ iha_error:
 void hsdp_ini(UNIT *uptr, t_bool f)
 {
     DEVICE  *dptr = get_dev(uptr);
+    int     unit = (uptr - dptr->units);        /* get the UNIT number */
     int     i = GET_TYPE(uptr->flags);
+    int     cn;
 
     /* start out at sector 0 */
     uptr->CHS = 0;                              /* set CHS to cyl/hd/sec = 0 */
     uptr->CMD &= LMASK;                         /* clear out the flags but leave ch/sa */
     /* total sectors on disk */
     uptr->capac = CAP(i);                       /* size in sectors */
+    sim_cancel(uptr);                           /* stop any timer */
+    /* reset track label cache */
+    for (cn=0; cn<TRK_CACHE; cn++) {
+        tkl_label[unit].tkl[cn].track = 0;
+        tkl_label[unit].tkl[cn].age = 0;
+    }
 
-    sim_debug(DEBUG_EXP, &dda_dev, "DPA init device %s on unit DPA%.1x cap %x %d\n",
+    sim_debug(DEBUG_EXP, dptr, "DPA init device %s on unit DPA%.1x cap %x %d\n",
         dptr->name, GET_UADDR(uptr->CMD), uptr->capac, uptr->capac);
+}
+
+/* handle rschnlio cmds for hsdp */
+uint16  hsdp_rschnlio(UNIT *uptr) {
+    DEVICE  *dptr = get_dev(uptr);
+    uint16  chsa = GET_UADDR(uptr->CMD);
+    int     cmd = uptr->CMD & DSK_CMDMSK;
+
+    sim_debug(DEBUG_EXP, dptr, "hsdp_rschnl chsa %04x cmd = %02x\n", chsa, cmd);
+    hsdp_ini(uptr, 0);                          /* reset the unit */
+    return SCPE_OK;
 }
 
 t_stat hsdp_reset(DEVICE *dptr)
@@ -3005,9 +3024,16 @@ int hsdp_label(UNIT *uptr, int use_strep) {
 
                 /* get sector address of utx flaw map sec 1 pointer */
                 /* use this address for sec 1 label pointer */
+#define NOT_NEEDED_0128
+#ifndef NOT_NEEDED_0128
+    int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-4) * SPT(type);
+                /* make logical */
+    int32       logua = uaddr*(SPT(type)-1)/(SPT(type));
+#else
     int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
                 /* make logical */
     int32       logua = uaddr*(SPT(type)-1)/(SPT(type));
+#endif
 
     /* write 30 byte track labels for all tracks on disk */
     /* tot_tracks entries will be created starting at end of disk */
@@ -3059,9 +3085,11 @@ int hsdp_label(UNIT *uptr, int use_strep) {
             "hsdp_label WTL star %02x %02x %02x %02x\n",
             label[0], label[1], label[2], label[3]);
 
-        /* daddr has dmap value for track zero label */
+        /* prepare track 0 label on disk */
         if (CHS == 0) {                         /* only write dmap address in trk 0 */
-#if 1
+            /* daddr has dmap value for track zero label */
+            /* this logical or physical address must be there, */
+            /* otherwise prep crashes with bad diag flaw map pointer */
             if (use_strep) {
                 /* output logical diag defect map address of disk */
                 label[12] = (logda >> 24) & 0xff;   /* ldeallp DMAP pointer */
@@ -3071,9 +3099,7 @@ int hsdp_label(UNIT *uptr, int use_strep) {
                 printf("hsdp_label WTL logda@daddr %08x -> %08x\r\n", logda, 0);
                 sim_debug(DEBUG_CMD, dptr,
                     "hsdp_label WTL logda@daddr %08x -> %08x\n", logda, 0);
-            } else
-#endif
-            {
+            } else {
                 /* output physical diag defect map address of disk */
                 label[12] = (daddr >> 24) & 0xff;   /* ldeallp DMAP pointer */
                 label[13] = (daddr >> 16) & 0xff;
@@ -3083,10 +3109,28 @@ int hsdp_label(UNIT *uptr, int use_strep) {
                 sim_debug(DEBUG_CMD, dptr,
                     "hsdp_label WTL daddr@daddr %08x -> %08x\n", vaddr, 0);
             }
+            /* if this is removed, UTX is unable to create newfs */
+            /* get preposterous size 0 error message */
+            /* address must be logical/physical */
+            /* uaddr has umap value for track zero label */
+            if (use_strep) {
+                /* output logical umap address */
+                label[16] = (logua >> 24) & 0xff;   /* lumapp UMAP lofical pointer */
+                label[17] = (logua >> 16) & 0xff;
+                label[18] = (logua >> 8) & 0xff;
+                label[19] = (logua) & 0xff;
+            } else {
+                /* output physical umap address */
+                label[16] = (uaddr >> 24) & 0xff;   /* lumapp UMAP physical pointer */
+                label[17] = (uaddr >> 16) & 0xff;
+                label[18] = (uaddr >> 8) & 0xff;
+                label[19] = (uaddr) & 0xff;
+            }
         }
 
         /* write vaddr to track label for dmap */
         if ((i*SPT(type)) == daddr) {               /* get track address in sectors */
+//no_logical #if 1
 #if 0
             if (use_strep) {
                 /* output logical vendor defect map address of disk */
@@ -3111,59 +3155,19 @@ int hsdp_label(UNIT *uptr, int use_strep) {
             }
         }
 
-        /* if this is removed, UTX is unable to create newfs */
-        /* get preposterous size 0 error message */
-#ifndef XXXX_121720
-        /* maybe not needed, but left anyway */
-        /* uaddr has umap value for track zero label */
-        if (CHS == 0) {                         /* only write dmap address in trk 0 */
-#if 1
-            if (use_strep) {
-                /* output logical umap address */
-                label[16] = (logua >> 24) & 0xff;   /* lumapp UMAP physical pointer */
-                label[17] = (logua >> 16) & 0xff;
-                label[18] = (logua >> 8) & 0xff;
-                label[19] = (logua) & 0xff;
-            } else
-#endif
-            {
-                /* output physical umap address */
-                label[16] = (uaddr >> 24) & 0xff;   /* lumapp UMAP physical pointer */
-                label[17] = (uaddr >> 16) & 0xff;
-                label[18] = (uaddr >> 8) & 0xff;
-                label[19] = (uaddr) & 0xff;
-            }
-        }
-#endif
-
         /* the tech doc shows the cyl/trk/sec data is in the first 4 bytes */
         /* of the track label, BUT it is really in the configuration data */
         /* area too.  Byte 27 is sectors/track and byte 28 is number of heads. */
         /* Byte 26 is mode. Byte 25 is copy of byte 27. */
-#if 1
-        if ((use_strep) && (daddr == (i*SPT(type)) || (i == 0))) {
-//      if ((use_strep) && (daddr == (i*SPT(type)) )) {
+        label[25] = SPT(type) & 0xff;               /* save sectors per track */
+//no_logical if ((use_strep) && (daddr == (i*SPT(type)) || (i == 0))) {
+        if ((use_strep) && (i == 0)) {
             label[25] = (SPT(type)-1) & 0xff;
-            if (CHS == 0)                           /* see if trk 0 label read */
-                uptr->LSC = label[25];              /* save logical sector count from label */
-        } else
-#endif
-        {
-            if (CHS == 0)                           /* see if trk 0 label read */
-                uptr->LSC = label[25];              /* save logical sector count from label */
-            label[25] = SPT(type) & 0xff;
         }
-        label[26] = hsdp_type[type].type & 0xfd;    /* zero bits 6 & set 7 in type byte */
-//      buf[26] = hsdp_type[type].type | 1;     /* mode data is 0x41 */
-#if 1
-        if ((use_strep) && (daddr == (i*SPT(type)) || (i == 0))) {
-//      if ((use_strep) && (daddr == (i*SPT(type)) )) {
-            label[27] = (SPT(type)-1) & 0xff;
-        } else
-#endif
-        {
-            label[27] = SPT(type) & 0xff;
-        }
+        uptr->LSC = label[25];                      /* save logical/physical sector count from label */
+        label[26] = hsdp_type[type].type & 0xfd;    /* zero bits 6 in type byte */
+//      label[26] = hsdp_type[type].type | 1;       /* mode data is 0x41 */
+        label[27] = label[25];                      /* same as label[25] */
         label[28] = HDS(type) & 0xff;
 
         if ((sim_fwrite((char *)&label, sizeof(uint8), 30, uptr->fileref)) != 30) {
@@ -3219,20 +3223,27 @@ int hsdp_label(UNIT *uptr, int use_strep) {
         label[13] = 0;
         label[14] = 0;
         label[15] = 0;
+        label[16] = 0;
+        label[17] = 0;
+        label[18] = 0;
+        label[19] = 0;
 
         /* if this is written, UTX will not be able to do a newfs */
         /* gets preposterous size 0 error */
-#ifndef XXXX_121720
+#ifdef XXXX_121720
         /* maybe not needed, but left anyway */
         /* uaddr has umap value for sector one label */
         if (CHS == 1) {                         /* write umap address in sec 1 */
 #if 1
             if (use_strep) {
                 /* output logical umap address */
-                label[12] = (logua >> 24) & 0xff;   /* lumapp UMAP physical pointer */
+                label[12] = (logua >> 24) & 0xff;   /* lumapp UMAP logical pointer */
                 label[13] = (logua >> 16) & 0xff;
                 label[14] = (logua >> 8) & 0xff;
                 label[15] = (logua) & 0xff;
+                sim_debug(DEBUG_CMD, dptr,
+                    "hsdp_format WSL uaddr star %02x %02x %02x %02x\n",
+                    label[12], label[13], label[14], label[15]);
             } else
 #endif
             {
@@ -3241,6 +3252,9 @@ int hsdp_label(UNIT *uptr, int use_strep) {
                 label[13] = (uaddr >> 16) & 0xff;
                 label[14] = (uaddr >> 8) & 0xff;
                 label[15] = (uaddr) & 0xff;
+                sim_debug(DEBUG_CMD, dptr,
+                    "hsdp_format WSL uaddr star %02x %02x %02x %02x\n",
+                    label[12], label[13], label[14], label[15]);
             }
         }
 #endif
@@ -3291,6 +3305,13 @@ int hsdp_format(UNIT *uptr) {
                 /* make logical */
     int32       logla = laddr*(SPT(type)-1)/(SPT(type));
 
+#ifndef NOT_NEEDED_0128
+                /* last track address of disk (cyl * hds * spt) - spt */
+    uint32      ltaddr = CAP(type)-SPT(type);       /* last track of disk */
+                /* make logical */
+    int32       loglta = ltaddr*(SPT(type)-1)/(SPT(type));
+#endif
+
                 /* get sector address of vendor defect table VDT */
                 /* put data = 0xf0000004 0xf4000000 */
     int32       vaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-1) * SPT(type);
@@ -3300,14 +3321,24 @@ int hsdp_format(UNIT *uptr) {
                 /* get sector address of utx diag map (DMAP) track 0 pointer */
                 /* put data = 0xf0000000 + (cyl-1), 0x8a000000 + daddr, */
                 /* 0x9a000000 + (cyl-1), 0xf4000000 */
-
 //  int32       daddr = vaddr - SPT(type);
     int32       daddr = (CYL(type)-4) * SPC(type) + (HDS(type)-2) * SPT(type);
                 /* make logical */
     int32       logda = daddr*(SPT(type)-1)/(SPT(type));
 
-//  int32       uaddr = daddr - SPT(type);
+#ifndef NOT_NEEDED_0128
+                /* get sector address of utx flaw data (1 track long) */
+                /* set trace data to zero */
+    int32       faddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
+                /* make logical */
+    int32       logfa = faddr*(SPT(type)-1)/(SPT(type));
+#endif
+
+#ifndef NOT_NEEDED_0128
+    int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-4) * SPT(type);
+#else
     int32       uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
+#endif
 
                 /* NULL vendor flaw map */
     uint32      vmap[2] = {0xf0000004, 0xf4000000};
@@ -3315,9 +3346,21 @@ int hsdp_format(UNIT *uptr) {
                 /* NULL diag flaw map */
     uint32      pdmap[4] = {0xf0000000 | (cap-1), 0x8a000000 | daddr,
                     0x9a000000 | (cap-1), 0xf4000000};
+
     uint32      dmap[4] = {0xf0000000 | (((cap-1)*(SPT(type)-1))/(SPT(type))),
                     0x8a000000 | logda,
                     0x9a000000 | (((cap-1)*(SPT(type)-1))/(SPT(type))), 0xf4000000};
+#ifndef NOT_NEEDED_0128
+                /* utx flaw map */
+    uint32      pfmap[4] = {0xf0000000 | (cap-1), 0x8a000000 | daddr,
+                    0x9a000000 | ltaddr, 0xf4000000};
+
+                /* utx flaw map */
+    uint32      fmap[4] = {0xf0000000 | (((cap-1)*(SPT(type)-1))/(SPT(type))),
+                    0x8a000000 | logda,
+                    0x9a000000 | loglta, 0xf4000000};
+#endif
+
 
     /* see if user wants to initialize the disk */
     if (!get_yn("Initialize disk? [Y] ", TRUE)) {
@@ -3330,12 +3373,14 @@ int hsdp_format(UNIT *uptr) {
     /* get physical sector address of media defect table */
     /* VDT  286965 (819/9/0) 0x460f5 for 8887 - 823/10/35 */ 
     /* MDT  286930 (819/8/0) 0x460d2 for 8887 - 823/10/35 Trk 0 ptr */
-    /* UMAP 286895 (819/7/0) 0x460af for 8887 - 823/10/35 */ 
+    /* FMAP 286895 (819/7/0) 0x460af for 8887 - 823/10/35 */ 
+    /* UMAP 286860 (819/6/0) 0x4608c for 8887 - 823/10/35 */ 
 
     /* get logical sector address of media defect table */
     /* VDT  278766 (819/9/0) 0x440ee for 8887 - 823/10/34 */ 
     /* MDT  278732 (819/8/0) 0x440cc for 8887 - 823/10/34 */ 
-    /* UMAP 278698 (819/7/0) 0x440aa for 8887 - 823/10/34 Sec 0 ptr */ 
+    /* FMAP 278698 (819/7/0) 0x440aa for 8887 - 823/10/34 Sec 0 ptr */ 
+    /* UMAP 278664 (819/6/0) 0x44088 for 8887 - 823/10/34 Sec 0 ptr */ 
 
     /* seek to sector 0 */
     if ((sim_fseek(uptr->fileref, 0, SEEK_SET)) != 0) { /* seek home */
@@ -3382,6 +3427,16 @@ int hsdp_format(UNIT *uptr) {
         pdmap[i] = (((pdmap[i] & 0xff) << 24) | ((pdmap[i] & 0xff00) << 8) |
             ((pdmap[i] & 0xff0000) >> 8) | ((pdmap[i] >> 24) & 0xff));
     }
+#ifndef NOT_NEEDED_0128
+    for (i=0; i<4; i++) {
+        fmap[i] = (((fmap[i] & 0xff) << 24) | ((fmap[i] & 0xff00) << 8) |
+            ((fmap[i] & 0xff0000) >> 8) | ((fmap[i] >> 24) & 0xff));
+    }
+    for (i=0; i<4; i++) {
+        pfmap[i] = (((pfmap[i] & 0xff) << 24) | ((pfmap[i] & 0xff00) << 8) |
+            ((pfmap[i] & 0xff0000) >> 8) | ((pfmap[i] >> 24) & 0xff));
+    }
+#endif
 
     /* now seek to end of disk and write the dmap data */
     /* setup dmap pointed to by track label 0 wd[3] = (cyl-4) * spt + (spt - 1) */
@@ -3428,7 +3483,8 @@ int hsdp_format(UNIT *uptr) {
             daddr, daddr*ssize);
             return 1;
         }
-    } else {
+    } else
+    {
         if ((sim_fwrite((char *)&pdmap, sizeof(uint32), 4, uptr->fileref)) != 4) {
             sim_debug(DEBUG_CMD, dptr,
             "Error writing DMAP to sect %06x offset %06x\n",
@@ -3436,15 +3492,44 @@ int hsdp_format(UNIT *uptr) {
             return 1;
         }
     }
+#ifndef NOT_NEEDED_0128
+    /* write dummy UTX DMAP to faddr */
+    if ((sim_fseek(uptr->fileref, faddr*ssize, SEEK_SET)) != 0) { /* seek DMAP */
+        sim_debug(DEBUG_CMD, dptr,
+        "Error on media FMAP seek to sect %06x offset %06x\n",
+        faddr, faddr*ssize);
+        return 1;
+    }
+    if (use_st_format) {
+        if ((sim_fwrite((char *)&fmap, sizeof(uint32), 4, uptr->fileref)) != 4) {
+            sim_debug(DEBUG_CMD, dptr,
+            "Error writing UTX LFMAP to sect %06x offset %06x\n",
+            faddr, faddr*ssize);
+            return 1;
+        }
+    } else
+    {
+        if ((sim_fwrite((char *)&pfmap, sizeof(uint32), 4, uptr->fileref)) != 4) {
+            sim_debug(DEBUG_CMD, dptr,
+            "Error writing UTX FMAP to sect %06x offset %06x\n",
+            faddr, faddr*ssize);
+            return 1;
+        }
+    }
+#endif
 
     printf("Disk %s has %x (%d) cyl, %x (%d) hds, %x (%d) sec\r\n",
         hsdp_type[type].name, CYL(type), CYL(type), HDS(type), HDS(type),
         SPT(type), SPT(type));
     printf("writing to vmap sec %x (%d) bytes %x (%d)\r\n",
         vaddr, vaddr, (vaddr)*ssize, (vaddr)*ssize);
-    printf("writing dmap to %x %d %x %d dmap to %x %d %x %d\r\n",
+    printf("writing to dmap %x (%d) %x (%d) dmap to %x (%d) %x (%d)\r\n",
        cap-1, cap-1, (cap-1)*ssize, (cap-1)*ssize,
        daddr, daddr, daddr*ssize, daddr*ssize);
+#ifndef NOT_NEEDED_0128
+    printf("writing to fmap sec %x (%d) bytes %x (%d)\r\n",
+        faddr, faddr, (faddr)*ssize, (faddr)*ssize);
+#endif
     printf("writing to umap sec %x (%d) bytes %x (%d)\r\n",
         uaddr, uaddr, (uaddr)*ssize, (uaddr)*ssize);
 
@@ -3472,13 +3557,15 @@ t_stat hsdp_attach(UNIT *uptr, CONST char *file)
     uint32          info, good;
     uint8           buff[1024];
     int             i, j;
+    int             use_st_format = 0;
 
                     /* last sector address of disk (cyl * hds * spt) - 1 */
-    uint32          laddr = CAP(type) - 1;      /* last sector of disk */
+    int32           laddr = CAP(type) - 1;      /* last sector of disk */
                     /* get sector address of utx diag map (DMAP) track 0 pointer */
                     /* put data = 0xf0000000 + (cyl-1), 0x8a000000 + daddr, */
                     /* 0x9a000000 + (cyl-1), 0xf4000000 */
     int32           daddr = (CYL(type)-4) * SPC(type) + (HDS(type)-2) * SPT(type);
+    int32           umapaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
                     /* defect map */
     uint32          dmap[4] = {0xf0000000 | (CAP(type)-1), 0x8a000000 | daddr,
                         0x9a000000 | (CAP(type)-1), 0xf4000000};
@@ -3510,7 +3597,7 @@ t_stat hsdp_attach(UNIT *uptr, CONST char *file)
 
     printf("Disk %s cyl %d hds %d sec %d ssiz %d capacity %d\r\n",
         hsdp_type[type].name, hsdp_type[type].cyl, hsdp_type[type].nhds,
-        hsdp_type[type].spt, ssize, uptr->capac); /* disk capacity */
+        hsdp_type[type].spt, ssize, uptr->capac); /* hsdp capacity */
 
     /* seek to end of disk */
     if ((sim_fseek(uptr->fileref, 0, SEEK_END)) != 0) {
@@ -3625,7 +3712,7 @@ ldone:
     i = SCPE_OK;
     /* see if disk has labels already, seek to sector past end of disk  */
     if ((r = sim_fread(buff, sizeof(uint8), 30, uptr->fileref) != 30)) {
-        int use_st_format = 1;
+        use_st_format = 1;
         /* the disk does not have labels, add them on */
         /* create labels for disk */
         sim_debug(DEBUG_CMD, dptr,
@@ -3638,14 +3725,50 @@ ldone:
         }
         /* create labels for disk */
         i = hsdp_label(uptr, use_st_format);    /* label disk */
-
-//0111  i = hsdp_label(uptr);                   /* label disk */
-//      i = hsdp_format(uptr);                  /* label disk */
         if (i != 0) {
             detach_unit(uptr);                  /* detach if error */
             return SCPE_FMT;                    /* error */
         }
     }
+#ifdef OLDWAY
+    else {
+#ifndef NOT_NEEDED_0128
+        int32   uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-4) * SPT(type);
+                /* make logical */
+        int32   logua = uaddr*(SPT(type)-1)/(SPT(type));
+#else
+        int32   uaddr = (CYL(type)-4) * SPC(type) + (HDS(type)-3) * SPT(type);
+                /* make logical */
+        int32   logua = uaddr*(SPT(type)-1)/(SPT(type));
+#endif
+        if (buff[25] == SPT(type)) {
+            /* uaddr has physical umap value for track zero label */
+            /* output physical umap address */
+            buff[16] = (uaddr >> 24) & 0xff;        /* lumapp DMAP pointer */
+            buff[17] = (uaddr >> 16) & 0xff;
+            buff[18] = (uaddr >> 8) & 0xff;
+            buff[19] = (uaddr) & 0xff;
+        } else {
+            /* logua has logical umap value for track zero label */
+            /* output logical umap address */
+            buff[16] = (logua >> 24) & 0xff;        /* lumapp DMAP pointer */
+            buff[17] = (logua >> 16) & 0xff;
+            buff[18] = (logua >> 8) & 0xff;
+            buff[19] = (logua) & 0xff;
+        }
+        if ((sim_fseek(uptr->fileref, CAP(type)*ssize, SEEK_SET)) != 0) { /* seek end */
+            detach_unit(uptr);                      /* detach if error */
+            return SCPE_FMT;                        /* error */
+        }
+        /* output updated umap address to track 0 for UTX21a */
+        if ((sim_fwrite(buff, sizeof(uint8), 30, uptr->fileref)) != 30) {
+            sim_debug(DEBUG_CMD, dptr,
+                "Error writing back track 0 label to sect %06x offset %06x\n",
+                CAP(type), CAP(type)*ssize);
+            return SCPE_FMT;                        /* error */
+        }
+    }
+#endif
 
     /* see if disk has labels already, seek to sector past end of disk  */
     if ((sim_fseek(uptr->fileref, CAP(type)*ssize, SEEK_SET)) != 0) { /* seek end */
@@ -3659,6 +3782,42 @@ ldone:
     }
     uptr->LSC = buff[25];                       /* save logical sector count from label */
 
+    /* UTX map (NUMP) does not insert an F4 after the replacement tracks */
+    /* so do it after the tracks are defined to stop halt on bootup */
+    /* utxmap + 32 + 88 + (3*spare) + 1 */
+    /* spare count is at utxmap + 8w (32) */
+    /* get umap sector address from umapaddr */
+    info = (buff[16]<<24) | (buff[17]<<16) | (buff[18]<<8) | buff[19];
+    daddr = umapaddr * ssize;                   /* byte offset in file */
+//  printf("info %8x daddr %8x\r\n", info, daddr);
+    if ((sim_fseek(uptr->fileref, umapaddr*ssize, SEEK_SET)) != 0) { /* seek umap */
+        detach_unit(uptr);                      /* detach if error */
+        return SCPE_FMT;                        /* error */
+    }
+    /* read umap into buff */
+    if ((r = sim_fread(buff, sizeof(uint8), ssize, uptr->fileref) != ssize)) {
+        detach_unit(uptr);                      /* detach if error */
+        return SCPE_FMT;                        /* error */
+    }
+    info = (buff[0]<<24) | (buff[1]<<16) | (buff[2]<<8) | buff[3];
+    good = (0x4e<<24) | (0x55<<16) | (0x4d<<8) | 0x50;  /* NUMP */
+//  printf("info %8x good %8x cnt %x\r\n", info, good, buff[35]);
+    if (info == good) {
+        /* we have a UTX umap, so fixup the data */
+        i = (16*8) + (buff[35]*3*4) - 1;        /* byte offset to where to put 0xf4 */
+//      printf("Fixing umap i %x info %8x good %8x buff[%x] %02x\r\n", i, info, good, i, buff[i]);
+        buff[i] = 0xf4;                         /* set stop for UTX search */
+        if ((sim_fseek(uptr->fileref, umapaddr*ssize, SEEK_SET)) != 0) { /* seek umap */
+            detach_unit(uptr);                  /* detach if error */
+            return SCPE_FMT;                    /* error */
+        }
+        if ((r = sim_fwrite(buff, sizeof(uint8), ssize, uptr->fileref) != ssize)) {
+            detach_unit(uptr);                  /* detach if error */
+            return SCPE_FMT;                    /* error */
+        }
+//      printf("Fix Done i %x info %8x good %8x buff[%x] %02x\r\n", i, info, good, i, buff[i]);
+    }
+
     if ((sim_fseek(uptr->fileref, 0, SEEK_SET)) != 0) { /* seek home */
         detach_unit(uptr);                      /* detach if error */
         return SCPE_FMT;                        /* error */
@@ -3667,13 +3826,25 @@ ldone:
     /* start out at sector 0 */
     uptr->CHS = 0;                              /* set CHS to cyl/hd/sec = 0 */
 
+    if (uptr->LSC == SPT(type)) {
+        /* physical sectoring */
     sim_debug(DEBUG_CMD, dptr,
-        "HSDP Attach %s cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\n",
-        hsdp_type[type].name, CYL(type), HDS(type), SPT(type), SPC(type),  
+        "HSDP PHY %02x Attach %s cyl %d hds %d pspt %d pspc %d cap sec %d cap bytes %d\n",
+        uptr->LSC, hsdp_type[type].name, CYL(type), HDS(type), SPT(type), SPC(type),
         CAP(type), CAPB(type));
-    printf("HSDP Attach %s cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\r\n",
-        hsdp_type[type].name, CYL(type), HDS(type), SPT(type), SPC(type),  
+    printf("HSDP PHY %02x Attach %s cyl %d hds %d pspt %d pspc %d cap sec %d cap bytes %d\r\n",
+        uptr->LSC, hsdp_type[type].name, CYL(type), HDS(type), SPT(type), SPC(type),
         CAP(type), CAPB(type));
+    } else {
+        /* logical sectoring */
+    sim_debug(DEBUG_CMD, dptr,
+        "HSDP LSF %02x Attach %s cyl %d hds %d lspt %d lspc %d cap sec %d cap bytes %d\n",
+        uptr->LSC, hsdp_type[type].name, CYL(type), HDS(type), SPT(type)-1, (SPT(type)-1)*HDS(type),
+        (CYL(type)*HDS(type)*(SPT(type)-1)), (CYL(type)*HDS(type)*(SPT(type)-1))*ssize);
+    printf("HSDP LSF %02x Attach %s cyl %d hds %d lspt %d lspc %d cap sec %d cap bytes %d\r\n",
+        uptr->LSC, hsdp_type[type].name, CYL(type), HDS(type), SPT(type)-1, (SPT(type)-1)*HDS(type),
+        (CYL(type)*HDS(type)*(SPT(type)-1)), (CYL(type)*HDS(type)*(SPT(type)-1))*ssize);
+    }
 
     sim_debug(DEBUG_CMD, dptr,
         "HSDP File %s attached to %s\n",

--- a/SEL32/sel32_mt.c
+++ b/SEL32/sel32_mt.c
@@ -152,6 +152,7 @@ uint16      mt_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd) ;
 t_stat      mt_srv(UNIT *uptr);
 t_stat      mt_boot(int32 unitnum, DEVICE *dptr);
 void        mt_ini(UNIT *uptr, t_bool);
+uint16      mt_rschnlio(UNIT *uptr);
 t_stat      mt_reset(DEVICE *dptr);
 t_stat      mt_attach(UNIT *uptr, CONST char *);
 t_stat      mt_detach(UNIT *uptr);
@@ -297,7 +298,7 @@ DIB             mta_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    mt_rschnlio,    /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     NULL,           /* uint16 (*iocl_io)(CHANP *chp, int32 tic_ok)) */  /* Process IOCL */
     mt_ini,         /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     mta_unit,       /* UNIT* units */                           /* Pointer to units structure */
@@ -345,7 +346,7 @@ DIB             mtb_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    mt_rschnlio,    /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     NULL,           /* uint16 (*iocl_io)(CHANP *chp, int32 tic_ok)) */  /* Process IOCL */
     mt_ini,         /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     mtb_unit,       /* UNIT* units */                           /* Pointer to units structure */
@@ -376,14 +377,14 @@ uint16 mt_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
     int         unit = (uptr - dptr->units);
     CHANP       *chp = find_chanp_ptr(chsa);    /* find the chanp pointer */
 
-    sim_debug(DEBUG_EXP, &mta_dev, "mt_startcmd entry chan %04x cmd %02x\n", chan, cmd);
+    sim_debug(DEBUG_EXP, dptr, "mt_startcmd entry chan %04x cmd %02x\n", chan, cmd);
     if (mt_busy[GET_DEV_BUF(dptr->flags)] != 0 || (uptr->CMD & MT_CMDMSK) != 0) {
-        sim_debug(DEBUG_EXP, &mta_dev, "mt_startcmd busy chan %04x cmd %02x\n", chan, cmd);
+        sim_debug(DEBUG_EXP, dptr, "mt_startcmd busy chan %04x cmd %02x\n", chan, cmd);
         uptr->flags |= MT_BUSY;                     /* Flag we need to send CUE */
         return SNS_BSY;
     }
 
-    sim_debug(DEBUG_EXP, &mta_dev, "mt_startcmd processing unit %01x cmd %02x\n", unit, cmd);
+    sim_debug(DEBUG_EXP, dptr, "mt_startcmd processing unit %01x cmd %02x\n", unit, cmd);
 
     switch (cmd & 0xFF) {
     case 0x00:                                      /* INCH command */
@@ -413,11 +414,11 @@ uint16 mt_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
     case 0x02:                                      /* Read command */
     case 0x0C:                                      /* Read backward */
         if (cmd == 0x01)
-        sim_debug(DEBUG_EXP, &mta_dev,
+        sim_debug(DEBUG_EXP, dptr,
             "mt_startcmd WRITE chan %04x addr %06x cnt %04x\n",
             chan, chp->ccw_addr, chp->ccw_count);
         if (cmd == 0x02)
-        sim_debug(DEBUG_EXP, &mta_dev,
+        sim_debug(DEBUG_EXP, dptr,
             "mt_startcmd READ chan %04x addr %06x cnt %04x\n",
             chan, chp->ccw_addr, chp->ccw_count);
         if (cmd != 0x03)                            /* if this is a nop do not zero status */
@@ -438,13 +439,13 @@ uint16 mt_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
         CLR_BUF(uptr);                              /* buffer is empty */
         uptr->POS = 0;                              /* reset buffer position pointer */
         mt_busy[GET_DEV_BUF(dptr->flags)] = 1;      /* show we are busy */
-        sim_debug(DEBUG_EXP, &mta_dev, "mt_startcmd sense %08x return 0 chan %04x cmd %02x\n",
+        sim_debug(DEBUG_EXP, dptr, "mt_startcmd sense %08x return 0 chan %04x cmd %02x\n",
             uptr->SNS, chan, cmd);
         sim_activate(uptr, 100);                    /* Start unit off */
         return 0;
 
     default:                                        /* invalid command */
-        sim_debug(DEBUG_EXP, &mta_dev, "mt_startcmd CMDREJ return chan %04x cmd %02x\n",
+        sim_debug(DEBUG_EXP, dptr, "mt_startcmd CMDREJ return chan %04x cmd %02x\n",
             chan, cmd);
         uptr->SNS |= SNS_CMDREJ;
         /* send program check */
@@ -455,7 +456,7 @@ uint16 mt_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
     /* not reached */
     if (uptr->SNS & 0xff000000)                     /* errors? */
         return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;
-    sim_debug(DEBUG_EXP, &mta_dev,
+    sim_debug(DEBUG_EXP, dptr,
         "mt_startcmd ret CHNEND|DEVEND chan %04x unit %04x cmd %02x\n", chan, unit, cmd);
     return SNS_CHNEND|SNS_DEVEND;
 #endif
@@ -464,7 +465,7 @@ uint16 mt_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
 /* Map simH errors into machine errors */
 t_stat mt_error(UNIT *uptr, uint16 chsa, t_stat r, DEVICE *dptr)
 {
-    sim_debug(DEBUG_CMD, &mta_dev, "mt_error status %08x\n", r);
+    sim_debug(DEBUG_CMD, dptr, "mt_error status %08x\n", r);
     mt_busy[GET_DEV_BUF(dptr->flags)] &= ~1;        /* not busy anymore */
 
     switch (r) {                                    /* switch on return value */
@@ -473,40 +474,40 @@ t_stat mt_error(UNIT *uptr, uint16 chsa, t_stat r, DEVICE *dptr)
         break;
 
     case MTSE_TMK:                                  /* tape mark */
-        sim_debug(DEBUG_CMD, &mta_dev, "FILE MARK\n");
+        sim_debug(DEBUG_CMD, dptr, "FILE MARK\n");
         uptr->SNS |= SNS_FMRKDT;                    /* file mark detected */
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
         break;
 
     case MTSE_WRP:                                  /* write protected */
         uptr->SNS |= SNS_WRP;                       /* write protected */
-        sim_debug(DEBUG_CMD, &mta_dev, "WRITE PROTECT %08x\n", r); /* operator intervention */
+        sim_debug(DEBUG_CMD, dptr, "WRITE PROTECT %08x\n", r); /* operator intervention */
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);      /* we are done with command */
         break;
 
     case MTSE_UNATT:                                /* unattached */
         uptr->SNS |= SNS_INTVENT;                   /* unit intervention required */
-        sim_debug(DEBUG_CMD, &mta_dev, "ATTENTION %08x\n", r); /* operator intervention */
+        sim_debug(DEBUG_CMD, dptr, "ATTENTION %08x\n", r); /* operator intervention */
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITEXP);
         break;
 
     case MTSE_IOERR:                                /* IO error */
     case MTSE_FMT:                                  /* invalid format */
     case MTSE_RECE:                                 /* error in record */
-        sim_debug(DEBUG_CMD, &mta_dev, "ERROR %08x\n", r);
+        sim_debug(DEBUG_CMD, dptr, "ERROR %08x\n", r);
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);      /* we are done with command */
         break;
 
     case MTSE_BOT:                                  /* beginning of tape */
         uptr->SNS |= SNS_LOAD;                      /* tape at BOT */
-        sim_debug(DEBUG_CMD, &mta_dev, "BOT\n");
+        sim_debug(DEBUG_CMD, dptr, "BOT\n");
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);      /* we are done with command */
         break;
 
     case MTSE_INVRL:                                /* invalid rec lnt */
     case MTSE_EOM:                                  /* end of medium */
         uptr->SNS |= SNS_EOT;                       /* tape at EOT */
-        sim_debug(DEBUG_CMD, &mta_dev, "EOT\n");
+        sim_debug(DEBUG_CMD, dptr, "EOT\n");
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITEXP);
         break;
     }
@@ -530,7 +531,7 @@ t_stat mt_srv(UNIT *uptr)
     uint8       ch;
 //  uint8       buf[1024];
 
-    sim_debug(DEBUG_DETAIL, &mta_dev, "mt_srv unit %04x cmd %02x\n", unit, cmd);
+    sim_debug(DEBUG_DETAIL, dptr, "mt_srv unit %04x cmd %02x\n", unit, cmd);
     if ((uptr->flags & UNIT_ATT) == 0) {        /* unit attached status */
         uptr->SNS |= SNS_INTVENT;               /* unit intervention required */
         mt_busy[bufnum] &= ~1;                  /* make our buffer not busy */
@@ -592,29 +593,29 @@ t_stat mt_srv(UNIT *uptr)
         break;
 
     case 0x80:      /* other? */                    /* default to NOP */
-        sim_debug(DEBUG_CMD, &mta_dev, "mt_srv cmd 80 DIAG unit=%04x SNS %08x\n", unit, uptr->SNS);
+        sim_debug(DEBUG_CMD, dptr, "mt_srv cmd 80 DIAG unit=%04x SNS %08x\n", unit, uptr->SNS);
         ch = (uptr->SNS >> 24) & 0xff;              /* get sense byte 0 status */
-        sim_debug(DEBUG_CMD, &mta_dev, "sense unit %02x byte 0 %02x\n", unit, ch);
+        sim_debug(DEBUG_CMD, dptr, "sense unit %02x byte 0 %02x\n", unit, ch);
         chan_write_byte(chsa, &ch);                 /* write byte 0 */
         ch = (uptr->SNS >> 16) & 0xff;              /* get sense byte 1 status */
-        sim_debug(DEBUG_CMD, &mta_dev, "sense unit %02x byte 1 %02x\n", unit, ch);
+        sim_debug(DEBUG_CMD, dptr, "sense unit %02x byte 1 %02x\n", unit, ch);
         chan_write_byte(chsa, &ch);                 /* write byte 1 */
         ch = (uptr->SNS >> 8) & 0xff;               /* get sense byte 2 status */
-        sim_debug(DEBUG_CMD, &mta_dev, "sense unit %02x byte 2 %02x\n", unit, ch);
+        sim_debug(DEBUG_CMD, dptr, "sense unit %02x byte 2 %02x\n", unit, ch);
         chan_write_byte(chsa, &ch);                 /* write byte 2 */
         ch = (uptr->SNS >> 0) & 0xff;               /* get sense byte 3 status */
-        sim_debug(DEBUG_CMD, &mta_dev, "sense unit %02x byte 3 %02x\n", unit, ch);
+        sim_debug(DEBUG_CMD, dptr, "sense unit %02x byte 3 %02x\n", unit, ch);
         chan_write_byte(chsa, &ch);                 /* write byte 3 */
         /* write zero extra status */
         for (ch=4; ch < 0xc; ch++) {
             uint8   zc = 0;
             chan_write_byte(chsa, &zc);             /* write zero byte */
-            sim_debug(DEBUG_CMD, &mta_dev,
+            sim_debug(DEBUG_CMD, dptr,
                 "sense unit %02x byte %1x %02x\n", unit, ch, zc);
         }
         uptr->CMD &= ~MT_CMDMSK;                    /* clear the cmd */
         mt_busy[bufnum] &= ~1;                      /* make our buffer not busy */
-        sim_debug(DEBUG_CMD, &mta_dev, "mt_srv DIAG SNS %08x char complete unit=%02x\n",
+        sim_debug(DEBUG_CMD, dptr, "mt_srv DIAG SNS %08x char complete unit=%02x\n",
             uptr->SNS, unit);
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);      /* we are done dev|chan end */
         break;
@@ -634,19 +635,19 @@ t_stat mt_srv(UNIT *uptr)
             if (i<4)
                 ch = (uptr->SNS >> (24-(i*8))) & 0xff;  /* get 8 bits of status */
             chan_write_byte(chsa, &ch);             /* write zero byte */
-            sim_debug(DEBUG_CMD, &mta_dev,
+            sim_debug(DEBUG_CMD, dptr,
                 "sense unit %02x byte %1x %02x\n", unit, i, ch);
         }
         uptr->CMD &= ~MT_CMDMSK;                    /* clear the cmd */
         mt_busy[bufnum] &= ~1;                      /* make our buffer not busy */
-        sim_debug(DEBUG_CMD, &mta_dev, "mt_srv SENSE %08x char complete unit=%02x\n",
+        sim_debug(DEBUG_CMD, dptr, "mt_srv SENSE %08x char complete unit=%02x\n",
             uptr->SNS, unit);
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);      /* we are done dev|chan end */
         break;
 
     case MT_READ:   /* 0x02 */                      /* read a record from the device */
-//      sim_debug(DEBUG_DETAIL, &mta_dev, "mt_srv cmd 2 READ unit=%02x\n", unit);
-        sim_debug(DEBUG_CMD, &mta_dev, "mt_srv cmd 2 READ unit=%02x\n", unit);
+//      sim_debug(DEBUG_DETAIL, dptr, "mt_srv cmd 2 READ unit=%02x\n", unit);
+        sim_debug(DEBUG_CMD, dptr, "mt_srv cmd 2 READ unit=%02x\n", unit);
         if (uptr->CMD & MT_READDONE) {              /* is the read complete */
             uptr->SNS &= ~(SNS_LOAD|SNS_EOT);       /* reset BOT & EOT */
             if (sim_tape_eot(uptr)) {               /* see if at EOM */
@@ -656,7 +657,7 @@ t_stat mt_srv(UNIT *uptr)
             uptr->CMD &= ~(MT_CMDMSK|MT_READDONE);  /* clear all but readdone & cmd */
             uptr->CMD &= ~MT_CMDMSK;                /* clear the cmd */
             mt_busy[bufnum] &= ~1;                  /* not busy anymore */
-            sim_debug(DEBUG_CMD, &mta_dev,
+            sim_debug(DEBUG_CMD, dptr,
                 "mt_srv READ %04x char complete unit=%02x sense %08x\n",
                 uptr->POS, unit, uptr->SNS);
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* set CE, DE */
@@ -667,16 +668,16 @@ t_stat mt_srv(UNIT *uptr)
         if (BUF_EMPTY(uptr)) {
             /* buffer is empty, so fill it with next record data */
             if ((r = sim_tape_rdrecf(uptr, &mt_buffer[bufnum][0], &reclen, BUFFSIZE)) != MTSE_OK) {
-                sim_debug(DEBUG_CMD, &mta_dev, "mt_srv READ fill buffer unit=%02x\n", unit);
+                sim_debug(DEBUG_CMD, dptr, "mt_srv READ fill buffer unit=%02x\n", unit);
                 uptr->CMD &= ~(MT_CMDMSK|MT_READDONE);  /* clear all but readdone & cmd */
                 return mt_error(uptr, chsa, r, dptr);   /* process any error & return status */
             }
             uptr->SNS &= ~(SNS_LOAD|SNS_EOT);       /* reset BOT & EOT */
             uptr->POS = 0;                          /* reset buffer position */
             uptr->hwmark = reclen;                  /* set buffer chars read in */
-//          sim_debug(DEBUG_DETAIL, &mta_dev, "mt_srv READ fill buffer complete count %04x\n", reclen);
-            sim_debug(DEBUG_CMD, &mta_dev, "mt_srv READ fill buffer complete count %04x\n", reclen);
-            sim_debug(DEBUG_CMD, &mta_dev,
+//          sim_debug(DEBUG_DETAIL, dptr, "mt_srv READ fill buffer complete count %04x\n", reclen);
+            sim_debug(DEBUG_CMD, dptr, "mt_srv READ fill buffer complete count %04x\n", reclen);
+            sim_debug(DEBUG_CMD, dptr,
                 "mt_srv READ MemBuf %06x cnt %04x %02x%02x%02x%02x\n",
                 chp->ccw_addr, chp->ccw_count,
                 mt_buffer[0][0], mt_buffer[0][1], mt_buffer[0][2], mt_buffer[0][3]);
@@ -686,31 +687,31 @@ t_stat mt_srv(UNIT *uptr)
 
         /* Send character over to channel */
         if (chan_write_byte(chsa, &ch)) {
-            sim_debug(DEBUG_CMD, &mta_dev,
+            sim_debug(DEBUG_CMD, dptr,
                 "Read unit %02x EOR cnt %04x hwm %04x\n", unit, uptr->POS, uptr->hwmark);
             /* If not read whole record, skip till end */
             if ((uint32)uptr->POS < uptr->hwmark) {
                 /* Send dummy character to force SLI */
                 chan_write_byte(chsa, &ch);         /* write the byte */
-                sim_debug(DEBUG_CMD, &mta_dev, "Read unit %02x send dump SLI\n", unit);
+                sim_debug(DEBUG_CMD, dptr, "Read unit %02x send dump SLI\n", unit);
                 sim_activate(uptr, (uptr->hwmark-uptr->POS) * 10); /* wait again */
                 uptr->CMD |= MT_READDONE;           /* read is done */
                 break;
             }
-            sim_debug(DEBUG_CMD, &mta_dev,
+            sim_debug(DEBUG_CMD, dptr,
                 "Read data @1 unit %02x cnt %04x ch %02x hwm %04x\n",
                     unit, uptr->POS, ch, uptr->hwmark);
             uptr->CMD &= ~MT_CMDMSK;                /* clear the cmd */
             mt_busy[bufnum] &= ~1;                  /* set not busy */
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* return end status */
         } else {
-//          sim_debug(DEBUG_CMD, &mta_dev,
-            sim_debug(DEBUG_DETAIL, &mta_dev,
+//          sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "Read data @2 unit %02x cnt %04x ch %02x hwm %04x\n",
                 unit, uptr->POS, ch, uptr->hwmark);
             if ((uint32)uptr->POS >= uptr->hwmark) { /* In IRG */
                 /* Handle end of data record */
-                sim_debug(DEBUG_CMD, &mta_dev,
+                sim_debug(DEBUG_CMD, dptr,
                     "Read end of data unit %02x cnt %04x ch %02x hwm %04x\n",
                     unit, uptr->POS, ch, uptr->hwmark);
                 uptr->CMD |= MT_READDONE;           /* read is done */
@@ -721,13 +722,13 @@ t_stat mt_srv(UNIT *uptr)
         break;
 
     case MT_SETM:   /* 0x83 */                      /* set mode byte */
-        sim_debug(DEBUG_CMD, &mta_dev, "mt_srv cmd 0x83 SETM unit=%02x\n", unit);
+        sim_debug(DEBUG_CMD, dptr, "mt_srv cmd 0x83 SETM unit=%02x\n", unit);
         /* Grab data until channel has no more */
         if (chan_read_byte(chsa, &ch)) {
             if (uptr->POS > 0) {                    /* Only if data in record */
                 reclen = uptr->hwmark;              /* set record length */
                 ch = mt_buffer[bufnum][0];          /* get the first byte read */
-                sim_debug(DEBUG_CMD, &mta_dev,
+                sim_debug(DEBUG_CMD, dptr,
                     "Write mode data done unit %02x chars %02x mode %02x\n", unit, reclen, ch);
                 /* put mode bits into byte 2 of SNS */
                 uptr->SNS = (uptr->SNS & 0xffff00ff) | (ch << 8);
@@ -738,7 +739,7 @@ t_stat mt_srv(UNIT *uptr)
             }
         } else {
             mt_buffer[bufnum][uptr->POS++] = ch;    /* save the character read in */
-            sim_debug(DEBUG_CMD, &mta_dev, "Write mode data in unit %02x POS %04x mode %02x\n",
+            sim_debug(DEBUG_CMD, dptr, "Write mode data in unit %02x POS %04x mode %02x\n",
                   unit, uptr->POS, ch);
             uptr->hwmark = uptr->POS;               /* set high water mark */
             sim_activate(uptr, 40);                 /* wait time */
@@ -751,7 +752,7 @@ t_stat mt_srv(UNIT *uptr)
             uptr->SNS |= SNS_CMDREJ;
             uptr->CMD &= ~MT_CMDMSK;
             mt_busy[bufnum] &= ~1;
-            sim_debug(DEBUG_CMD, &mta_dev, "Write write protected unit=%02x\n", unit);
+            sim_debug(DEBUG_CMD, dptr, "Write write protected unit=%02x\n", unit);
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
             break;
         }
@@ -760,7 +761,7 @@ t_stat mt_srv(UNIT *uptr)
         if (chan_read_byte(chsa, &ch)) {
             if (uptr->POS > 0) {                   /* Only if data in record */
                 reclen = uptr->hwmark;
-                sim_debug(DEBUG_CMD, &mta_dev, "Write unit=%02x Block %04x chars\n",
+                sim_debug(DEBUG_CMD, dptr, "Write unit=%02x Block %04x chars\n",
                     unit, reclen);
                 r = sim_tape_wrrecf(uptr, &mt_buffer[bufnum][0], reclen);
                 uptr->POS = 0;
@@ -769,7 +770,7 @@ t_stat mt_srv(UNIT *uptr)
             }
         } else {
             mt_buffer[bufnum][uptr->POS++] = ch;
-            sim_debug(DEBUG_DETAIL, &mta_dev, "Write data unit=%02x %04x %02x\n",
+            sim_debug(DEBUG_DETAIL, dptr, "Write data unit=%02x %04x %02x\n",
                 unit, uptr->POS, ch);
             uptr->hwmark = uptr->POS;
         }
@@ -792,20 +793,20 @@ t_stat mt_srv(UNIT *uptr)
                 chan_end(chsa, SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK);
                 return SCPE_OK;
             }
-            sim_debug(DEBUG_CMD, &mta_dev, "Read backward unit=%02x\n", unit);
+            sim_debug(DEBUG_CMD, dptr, "Read backward unit=%02x\n", unit);
             if ((r = sim_tape_rdrecr(uptr, &mt_buffer[bufnum][0], &reclen, BUFFSIZE)) != MTSE_OK) {
                 uptr->CMD &= ~(MT_CMDMSK|MT_READDONE);
                 return mt_error(uptr, chsa, r, dptr);
             }
             uptr->POS = reclen;
             uptr->hwmark = reclen;
-            sim_debug(DEBUG_CMD, &mta_dev, "Binary Block %04x chars\n", reclen);
+            sim_debug(DEBUG_CMD, dptr, "Binary Block %04x chars\n", reclen);
         }
 
         ch = mt_buffer[bufnum][--uptr->POS];
 
         if (chan_write_byte(chsa, &ch)) {
-            sim_debug(DEBUG_CMD, &mta_dev, "Read unit=%02x EOR cnt %04x\n",
+            sim_debug(DEBUG_CMD, dptr, "Read unit=%02x EOR cnt %04x\n",
                 unit, uptr->POS);
             /* If not read whole record, skip till end */
             if (uptr->POS >= 0) {
@@ -817,7 +818,7 @@ t_stat mt_srv(UNIT *uptr)
             mt_busy[bufnum] &= ~1;
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
         } else {
-            sim_debug(DEBUG_DETAIL, &mta_dev, "Read data unit=%02x %04x %02x\n",
+            sim_debug(DEBUG_DETAIL, dptr, "Read data unit=%02x %04x %02x\n",
                 unit, uptr->POS, ch);
             if (uptr->POS == 0) {      /* In IRG */
                 uptr->CMD &= ~MT_CMDMSK;
@@ -840,7 +841,7 @@ t_stat mt_srv(UNIT *uptr)
             uptr->POS ++;
             sim_activate(uptr, 500);
         } else {
-            sim_debug(DEBUG_CMD, &mta_dev, "Write Mark unit=%02x\n", unit);
+            sim_debug(DEBUG_CMD, dptr, "Write Mark unit=%02x\n", unit);
             uptr->CMD &= ~(MT_CMDMSK);
             r = sim_tape_wrtmk(uptr);
             chan_end(chsa, SNS_DEVEND);
@@ -849,7 +850,7 @@ t_stat mt_srv(UNIT *uptr)
         break;
 
     case MT_BSR:    /* 0x53 */                      /* Backspace record */
-        sim_debug(DEBUG_CMD, &mta_dev, "mt_srv cmd 0x53 BSR unit %02x POS %04x\n",
+        sim_debug(DEBUG_CMD, dptr, "mt_srv cmd 0x53 BSR unit %02x POS %04x\n",
             unit, uptr->POS);
         switch (uptr->POS ) {
         case 0:
@@ -864,20 +865,20 @@ t_stat mt_srv(UNIT *uptr)
             break;
         case 1:
             uptr->POS++;
-            sim_debug(DEBUG_CMD, &mta_dev, "Backspace rec unit %02x POS %04x\n",
+            sim_debug(DEBUG_CMD, dptr, "Backspace rec unit %02x POS %04x\n",
                 unit, uptr->POS);
             r = sim_tape_sprecr(uptr, &reclen);
             /* SEL requires Unit Except & EOF on EOF */
             if (r == MTSE_TMK) {            /* test for EOF */
                 uptr->POS++;
-                sim_debug(DEBUG_CMD, &mta_dev, "BSR MARK\n");
+                sim_debug(DEBUG_CMD, dptr, "BSR MARK\n");
                 sim_activate(uptr, 50);
             /* SEL requires Unit Except & BOT on BOT */
             } else if (r == MTSE_BOT) {
                 uptr->POS+= 2;
                 sim_activate(uptr, 50);
             } else {
-                sim_debug(DEBUG_CMD, &mta_dev, "Backspace reclen %04x\n", reclen);
+                sim_debug(DEBUG_CMD, dptr, "Backspace reclen %04x\n", reclen);
                 sim_activate(uptr, 50);
             }
             break;
@@ -902,7 +903,7 @@ t_stat mt_srv(UNIT *uptr)
         break;
 
     case MT_BSF:    /* 0x73 */          /* Backspace file */
-        sim_debug(DEBUG_CMD, &mta_dev, "mt_srv cmd 0x73 BSF unit %02x\n", unit);
+        sim_debug(DEBUG_CMD, dptr, "mt_srv cmd 0x73 BSF unit %02x\n", unit);
         switch(uptr->POS) {
         case 0:
             if (sim_tape_bot(uptr)) {
@@ -915,12 +916,12 @@ t_stat mt_srv(UNIT *uptr)
             sim_activate(uptr, 500);
             break;
         case 1:
-            sim_debug(DEBUG_CMD, &mta_dev, "Backspace file unit=%02x\n", unit);
+            sim_debug(DEBUG_CMD, dptr, "Backspace file unit=%02x\n", unit);
             uptr->SNS &= ~(SNS_LOAD|SNS_EOT|SNS_FMRKDT);    /* reset BOT, EOT, EOF */
             r = sim_tape_sprecr(uptr, &reclen);
             if (r == MTSE_TMK) {
                 uptr->POS++;
-                sim_debug(DEBUG_DETAIL, &mta_dev, "BSF MARK\n");
+                sim_debug(DEBUG_DETAIL, dptr, "BSF MARK\n");
                 sim_activate(uptr, 50);
             } else if (r == MTSE_BOT) {
                 uptr->POS+= 2;
@@ -947,27 +948,27 @@ t_stat mt_srv(UNIT *uptr)
     case MT_FSR:    /* 0x43 */          /* Advance record */
         switch(uptr->POS) {
         case 0:
-            sim_debug(DEBUG_CMD, &mta_dev, "Skip rec entry unit=%02x ", unit);
+            sim_debug(DEBUG_CMD, dptr, "Skip rec entry unit=%02x ", unit);
             uptr->POS++;
             sim_activate(uptr, 50);
             break;
         case 1:
             uptr->POS++;
-            sim_debug(DEBUG_CMD, &mta_dev, "Skip rec unit=%02x ", unit);
+            sim_debug(DEBUG_CMD, dptr, "Skip rec unit=%02x ", unit);
             uptr->SNS &= ~(SNS_LOAD|SNS_EOT|SNS_FMRKDT);    /* reset BOT, EOT, EOF */
             r = sim_tape_sprecf(uptr, &reclen);
             if (r == MTSE_TMK) {
                 uptr->POS = 3;
                 uptr->SNS |= SNS_FMRKDT;            /* file mark detected */
-                sim_debug(DEBUG_CMD, &mta_dev, "FSR MARK\n");
+                sim_debug(DEBUG_CMD, dptr, "FSR MARK\n");
                 sim_activate(uptr, 50);
             } else if (r == MTSE_EOM) {
                 uptr->POS = 4;
                 uptr->SNS |= SNS_EOT;               /* set EOT status */
-                sim_debug(DEBUG_CMD, &mta_dev, "FSR EOT\n");
+                sim_debug(DEBUG_CMD, dptr, "FSR EOT\n");
                 sim_activate(uptr, 50);
             } else {
-                sim_debug(DEBUG_CMD, &mta_dev, "FSR skipped %04x byte record\n",
+                sim_debug(DEBUG_CMD, dptr, "FSR skipped %04x byte record\n",
                     reclen);
                 sim_activate(uptr, 10 + (10 * reclen));
             }
@@ -975,19 +976,19 @@ t_stat mt_srv(UNIT *uptr)
         case 2:
             uptr->CMD &= ~(MT_CMDMSK);
             mt_busy[bufnum] &= ~1;
-            sim_debug(DEBUG_CMD, &mta_dev, "Skip record Completed\n");
+            sim_debug(DEBUG_CMD, dptr, "Skip record Completed\n");
             chan_end(chsa, SNS_DEVEND);
             break;
         case 3:
             uptr->CMD &= ~(MT_CMDMSK);
             mt_busy[bufnum] &= ~1;
-            sim_debug(DEBUG_CMD, &mta_dev, "Skip record now at EOF\n");
+            sim_debug(DEBUG_CMD, dptr, "Skip record now at EOF\n");
             chan_end(chsa, SNS_DEVEND|SNS_UNITEXP);
             break;
         case 4:
             uptr->CMD &= ~(MT_CMDMSK);
             mt_busy[bufnum] &= ~1;
-            sim_debug(DEBUG_CMD, &mta_dev, "Skip record now at EOT\n");
+            sim_debug(DEBUG_CMD, dptr, "Skip record now at EOT\n");
             chan_end(chsa, SNS_DEVEND|SNS_UNITEXP);
             break;
         }
@@ -996,34 +997,34 @@ t_stat mt_srv(UNIT *uptr)
     case MT_FSF:    /* 0x63 */          /* advance filemark */
         switch(uptr->POS) {
         case 0:
-            sim_debug(DEBUG_CMD, &mta_dev,
+            sim_debug(DEBUG_CMD, dptr,
                 "Skip file entry sense %08x unit %02x\n", uptr->SNS, unit);
             uptr->POS++;
             sim_activate(uptr, 50);
             break;
         case 1:
-            sim_debug(DEBUG_CMD, &mta_dev, "Skip file unit=%02x\n", unit);
+            sim_debug(DEBUG_CMD, dptr, "Skip file unit=%02x\n", unit);
             uptr->SNS &= ~(SNS_LOAD|SNS_EOT|SNS_FMRKDT);    /* reset BOT, EOT, EOF */
             r = sim_tape_sprecf(uptr, &reclen);
             if (r == MTSE_TMK) {
                 uptr->POS++;
                 uptr->SNS |= SNS_FMRKDT;            /* file mark detected */
-                sim_debug(DEBUG_CMD, &mta_dev, "FSF EOF MARK sense %08x\n", uptr->SNS);
+                sim_debug(DEBUG_CMD, dptr, "FSF EOF MARK sense %08x\n", uptr->SNS);
                 sim_activate(uptr, 50);
             } else if (r == MTSE_EOM) {
                 uptr->SNS |= SNS_EOT;               /* set EOT status */
-                sim_debug(DEBUG_CMD, &mta_dev, "FSF EOT sense %08x\n", uptr->SNS);
+                sim_debug(DEBUG_CMD, dptr, "FSF EOT sense %08x\n", uptr->SNS);
                 uptr->POS+= 2;
                 sim_activate(uptr, 50);
             } else {
-                sim_debug(DEBUG_CMD, &mta_dev, "FSF skipped %04x byte record\n", reclen);
+                sim_debug(DEBUG_CMD, dptr, "FSF skipped %04x byte record\n", reclen);
                 sim_activate(uptr, 50);
             }
             break;
         case 2:
             uptr->CMD &= ~(MT_CMDMSK);
             mt_busy[bufnum] &= ~1;
-            sim_debug(DEBUG_CMD, &mta_dev,
+            sim_debug(DEBUG_CMD, dptr,
                 "Skip file done sense %08x unit %02x\n", uptr->SNS, unit);
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* we are done dev|chan end */
             break;
@@ -1031,7 +1032,7 @@ t_stat mt_srv(UNIT *uptr)
             uptr->CMD &= ~(MT_CMDMSK);
             uptr->SNS |= SNS_EOT;                   /* set EOT status */
             mt_busy[bufnum] &= ~1;
-            sim_debug(DEBUG_CMD, &mta_dev,
+            sim_debug(DEBUG_CMD, dptr,
                 "Skip file got EOT sense %08x unit %02x\n", uptr->SNS, unit);
             chan_end(chsa, SNS_DEVEND|SNS_UNITEXP);
             break;
@@ -1052,7 +1053,7 @@ t_stat mt_srv(UNIT *uptr)
             }
             break;
         case 1:
-            sim_debug(DEBUG_CMD, &mta_dev, "Erase unit=%02x\n", unit);
+            sim_debug(DEBUG_CMD, dptr, "Erase unit=%02x\n", unit);
             r = sim_tape_wrgap(uptr, 35);
             sim_activate(uptr, 5000);
             uptr->POS++;
@@ -1069,10 +1070,10 @@ t_stat mt_srv(UNIT *uptr)
     case MT_REW:    /* 0x23 */                      /* rewind tape */
         if (uptr->POS == 0) {
             uptr->POS++;
-            sim_debug(DEBUG_CMD, &mta_dev, "Start rewind unit %02x\n", unit);
+            sim_debug(DEBUG_CMD, dptr, "Start rewind unit %02x\n", unit);
             sim_activate(uptr, 1500);
         } else {
-            sim_debug(DEBUG_CMD, &mta_dev, "Rewind complete unit %02x\n", unit);
+            sim_debug(DEBUG_CMD, dptr, "Rewind complete unit %02x\n", unit);
             uptr->CMD &= ~(MT_CMDMSK);
             r = sim_tape_rewind(uptr);
             uptr->SNS |= SNS_LOAD;                  /* set BOT */
@@ -1087,7 +1088,7 @@ t_stat mt_srv(UNIT *uptr)
              mt_busy[bufnum] &= ~1;
              sim_activate(uptr, 30000);
          } else {
-             sim_debug(DEBUG_CMD, &mta_dev, "Unload unit=%02x\n", unit);
+             sim_debug(DEBUG_CMD, dptr, "Unload unit=%02x\n", unit);
              uptr->CMD &= ~(MT_CMDMSK);
              r = sim_tape_detach(uptr);
          }
@@ -1107,15 +1108,28 @@ void mt_ini(UNIT *uptr, t_bool f)
     uptr->SNS = 0;                                  /* clear sense data */
     uptr->SNS |= (SNS_RDY|SNS_ONLN|SNS_LOAD);       /* set initial status */
     mt_busy[GET_DEV_BUF(dptr->flags)] = 0;          /* set not busy */
+    sim_cancel(uptr);                               /* cancel any timers */
     sim_debug(DEBUG_EXP, dptr, "MT init device %s unit %02x\n",
         dptr->name, GET_UADDR(uptr->CMD));
+}
+
+/* handle rschnlio cmds for tape */
+uint16  mt_rschnlio(UNIT *uptr) {
+    DEVICE *dptr = get_dev(uptr);
+    uint16  chsa = GET_UADDR(uptr->CMD);
+    int     cmd = uptr->CMD & MT_CMDMSK;
+//  int     unit = (uptr - mt_unit);                /* unit 0 */
+
+    sim_debug(DEBUG_EXP, dptr, "mt_rschnl chsa %04x cmd = %02x\n", chsa, cmd);
+    mt_ini(uptr, 0);                                /* reset the unit */
+    return SCPE_OK;
 }
 
 /* reset the mag tape */
 t_stat mt_reset(DEVICE *dptr)
 {
     /* nothing to do?? */
-    sim_debug(DEBUG_EXP, &mta_dev, "MT reset name %s\n", dptr->name);
+    sim_debug(DEBUG_EXP, dptr, "MT reset name %s\n", dptr->name);
     return SCPE_OK;
 }
 
@@ -1130,10 +1144,10 @@ t_stat mt_attach(UNIT *uptr, CONST char *file)
 
     /* mount the specified file to the MT */
     if ((r = sim_tape_attach(uptr, file)) != SCPE_OK) {
-       sim_debug(DEBUG_EXP, &mta_dev, "mt_attach ERROR filename %s status %08x\n", file, r);
+       sim_debug(DEBUG_EXP, dptr, "mt_attach ERROR filename %s status %08x\n", file, r);
        return r;                                    /* report any error */
     }
-    sim_debug(DEBUG_EXP, &mta_dev, "mt_attach complete filename %s\n", file);
+    sim_debug(DEBUG_EXP, dptr, "mt_attach complete filename %s\n", file);
     uptr->CMD &= ~0xffff;                           /* clear out the flags but leave ch/sa */
     uptr->POS = 0;                                  /* clear position data */
     uptr->SNS = 0;                                  /* clear sense data */
@@ -1157,7 +1171,8 @@ t_stat mt_attach(UNIT *uptr, CONST char *file)
 /* detach the MT device and unload any tape */
 t_stat mt_detach(UNIT *uptr)
 {
-    sim_debug(DEBUG_EXP, &mta_dev, "mt_detach\n");
+    DEVICE      *dptr = get_dev(uptr);              /* get device pointer */
+    sim_debug(DEBUG_EXP, dptr, "mt_detach\n");
     uptr->CMD &= ~0xffff;                           /* clear out the flags but leave ch/sa */
     uptr->POS = 0;                                  /* clear position data */
     uptr->SNS = 0;                                  /* clear sense data */
@@ -1169,9 +1184,9 @@ t_stat mt_boot(int32 unit_num, DEVICE *dptr)
 {
     UNIT    *uptr = &dptr->units[unit_num];         /* find tape unit pointer */
 
-    sim_debug(DEBUG_EXP, &mta_dev, "MT Boot dev/unit %04x\n", GET_UADDR(uptr->CMD));
+    sim_debug(DEBUG_EXP, dptr, "MT Boot dev/unit %04x\n", GET_UADDR(uptr->CMD));
     if ((uptr->flags & UNIT_ATT) == 0) {            /* Is MT device already attached? */
-        sim_debug(DEBUG_EXP, &mta_dev,
+        sim_debug(DEBUG_EXP, dptr,
             "MT Boot attach error dev/unit %04x\n", GET_UADDR(uptr->CMD));
         return SCPE_UNATT;                          /* not attached, return error */
     }

--- a/SEL32/sel32_scfi.c
+++ b/SEL32/sel32_scfi.c
@@ -274,6 +274,7 @@ uint16  scfi_iocl(CHANP *chp, int32 tic_ok);
 t_stat  scfi_srv(UNIT *uptr);
 t_stat  scfi_boot(int32 unitnum, DEVICE *dptr);
 void    scfi_ini(UNIT *, t_bool);
+uint16  scfi_rschnlio(UNIT *uptr);
 t_stat  scfi_reset(DEVICE *);
 t_stat  scfi_attach(UNIT *, CONST char *);
 t_stat  scfi_detach(UNIT *);
@@ -318,7 +319,7 @@ DIB             sda_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    scfi_rschnlio,  /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     scfi_iocl,      /* uint16 (*iocl_io)(CHANP *chp, int32 tik_ok)) */  /* Process IOCL */
     scfi_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     sda_unit,       /* UNIT* units */                           /* Pointer to units structure */
@@ -364,7 +365,7 @@ DIB             sdb_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    scfi_rschnlio,  /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     scfi_iocl,      /* uint16 (*iocl_io)(CHANP *chp, int32 tic_ok)) */  /* Process IOCL */
     scfi_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     sdb_unit,       /* UNIT* units */                           /* Pointer to units structure */
@@ -407,12 +408,14 @@ uint16 scfi_preio(UNIT *uptr, uint16 chan)
     uint16      chsa = GET_UADDR(uptr->CMD);
     int         unit = (uptr - dptr->units);
 
-    sim_debug(DEBUG_CMD, dptr, "scfi_preio CMD %08x unit %02x\n", uptr->CMD, unit);
+    sim_debug(DEBUG_DETAIL, dptr,
+        "scfi_preio CMD %08x unit %02x\n", uptr->CMD, unit);
     if ((uptr->CMD & 0xff00) != 0) {            /* just return if busy */
         return SNS_BSY;
     }
 
-    sim_debug(DEBUG_CMD, dptr, "scfi_preio unit %02x chsa %04x OK\n", unit, chsa);
+    sim_debug(DEBUG_DETAIL, dptr,
+        "scfi_preio unit %02x chsa %04x OK\n", unit, chsa);
     return SCPE_OK;                             /* good to go */
 }
 
@@ -424,7 +427,6 @@ uint16  scfi_iocl(CHANP *chp, int32 tic_ok)
     uint32      word1 = 0;
     uint32      word2 = 0;
     int32       docmd = 0;
-//  DIB         *dibp = dib_unit[chp->chan_dev];/* get the DIB pointer */
     UNIT        *uptr = chp->unitptr;           /* get the unit ptr */
     uint16      chan = get_chan(chp->chan_dev); /* our channel */
     uint16      devstat = 0;
@@ -606,7 +608,8 @@ loop:
             return 1;                           /* if none, error */
         }
 
-        sim_debug(DEBUG_XIO, dptr,
+//      sim_debug(DEBUG_XIO, dptr,
+        sim_debug(DEBUG_DETAIL, dptr,
             "scfi_iocl @%06x before start_cmd chan %04x status %04x count %04x SNS %08x\n",
             chp->chan_caw, chan, chp->chan_status, chp->ccw_count, uptr->u5);
 
@@ -616,7 +619,8 @@ loop:
         chp->chan_status = (chp->chan_status & 0xff00) | devstat;
         chp->chan_info &= ~INFO_SIOCD;          /* show not first IOCD in channel prog */
 
-        sim_debug(DEBUG_XIO, dptr,
+//      sim_debug(DEBUG_XIO, dptr,
+        sim_debug(DEBUG_DETAIL, dptr,
             "scfi_iocl @%06x after start_cmd chan %04x status %08x count %04x\n",
             chp->chan_caw, chan, chp->chan_status, chp->ccw_count);
 
@@ -647,14 +651,16 @@ loop:
         if (chp->chan_status & (STATUS_DEND|STATUS_CEND)) {
             uint16  chsa = GET_UADDR(uptr->u3); /* get channel & sub address */
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* show I/O complete */
-            sim_debug(DEBUG_XIO, dptr,
+//          sim_debug(DEBUG_XIO, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "scfi_iocl @%06x FIFO #%1x cmd complete chan %04x status %04x count %04x\n",
                 chp->chan_caw, FIFO_Num(chsa), chan, chp->chan_status, chp->ccw_count);
         }
     }
     /* the device processor returned OK (0), so wait for I/O to complete */
     /* nothing happening, so return */
-    sim_debug(DEBUG_XIO, dptr,
+//  sim_debug(DEBUG_XIO, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "scfi_iocl @%06x return, chan %04x status %04x count %04x irq_pend %1x\n",
         chp->chan_caw, chan, chp->chan_status, chp->ccw_count, irq_pend);
     return 0;                                   /* good return */
@@ -667,23 +673,26 @@ uint16 scfi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
     int32       unit = (uptr - dptr->units);
     CHANP       *chp = find_chanp_ptr(chsa);    /* find the chanp pointer */
 
-    sim_debug(DEBUG_CMD, dptr,
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "scfi_startcmd chsa %04x unit %02x cmd %02x CMD %08x\n",
         chsa, unit, cmd, uptr->CMD);
     if ((uptr->flags & UNIT_ATT) == 0) {        /* unit attached status */
-        sim_debug(DEBUG_CMD, dptr, "scfi_startcmd unit %02x not attached\n", unit);
+        sim_debug(DEBUG_EXP, dptr, "scfi_startcmd unit %02x not attached\n", unit);
         uptr->SNS |= SNS_INTVENT;               /* unit intervention required */
         if (cmd != DSK_SNS)                     /* we are completed with unit check status */
             return SNS_CHNEND|SNS_DEVEND|SNS_UNITCHK;
     }
 
     if ((uptr->CMD & DSK_CMDMSK) != 0) {
-        sim_debug(DEBUG_CMD, dptr, "scfi_startcmd unit %02x busy\n", unit);
+        sim_debug(DEBUG_EXP, dptr, "scfi_startcmd unit %02x busy\n", unit);
         uptr->CMD |= DSK_BUSY;                  /* Flag we are busy */
         return SNS_BSY;
     }
     uptr->SNS2 |= SNS_USEL;                     /* unit selected */
-    sim_debug(DEBUG_CMD, dptr, "scfi_startcmd CMD continue unit=%02x cmd %02x iocla %06x cnt %04x\n",
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
+        "scfi_startcmd CMD continue unit=%02x cmd %02x iocla %06x cnt %04x\n",
         unit, cmd, chp->chan_caw, chp->ccw_count);
 
     /* Unit is online, so process a command */
@@ -746,7 +755,7 @@ uint16 scfi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
         break;
     }
 
-    sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_EXP, dptr,
         "scfi_startcmd done with bad disk cmd %02x chsa %04x SNS %08x\n",
         cmd, chsa, uptr->SNS);
     uptr->SNS |= SNS_CMDREJ;                    /* cmd rejected */
@@ -760,28 +769,34 @@ uint16  scfi_haltio(UNIT *uptr) {
     int         cmd = uptr->CMD & DSK_CMDMSK;
     CHANP       *chp = find_chanp_ptr(chsa);    /* find the chanp pointer */
 
-    sim_debug(DEBUG_EXP, dptr, "scfi_haltio enter chsa %04x cmd = %02x\n", chsa, cmd);
+//  sim_debug(DEBUG_EXP, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
+        "scfi_haltio enter chsa %04x cmd = %02x\n", chsa, cmd);
 
     /* terminate any input command */
     /* UTX wants SLI bit, but no unit exception */
     /* status must not have an error bit set */
     /* otherwise, UTX will panic with "bad status" */
     if ((uptr->CMD & DSK_CMDMSK) != 0) {        /* is unit busy */
-        sim_debug(DEBUG_CMD, dptr,
-            "scfi_haltio HIO chsa %04x cmd = %02x ccw_count %02x\n", chsa, cmd, chp->ccw_count);
+//      sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_DETAIL, dptr,
+            "scfi_haltio HIO chsa %04x cmd = %02x ccw_count %02x\n",
+            chsa, cmd, chp->ccw_count);
         /* stop any I/O and post status and return error status */
         chp->ccw_flags &= ~(FLAG_DC|FLAG_CC);   /* stop any chaining */
         uptr->CMD &= LMASK;                     /* make non-busy */
         uptr->SNS2 |= (SNS_ONC|SNS_UNR);        /* on cylinder & ready */
         sim_cancel(uptr);                       /* clear the input timer */
-        sim_debug(DEBUG_CMD, dptr,
+//      sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
             "scfi_haltio HIO I/O stop chsa %04x cmd = %02x\n", chsa, cmd);
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* force end */
         return SCPE_IOERR;
     }
     uptr->CMD &= LMASK;                         /* make non-busy */
     uptr->SNS2 |= (SNS_ONC|SNS_UNR);            /* on cylinder & ready */
-    sim_debug(DEBUG_CMD, dptr,
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "scfi_haltio HIO I/O not busy chsa %04x cmd = %02x\n", chsa, cmd);
     return SCPE_OK;                             /* not busy */
 }
@@ -805,7 +820,8 @@ t_stat scfi_srv(UNIT *uptr)
     uint8           buf[1024];
     uint8           buf2[1024];
 
-    sim_debug(DEBUG_CMD, dptr,
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "scfi_srv entry unit %02x CMD %08x chsa %04x count %04x %x/%x/%x \n",
         unit, uptr->CMD, chsa, chp->ccw_count,
         STAR2CYL(uptr->CHS), (uptr->CHS >> 8)&0xff, (uptr->CHS&0xff));
@@ -818,7 +834,8 @@ t_stat scfi_srv(UNIT *uptr)
         }
     }
 
-    sim_debug(DEBUG_CMD, dptr,
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "scfi_srv cmd=%02x chsa %04x count %04x\n", cmd, chsa, chp->ccw_count);
 
     switch (cmd) {
@@ -1076,7 +1093,7 @@ t_stat scfi_srv(UNIT *uptr)
             (uptr->CHS >> 8) & 0xff, (uptr->CHS) & 0xff);
 
         if (len != 4) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "scfi_srv SEEK bad count unit %02x count %04x\n", unit, len);
             uptr->CMD &= LMASK;                 /* remove old status bits & cmd */
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND|STATUS_PCHK|STATUS_LENGTH);
@@ -1263,7 +1280,7 @@ t_stat scfi_srv(UNIT *uptr)
 
             /* read in a sector of data from disk */
             if ((len=sim_fread(buf, 1, ssize, uptr->fileref)) != ssize) {
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "Error %08x on read %04x of diskfile cyl %04x hds %02x sec %02x\n",
                     len, ssize, ((uptr->CHS)>>16)&0xffff, ((uptr->CHS)>>8)&0xff, (uptr->CHS)&0xff);
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -1271,10 +1288,10 @@ t_stat scfi_srv(UNIT *uptr)
                 break;
             }
 
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "scfi_srv after READ chsa %04x buffer %06x count %04x\n",
                 chsa, chp->ccw_addr, chp->ccw_count);
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "scfi_srv after READ buffer %06x count %04x data %02x%02x%02x%02x %02x%02x%02x%02x\n",
 //              chp->ccw_addr, chp->ccw_count, buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7]);
                 chp->ccw_addr, chp->ccw_count, buf[1016], buf[1017], buf[1018], buf[1019],
@@ -1311,7 +1328,7 @@ t_stat scfi_srv(UNIT *uptr)
             /* see if over end of disk */
             if (tstart >= (uint32)CAP(type)) {
                 /* EOM reached, abort */
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "DISK Read reached EOM for read from disk @ /%04x/%02x/%02x\n",
                     STAR2CYL(uptr->CHS), (uptr->CHS >> 8)&0xff, (uptr->CHS&0xff));
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -1402,7 +1419,7 @@ t_stat scfi_srv(UNIT *uptr)
 
             /* write the sector to disk */
             if ((i=sim_fwrite(buf2, 1, ssize, uptr->fileref)) != ssize) {
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "Error %08x on write %04x bytes to diskfile cyl %04x hds %02x sec %02x\n",
                     i, ssize, STAR2CYL(uptr->CHS), ((uptr->CHS) >> 8)&0xff, (uptr->CHS&0xff));
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -1410,7 +1427,7 @@ t_stat scfi_srv(UNIT *uptr)
                 break;
             }
 
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_DETAIL, dptr,
                 "scfi_srv after WRITE buffer %06x count %04x data %02x%02x%02x%02x %02x%02x%02x%02x\n",
                 chp->ccw_addr, chp->ccw_count, buf2[1016], buf2[1017], buf2[1018], buf2[1019],
                 buf2[1020], buf2[1021], buf2[1022], buf2[1023]);
@@ -1434,7 +1451,7 @@ t_stat scfi_srv(UNIT *uptr)
             /* see if over end of disk */
             if (tstart >= (uint32)CAP(type)) {
                 /* EOM reached, abort */
-                sim_debug(DEBUG_CMD, dptr,
+                sim_debug(DEBUG_EXP, dptr,
                     "DISK Write reached EOM for write to disk @ %04x/%02x/%02x\n",
                     STAR2CYL(uptr->CHS), (uptr->CHS >> 8)&0xff, (uptr->CHS&0xff));
                 uptr->CMD &= LMASK;             /* remove old status bits & cmd */
@@ -1464,7 +1481,7 @@ t_stat scfi_srv(UNIT *uptr)
          break;
 
     default:
-        sim_debug(DEBUG_CMD, dptr, "invalid command %02x unit %02x\n", cmd, unit);
+        sim_debug(DEBUG_EXP, dptr, "invalid command %02x unit %02x\n", cmd, unit);
         uptr->SNS |= SNS_CMDREJ;
         uptr->CMD &= LMASK;                     /* remove old status bits & cmd */
         chan_end(chsa, SNS_CHNEND|STATUS_PCHK); /* return Prog Check */
@@ -1473,6 +1490,18 @@ t_stat scfi_srv(UNIT *uptr)
     sim_debug(DEBUG_DETAIL, dptr,
         "scfi_srv done cmd %02x chsa %04x chs %04x/%02x/%02x\n",
         cmd, chsa, ((uptr->CHS)>>16)&0xffff, ((uptr->CHS)>>8)&0xff, (uptr->CHS)&0xff);
+    return SCPE_OK;
+}
+
+/* handle rschnlio cmds for disk */
+uint16  scfi_rschnlio(UNIT *uptr) {
+    DEVICE  *dptr = get_dev(uptr);
+    uint16  chsa = GET_UADDR(uptr->CMD);
+    int     cmd = uptr->CMD & DSK_CMDMSK;
+
+    sim_debug(DEBUG_EXP, dptr,
+        "scfi_rschnl chsa %04x cmd = %02x\n", chsa, cmd);
+    scfi_ini(uptr, 0);                          /* reset the unit */
     return SCPE_OK;
 }
 
@@ -1488,6 +1517,7 @@ void scfi_ini(UNIT *uptr, t_bool f)
     uptr->CMD &= LMASK;                         /* remove old status bits & cmd */
     /* total sectors on disk */
     uptr->capac = CAP(i);                       /* size in sectors */
+    sim_cancel(uptr);                           /* stop any timers */
 
     sim_debug(DEBUG_EXP, &sda_dev, "SDA init device %s on unit SDA%04x cap %x %d\n",
         dptr->name, GET_UADDR(uptr->CMD), uptr->capac, uptr->capac);
@@ -1544,7 +1574,7 @@ int scfi_format(UNIT *uptr) {
     /* write zeros to each track of the disk */
     for (cyl = 0; cyl < cylv; cyl++) {
         if ((sim_fwrite(buff, 1, csize*ssize, uptr->fileref)) != csize*ssize) {
-            sim_debug(DEBUG_CMD, dptr,
+            sim_debug(DEBUG_EXP, dptr,
                 "Error on write to diskfile cyl %04x\n", cyl);
             free(buff);                         /* free cylinder buffer */
             buff = 0;
@@ -1567,13 +1597,13 @@ int scfi_format(UNIT *uptr) {
     /* now seek to end of disk and write the dmap data to last sector */
     /* write dmap data to last sector on disk */
     if ((sim_fseek(uptr->fileref, laddr*ssize, SEEK_SET)) != 0) { /* seek last sector */
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
         "Error on last sector seek to sect %06x offset %06x\n",
         cap-1, (cap-1)*ssize);
         return 1;
     }
     if ((sim_fwrite((char *)&dmap, sizeof(uint32), 4, uptr->fileref)) != 4) {
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
         "Error writing DMAP to sect %06x offset %06x\n",
         cap-1, (cap-1)*ssize);
         return 1;
@@ -1582,8 +1612,8 @@ int scfi_format(UNIT *uptr) {
     printf("Disk %s has %x (%d) cyl, %x (%d) hds, %x (%d) sec\r\n",
         scfi_type[type].name, CYL(type), CYL(type), HDS(type), HDS(type),
         SPT(type), SPT(type));
-    /* seek home again */
 
+    /* seek home again */
     if ((sim_fseek(uptr->fileref, 0, SEEK_SET)) != 0) { /* seek home */
         fprintf (stderr, "Error on seek to 0\r\n");
         return 1;
@@ -1640,8 +1670,7 @@ t_stat scfi_attach(UNIT *uptr, CONST char *file)
         "SCFI Disk %s cyl %d hds %d sec %d ssiz %d capacity %d\n",
         scfi_type[type].name, scfi_type[type].cyl, scfi_type[type].nhds,
         scfi_type[type].spt, ssize, uptr->capac); /* disk capacity */
-    printf(
-        "SCFI Disk %s cyl %d hds %d sec %d ssiz %d capacity %d\r\n",
+    printf("SCFI Disk %s cyl %d hds %d sec %d ssiz %d capacity %d\r\n",
         scfi_type[type].name, scfi_type[type].cyl, scfi_type[type].nhds,
         scfi_type[type].spt, ssize, uptr->capac); /* disk capacity */
 
@@ -1665,8 +1694,7 @@ t_stat scfi_attach(UNIT *uptr, CONST char *file)
         j = (CAP(type) - (s/ssize));            /* get # sectors to write */
         sim_debug(DEBUG_CMD, dptr,
             "SCFI Disk attach for MPX 1.X needs %04d more sectors added to disk\n", j);
-        printf(
-            "SCFI Disk attach for MPX 1.X needs %04d more sectors added to disk\r\n", j);
+        printf("SCFI Disk attach for MPX 1.X needs %04d more sectors added to disk\r\n", j);
         /* must be MPX 1.X disk, extend to MPX 3.X size */
         /* write sectors of zero to end of disk to fill it out */
         for (i=0; i<j; i++) {
@@ -1685,14 +1713,14 @@ t_stat scfi_attach(UNIT *uptr, CONST char *file)
     /* seek last sector of disk */
     if ((sim_fseek(uptr->fileref, (CAP(type)-1)*ssize, SEEK_SET)) != 0) {
         sim_debug(DEBUG_CMD, dptr, "SCFI Disk attach SEEK last sector failed\n");
-        printf( "SCFI Disk attach SEEK last sector failed\r\n");
+        printf("SCFI Disk attach SEEK last sector failed\r\n");
         goto fmt;
     }
 
     /* see if there is disk size-1 in last sector of disk, if not add it */
     if ((r = sim_fread(buff, sizeof(uint8), ssize, uptr->fileref) != ssize)) {
         sim_debug(DEBUG_CMD, dptr, "SCFI Disk format fread error = %04d\n", r);
-        printf( "SCFI Disk format fread error = %04d\r\n", r);
+        printf("SCFI Disk format fread error = %04d\r\n", r);
 add_size:
         if (ssize == 768) {
             /* assume we have MPX 1x, and go on */
@@ -1767,25 +1795,24 @@ ldone:
     uptr->CHS = 0;                              /* set CHS to cyl/hd/sec = 0 */
 
     sim_debug(DEBUG_CMD, dptr,
-        "SCFI Attach %s cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\n",
-        scfi_type[type].name, CYL(type), HDS(type), SPT(type), SPC(type),
+        "SCFI Attach %s %04x cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\n",
+        scfi_type[type].name, chsa, CYL(type), HDS(type), SPT(type), SPC(type),
         CAP(type), CAPB(type));
-    printf(
-        "SCFI Attach %s cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\r\n",
-        scfi_type[type].name, CYL(type), HDS(type), SPT(type), SPC(type),
+    printf("SCFI Attach %s %04x cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\r\n",
+        scfi_type[type].name, chsa, CYL(type), HDS(type), SPT(type), SPC(type),
         CAP(type), CAPB(type));
 
     sim_debug(DEBUG_CMD, dptr,
-       "SCFI File %s attached to %s is ready\n",
-        file, scfi_type[type].name);
-    printf("SCFI File %s attached to %s is ready\r\n",
-        file, scfi_type[type].name);
+       "SCFI File %s at chsa %04x attached to %s is ready\n",
+        file, chsa, scfi_type[type].name);
+    printf("SCFI File %s at chsa %04x attached to %s is ready\r\n",
+        file, chsa, scfi_type[type].name);
 
     /* check for valid configured disk */
     /* must have valid DIB and Channel Program pointer */
     dibp = (DIB *)dptr->ctxt;                   /* get the DIB pointer */
     if ((dib_unit[chsa] == NULL) || (dibp == NULL) || (chp == NULL)) {
-        sim_debug(DEBUG_CMD, dptr,
+        sim_debug(DEBUG_EXP, dptr,
             "ERROR===ERROR\nSCFI device %s not configured on system, aborting\n",
             dptr->name);
         printf("ERROR===ERROR\nSCFI device %s not configured on system, aborting\r\n",
@@ -1808,9 +1835,11 @@ t_stat scfi_detach(UNIT *uptr) {
 t_stat scfi_boot(int32 unit_num, DEVICE *dptr) {
     UNIT    *uptr = &dptr->units[unit_num];     /* find disk unit number */
 
-    sim_debug(DEBUG_CMD, dptr, "SCFI Disk Boot dev/unit %x\n", GET_UADDR(uptr->CMD));
+    sim_debug(DEBUG_CMD, dptr,
+        "SCFI Disk Boot dev/unit %x\n", GET_UADDR(uptr->CMD));
     if ((uptr->flags & UNIT_ATT) == 0) {
-        sim_debug(DEBUG_EXP, dptr, "SCFI Disk Boot attach error dev/unit %04x\n",
+        sim_debug(DEBUG_EXP, dptr,
+            "SCFI Disk Boot attach error dev/unit %04x\n",
             GET_UADDR(uptr->CMD));
         return SCPE_UNATT;                      /* attached? */
     }

--- a/SEL32/sel32_scsi.c
+++ b/SEL32/sel32_scsi.c
@@ -289,6 +289,7 @@ uint16  scsi_haltio(UNIT *uptr);
 t_stat  scsi_srv(UNIT *);
 t_stat  scsi_boot(int32 unitnum, DEVICE *);
 void    scsi_ini(UNIT *, t_bool);
+uint16  scsi_rschnlio(UNIT *uptr);
 t_stat  scsi_reset(DEVICE *);
 t_stat  scsi_attach(UNIT *, CONST char *);
 t_stat  scsi_detach(UNIT *);
@@ -319,7 +320,8 @@ UNIT    sba_unit[] = {
     {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7608)},  /* 1 */
 };
 
-//DIB sba_dib = {scsi_preio, scsi_startcmd, NULL, NULL, NULL, scsi_ini, sba_unit, sba_chp, NUM_UNITS_SCSI, 0x0f, 0x0400, 0, 0, 0};
+//DIB sba_dib = {scsi_preio, scsi_startcmd, NULL, NULL, NULL, scsi_ini,
+//sba_unit, sba_chp, NUM_UNITS_SCSI, 0x0f, 0x0400, 0, 0, 0};
 
 DIB     sba_dib = {
     scsi_preio,     /* uint16 (*pre_io)(UNIT *uptr, uint16 chan)*/  /* Pre Start I/O */
@@ -328,7 +330,7 @@ DIB     sba_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    scsi_rschnlio,  /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     NULL,           /* uint16 (*iocl_io)(CHANP *chp, int32 tic_ok)) */  /* Process IOCL */
     scsi_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     sba_unit,       /* UNIT* units */                           /* Pointer to units structure */
@@ -362,7 +364,8 @@ UNIT    sbb_unit[] = {
     {UDATA(&scsi_srv, UNIT_SCSI|SET_TYPE(0), 0), 0, UNIT_ADDR(0x7648)},  /* 1 */
 };
 
-//DIB sdb_dib = {scsi_preio, scsi_startcmd, NULL, NULL, NULL, scsi_ini, sdb_unit, sdb_chp, NUM_UNITS_SCSI, 0x0f, 0x0c00, 0, 0, 0};
+//DIB sdb_dib = {scsi_preio, scsi_startcmd, NULL, NULL, NULL,
+//scsi_ini, sdb_unit, sdb_chp, NUM_UNITS_SCSI, 0x0f, 0x0c00, 0, 0, 0};
 
 DIB     sbb_dib = {
     scsi_preio,     /* uint16 (*pre_io)(UNIT *uptr, uint16 chan)*/  /* Pre Start I/O */
@@ -371,7 +374,7 @@ DIB     sbb_dib = {
     NULL,           /* uint16 (*stop_io)(UNIT *uptr) */         /* Stop I/O */
     NULL,           /* uint16 (*test_io)(UNIT *uptr) */         /* Test I/O */
     NULL,           /* uint16 (*rsctl_io)(UNIT *uptr) */        /* Reset Controller */
-    NULL,           /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
+    scsi_rschnlio,  /* uint16 (*rschnl_io)(UNIT *uptr) */       /* Reset Channel */
     NULL,           /* uint16 (*iocl_io)(CHANP *chp, int32 tic_ok)) */  /* Process IOCL */
     scsi_ini,       /* void  (*dev_ini)(UNIT *, t_bool) */      /* init function */
     sbb_unit,       /* UNIT* units */                           /* Pointer to units structure */
@@ -451,9 +454,6 @@ uint16 scsi_startcmd(UNIT *uptr, uint16 chan,  uint8 cmd)
     switch (cmd) {
 
     case DSK_INCH:                              /* INCH 0x00 */
-#ifdef DO_DYNAMIC_DEBUG
-//  cpu_dev.dctrl |= (DEBUG_INST | DEBUG_CMD | DEBUG_EXP | DEBUG_IRQ | DEBUG_XIO);
-#endif
         sim_debug(DEBUG_CMD, dptr,
             "scsi_startcmd starting INCH %06x cmd, chsa %04x MemBuf %08x cnt %04x\n",
             uptr->u4, chsa, chp->ccw_addr, chp->ccw_count);
@@ -815,10 +815,8 @@ t_stat scsi_srv(UNIT *uptr)
         sim_debug(DEBUG_CMD, dptr, "Load Mode Reg unit=%02x old %x new %x\n",
             unit, (uptr->SNS)&0xff, buf[0]);
         uptr->CMD &= LMASK;                     /* remove old cmd */
-//      uptr->SNS &= MASK24;                    /* clear old mode data */
         /* leave the TCMD bit */
         uptr->SNS &= (MASK24 | SNS_TCMD);       /* clear old mode data */
-//      uptr->SNS |= (buf[0] << 24);            /* save mode value */
         /* do not change TCMD bit */
         uptr->SNS |= ((buf[0]&0xfe) << 24);     /* save mode value */
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);
@@ -867,7 +865,6 @@ t_stat scsi_srv(UNIT *uptr)
                     ch, chsa, chp->ccw_addr, tstart, bcnt); 
 
                 /* convert sect address to chs value */
-//              uptr->CHS = scsisec2star(tstart, type);
                 uptr->CHS = tstart;
                 /* get byte address for seek */
                 tstart = tstart * SSB(type);
@@ -898,7 +895,6 @@ t_stat scsi_srv(UNIT *uptr)
                     buf[12] = 0xf4;
                     buf[17] = (uint8)HDS(type); /* # of heads */
                     buf[23] = (uint8)SPT(type); /* Sect/track */
-//                  buf[27] = SPT(type);        /* Sect/track */
                     goto merge;                 /* go output data and return */
                 }
                 /* this is most likely UTX calling */
@@ -969,7 +965,6 @@ t_stat scsi_srv(UNIT *uptr)
                 buf[12] = 0xf4;
                 buf[17] = (uint8)HDS(type);     /* # of heads */
                 buf[23] = (uint8)SPT(type);     /* Sect/track */
-//              buf[27] = SPT(type);            /* Sect/track */
 
 merge:
                 /* output response data */
@@ -1250,7 +1245,6 @@ read_cap:                                       /* merge point from TCMD process
             "scsi_srv cmd RCAP chsa %04x capacity %06x secsize %03x completed\n",
             chsa, cap, ssize);
         chan_end(chsa, SNS_CHNEND|SNS_DEVEND);  /* return OK */
-//      return SCPE_OK;
         break;
 
     /* Transfer Command Packet (specifies CDB to send) */
@@ -1319,13 +1313,14 @@ read_cap:                                       /* merge point from TCMD process
         break;
 
     default:
-        sim_debug(DEBUG_CMD, dptr, "invalid command %02x unit %02x\n", cmd, unit);
+        sim_debug(DEBUG_EXP, dptr, "invalid command %02x unit %02x\n", cmd, unit);
         uptr->SNS |= SNS_CMDREJ;
         uptr->CMD &= LMASK;                     /* remove old status bits & cmd */
         return SNS_CHNEND|STATUS_PCHK;
         break;
     }
-    sim_debug(DEBUG_CMD, dptr,
+//  sim_debug(DEBUG_CMD, dptr,
+    sim_debug(DEBUG_DETAIL, dptr,
         "scsi_srv done cmd %02x chsa %04x count %04x\n", cmd, chsa, chp->ccw_count);
     return SCPE_OK;
 }
@@ -1343,9 +1338,22 @@ void scsi_ini(UNIT *uptr, t_bool f)
     uptr->SNS = 0;                              /* clear any status */
     /* total sectors on disk */
     uptr->capac = CAP(i);                       /* disk size in sectors */
+    sim_cancel(uptr);                           /* stop any timers */
 
-    sim_debug(DEBUG_EXP, &sba_dev, "SBA init device %s on unit SBA%04x cap %x %d\n",
+    sim_debug(DEBUG_EXP, &sba_dev, "SCSI init device %s on unit SBA%04x cap %x %d\n",
         dptr->name, GET_UADDR(uptr->CMD), uptr->capac, uptr->capac);
+}
+
+/* handle rschnlio cmds for scsi */
+uint16  scsi_rschnlio(UNIT *uptr) {
+    DEVICE  *dptr = get_dev(uptr);
+    uint16  chsa = GET_UADDR(uptr->CMD);
+    int     cmd = uptr->CMD & DSK_CMDMSK;
+
+    sim_debug(DEBUG_EXP, dptr,
+        "scsi_rschnl chsa %04x cmd = %02x\n", chsa, cmd);
+    scsi_ini(uptr, 0);                          /* reset the unit */
+    return SCPE_OK;
 }
 
 t_stat scsi_reset(DEVICE * dptr)
@@ -1358,20 +1366,20 @@ t_stat scsi_reset(DEVICE * dptr)
 int scsi_format(UNIT *uptr) {
     int         type = GET_TYPE(uptr->flags);
     DEVICE      *dptr = get_dev(uptr);
-    int32       ssize = scsi_type[type].ssiz * 4;       /* disk sector size in bytes */
-    uint32      tsize = scsi_type[type].spt;            /* get track size in sectors */
+    int32       ssize = scsi_type[type].ssiz * 4;   /* disk sector size in bytes */
+    uint32      tsize = scsi_type[type].spt;    /* get track size in sectors */
     uint32      csize = scsi_type[type].nhds * tsize;   /* get cylinder size in sectors */
-    uint32      cyl = scsi_type[type].cyl;              /* get # cyl */
-    uint32      cap = scsi_type[type].cyl * csize;      /* disk capacity in sectors */
-    uint32      cylv = cyl;                             /* number of cylinders */
+    uint32      cyl = scsi_type[type].cyl;      /* get # cyl */
+    uint32      cap = scsi_type[type].cyl * csize;  /* disk capacity in sectors */
+    uint32      cylv = cyl;                     /* number of cylinders */
     uint8       *buff;
     int         i;
 
                 /* last sector address of disk (cyl * hds * spt) - 1 */
-    uint32      laddr = CAP(type) - 1;              /* last sector of disk */
+    uint32      laddr = CAP(type) - 1;          /* last sector of disk */
 
                 /* last track address of disk (cyl * hds * spt) - spt */
-    uint32      ltaddr = CAP(type)-SPT(type);       /* last sector of disk */
+    uint32      ltaddr = CAP(type)-SPT(type);   /* last sector of disk */
 
                 /* get sector address of vendor defect table VDT */
                 /* put data = 0xf0000000 0xf4000000 */
@@ -1434,11 +1442,6 @@ int scsi_format(UNIT *uptr) {
         detach_unit(uptr);
         return SCPE_ARG;
     }
-    /* put dummy data in first word of disk */
-    buff[0] = 'Z';
-    buff[1] = 'E';
-    buff[2] = 'R';
-    buff[3] = 'O';
     sim_debug(DEBUG_CMD, dptr,
         "Creating disk file of trk size %04x bytes, capacity %d\n",
         tsize*ssize, cap*ssize);
@@ -1451,12 +1454,6 @@ int scsi_format(UNIT *uptr) {
             free(buff);                         /* free cylinder buffer */
             buff = 0;
             return 1;
-        }
-        if (cyl == 0) {
-            buff[0] = 0;
-            buff[1] = 0;
-            buff[2] = 0;
-            buff[3] = 0;
         }
         if ((cyl % 100) == 0)
             fputc('.', stderr);
@@ -1557,6 +1554,9 @@ int scsi_format(UNIT *uptr) {
         return 1;
     }
 
+    printf("SCSI Disk %s has %x (%d) cyl, %x (%d) hds, %x (%d) sec\r\n",
+        scsi_type[type].name, CYL(type), CYL(type), HDS(type), HDS(type),
+        SPT(type), SPT(type));
     printf("writing to vmap sec %x (%d) bytes %x (%d)\n",
         vaddr, vaddr, (vaddr)*ssize, (vaddr)*ssize);
     printf("writing to flaw map sec %x (%d) bytes %x (%d)\n",
@@ -1581,11 +1581,26 @@ t_stat scsi_attach(UNIT *uptr, CONST char *file) {
     int             type = GET_TYPE(uptr->flags);
     DEVICE          *dptr = get_dev(uptr);
     DIB             *dibp = 0;
-    t_stat          r;
+    t_stat          r, s;
     uint32          ssize;                      /* sector size in bytes */
+    uint32          info, good,zmap = 0x5a4d4150;   /* ZMAP */
     uint8           buff[1024];
+    int             i, j;
+
+                    /* last sector address of disk (cyl * hds * spt) - 1 */
+    uint32          laddr = CAP(type) - 1;      /* last sector of disk */
+                    /* defect map */
+    uint32          dmap[4] = {0xf0000000 | (CAP(type)-1), 0x8a000000,
+                        0x9a000000 | (CAP(type)-1), 0xf4000000};
+
+    for (i=0; i<4; i++) {                       /* byte swap data for last sector */
+        dmap[i] = (((dmap[i] & 0xff) << 24) | ((dmap[i] & 0xff00) << 8) |
+            ((dmap[i] & 0xff0000) >> 8) | ((dmap[i] >> 24) & 0xff));
+    }
 
     uptr->SNS = 0;                              /* clear any status */
+
+    /* see if valid disk entry */
     if (scsi_type[type].name == 0) {            /* does the assigned disk have a name */
         detach_unit(uptr);                      /* no, reject */
         return SCPE_FMT;                        /* error */
@@ -1597,6 +1612,8 @@ t_stat scsi_attach(UNIT *uptr, CONST char *file) {
 
     uptr->capac = CAP(type);                    /* disk capacity in sectors */
     ssize = SSB(type);                          /* get sector size in bytes */
+    for (i=0; i<(int)ssize; i++)
+        buff[i] = 0;                            /* zero the buffer */
 
     sim_debug(DEBUG_CMD, dptr, "SCSI Disk %s %04x cyl %d hds %d sec %d ssiz %d capacity %d\n",
         scsi_type[type].name, chsa, scsi_type[type].cyl, scsi_type[type].nhds, 
@@ -1605,22 +1622,110 @@ t_stat scsi_attach(UNIT *uptr, CONST char *file) {
         scsi_type[type].name, chsa, scsi_type[type].cyl, scsi_type[type].nhds, 
         scsi_type[type].spt, ssize, uptr->capac); /* disk capacity */
 
-
-    if ((sim_fseek(uptr->fileref, 0, SEEK_SET)) != 0) { /* seek home */
-        detach_unit(uptr);                      /* if no space, error */
-        return SCPE_FMT;                        /* error */
+    /* seek to end of disk */
+    if ((sim_fseek(uptr->fileref, 0, SEEK_END)) != 0) {
+        sim_debug(DEBUG_CMD, dptr, "SCSI Disk attach SEEK end failed\n");
+        printf( "SCSI Disk attach SEEK end failed\r\n");
+        goto fmt;                               /* not setup, go format */
     }
 
-    /* read in the 1st sector of the 'disk' */
-    if ((r = sim_fread(&buff[0], sizeof(uint8), ssize, uptr->fileref) != ssize)) {
-        sim_debug(DEBUG_CMD, dptr, "Disk format fread ret = %04x\n", r);
+    s = ftell(uptr->fileref);                   /* get current file position */
+    if (s == 0) {
+        sim_debug(DEBUG_CMD, dptr, "SCSI Disk attach ftell failed s=%06d\n", s);
+        printf("SCSI Disk attach ftell failed s=%06d\r\n", s);
+        goto fmt;                               /* not setup, go format */
+    }
+    sim_debug(DEBUG_CMD, dptr, "SCSI Disk attach ftell value s=%06d b=%06d CAP %06d\n", s/ssize, s, CAP(type));
+    printf("SCSI Disk attach ftell value s=%06d b=%06d CAP %06d\r\n", s/ssize, s, CAP(type));
+
+    if (((int)s/(int)ssize) < ((int)CAP(type))) {   /* full sized disk? */
+        j = (CAP(type) - (s/ssize));            /* get # sectors to write */
+        sim_debug(DEBUG_CMD, dptr,
+            "SCSI Disk attach for MPX 1.X needs %04d more sectors added to disk\n", j);
+        printf("SSFI Disk attach for MPX 1.X needs %04d more sectors added to disk\r\n", j);
+        /* must be MPX 1.X disk, extend to MPX 3.X size */
+        /* write sectors of zero to end of disk to fill it out */
+        for (i=0; i<j; i++) {
+            if ((r = sim_fwrite(buff, sizeof(uint8), ssize, uptr->fileref) != ssize)) {
+                sim_debug(DEBUG_CMD, dptr, "SCSI Disk attach fread ret = %04d\n", r);
+                printf("SCSI Disk attach fread ret = %04d\r\n", r);
+                goto fmt;                       /* not setup, go format */
+            }
+        }
+        s = ftell(uptr->fileref);               /* get current file position */
+        sim_debug(DEBUG_CMD, dptr,
+            "SCSI Disk attach MPX 1.X file extended & sized secs %06d bytes %06d\n", s/ssize, s);
+        printf("SCSI Disk attach MPX 1.X  file extended & sized secs %06d bytes %06d\r\n", s/ssize, s);
+    }
+
+    /* seek last sector of disk */
+    if ((sim_fseek(uptr->fileref, (CAP(type)-1)*ssize, SEEK_SET)) != 0) {
+        sim_debug(DEBUG_CMD, dptr, "SCSI Disk attach SEEK last sector failed\n");
+        printf("SCSI Disk attach SEEK last sector failed\r\n");
         goto fmt;
     }
 
-    if ((buff[0] | buff[1] | buff[2] | buff[3]) == 0) {
+    /* see if there is disk size-1 in last sector of disk, if not add it */
+    if ((r = sim_fread(buff, sizeof(uint8), ssize, uptr->fileref) != ssize)) {
+        sim_debug(DEBUG_CMD, dptr, "SCSI Disk format fread error = %04d\n", r);
+        printf("SCSI Disk format fread error = %04d\r\n", r);
+add_size:
+        if (ssize == 768) {
+            /* assume we have MPX 1x, and go on */
+            /* write dmap data to last sector on disk for mpx 1.x */
+            if ((sim_fseek(uptr->fileref, laddr*ssize, SEEK_SET)) != 0) { /* seek last sector */
+                sim_debug(DEBUG_CMD, dptr,
+                    "SCSI Error on last sector seek to sect %06d offset %06d bytes\n",
+                    (CAP(type)-1), (CAP(type)-1)*ssize);
+                printf("SCSI Error on last sector seek to sect %06d offset %06d bytes\r\n",
+                    (CAP(type)-1), (CAP(type)-1)*ssize);
+                goto fmt;
+            }
+            if ((sim_fwrite((char *)&dmap, sizeof(uint32), 4, uptr->fileref)) != 4) {
+                sim_debug(DEBUG_CMD, dptr,
+                    "SCSI Error writing DMAP to sect %06x offset %06d bytes\n",
+                    (CAP(type)-1), (CAP(type)-1)*ssize);
+                printf("SCSI Error writing DMAP to sect %06x offset %06d bytes\r\n",
+                    (CAP(type)-1), (CAP(type)-1)*ssize);
+                goto fmt;
+            }
+
+            /* seek last sector of disk */
+            if ((sim_fseek(uptr->fileref, (CAP(type))*ssize, SEEK_SET)) != 0) {
+                sim_debug(DEBUG_CMD, dptr, "SCSI Disk attach SEEK last sector failed\n");
+                printf( "SCSI Disk attach SEEK last sector failed\r\n");
+                goto fmt;
+            }
+            s = ftell(uptr->fileref);           /* get current file position */
+            sim_debug(DEBUG_CMD, dptr,
+                "SCSI Disk attach MPX file extended & sized secs %06d bytes %06d\n", s/ssize, s);
+            printf("SCSI Disk attach MPX file extended & sized secs %06d bytes %06d\r\n", s/ssize, s);
+            goto ldone;
+        } else {
+            /* error if UTX */
+            detach_unit(uptr);                  /* if error, abort */
+            return SCPE_FMT;                    /* error */
+        }
+    } else {
+        /* if not disk size, go add it in for MPX, error if UTX */
+        if ((buff[0] | buff[1] | buff[2] | buff[3]) == 0) {
+            sim_debug(DEBUG_CMD, dptr,
+                "SCSI Disk format0 buf0 %02x buf1 %02x buf2 %02x buf3 %02x\n",
+                buff[0], buff[1], buff[2], buff[3]);
+            goto add_size;
+        }
+    }
+
+    /* the last sector is used by UTX for a ZMAP, so if there we are good to go */
+    info = (buff[0]<<24) | (buff[1]<<16) | (buff[2]<<8) | buff[3];
+    good = 0xf0000000 | (CAP(type)-1);
+    /* check for 0xf0ssssss where ssssss is disk size-1 in sectors */
+    if ((info != good) && (info != zmap)) {
         sim_debug(DEBUG_CMD, dptr,
-        "Disk format buf0 %02x buf1 %02x buf2 %02x buf3 %02x\n",
-        buff[0], buff[1], buff[2], buff[3]);
+            "SCSI Disk format error buf0 %02x buf1 %02x buf2 %02x buf3 %02x\n",
+            buff[0], buff[1], buff[2], buff[3]);
+        printf("SCSI Disk format error buf0 %02x buf1 %02x buf2 %02x buf3 %02x\r\n",
+            buff[0], buff[1], buff[2], buff[3]);
 fmt:
         /* format the drive */
         if (scsi_format(uptr)) {
@@ -1628,26 +1733,27 @@ fmt:
             return SCPE_FMT;                    /* error */
         }
     }
-
+ldone:
     if ((sim_fseek(uptr->fileref, 0, SEEK_SET)) != 0) { /* seek home */
         detach_unit(uptr);                      /* if no space, error */
         return SCPE_FMT;                        /* error */
     }
 
+    /* start out at sector 0 */
     uptr->CHS = 0;                              /* set CHS to cyl/hd/sec = 0 */
 
     sim_debug(DEBUG_CMD, dptr,
-        "Attach %s %04x cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\n",
+        "SCSI Attach %s %04x cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\n",
         scsi_type[type].name, chsa, CYL(type), HDS(type), SPT(type), SPC(type),  
         CAP(type), CAPB(type));
 
-    printf("Attach %s %04x cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\r\n",
+    printf("SCSI Attach %s %04x cyl %d hds %d spt %d spc %d cap sec %d cap bytes %d\r\n",
         scsi_type[type].name, chsa, CYL(type), HDS(type), SPT(type), SPC(type),  
         CAP(type), CAPB(type));
 
-    sim_debug(DEBUG_CMD, dptr, "File %s at chsa %04x attached to %s\n",
+    sim_debug(DEBUG_CMD, dptr, "SCSI File %s at chsa %04x attached to %s is ready\n",
         file, chsa, scsi_type[type].name);
-    printf("File %s at chsa %04x attached to %s\r\n",
+    printf("SCSI File %s at chsa %04x attached to %s is ready\r\n",
         file, chsa, scsi_type[type].name);
 
     /* check for valid configured disk */
@@ -1740,9 +1846,9 @@ t_stat scsi_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag,
     }
     fprintf (st, ".\nEach drive has the following storage capacity:\r\n");
     for (i = 0; scsi_type[i].name != 0; i++) {
-        int32   size = CAPB(i);                     /* disk capacity in bytes */
-        size /= 1024;                               /* make KB */
-        size = (10 * size) / 1024;                  /* size in MB * 10 */
+        int32   size = CAPB(i);                 /* disk capacity in bytes */
+        size /= 1024;                           /* make KB */
+        size = (10 * size) / 1024;              /* size in MB * 10 */
         fprintf(st, "      %-8s %4d.%1d MB cyl %3d hds %3d sec %3d blk %3d\r\n",
             scsi_type[i].name, size/10, size%10, CYL(i), HDS(i), SPT(i), SSB(i));
     }

--- a/SEL32/sel32_sys.c
+++ b/SEL32/sel32_sys.c
@@ -346,26 +346,26 @@ t_stat load_tap (FILE *fileref)
 t_value get_2hex(char *pt, uint32 *val)
 {
     int32 hexval;
-    uint32 c1 = sim_toupper((uint32)pt[0]);     /* first hex char */
-    uint32 c2 = sim_toupper((uint32)pt[1]);     /* next hex char */
+    uint32 c1 = sim_toupper((uint32)pt[0]); /* first hex char */
+    uint32 c2 = sim_toupper((uint32)pt[1]); /* next hex char */
 
-    if (isdigit(c1))                            /* digit */
-        hexval = c1 - (uint32)'0';              /* get value */
+    if (isdigit(c1))                        /* digit */
+        hexval = c1 - (uint32)'0';          /* get value */
     else
-    if (isxdigit(c1))                           /* hex digit */
-        hexval = c1 - (uint32)'A' + 10;         /* get hex value */
+    if (isxdigit(c1))                       /* hex digit */
+        hexval = c1 - (uint32)'A' + 10;     /* get hex value */
     else
-        return SCPE_ARG;                        /* oops, error */
-    hexval <<= 4;                               /* move to upper nibble */
-    if (isdigit(c2))                            /* digit */
-        hexval += c2 - (uint32)'0';             /* get value */
+        return SCPE_ARG;                    /* oops, error */
+    hexval <<= 4;                           /* move to upper nibble */
+    if (isdigit(c2))                        /* digit */
+        hexval += c2 - (uint32)'0';         /* get value */
     else
-    if (isxdigit(c2))                           /* hex digit */
-        hexval += c2 - (uint32)'A' + 10;            /* get hex value */
+    if (isxdigit(c2))                       /* hex digit */
+        hexval += c2 - (uint32)'A' + 10;    /* get hex value */
     else
-        return SCPE_ARG;                        /* oops, error */
-    *val = hexval;                              /* return value to caller */
-    return SCPE_OK;                             /* all OK */
+        return SCPE_ARG;                    /* oops, error */
+    *val = hexval;                          /* return value to caller */
+    return SCPE_OK;                         /* all OK */
 }
 
 /* load an ICL file and configure SPAD interupt and device entries */
@@ -373,24 +373,24 @@ t_value get_2hex(char *pt, uint32 *val)
 /* return SCPE_OK on load complete */
 t_stat load_icl(FILE *fileref)
 {
-    char    *cp;        /* work pointer in buf[] */
-    uint32  sa;         /* spad address */
-    uint32  dev;        /* device entry */
-    uint32  intr;       /* interrupt entry */
-    uint32  data;       /* entry data */
-    uint32  cls;        /* device class */
-    uint32  ivl;        /* Interrupt Vector Location */
-    uint32  i;          /* just a tmp */
-    char    buf[120];   /* input buffer */
+    char        *cp;                        /* work pointer in buf[] */
+    uint32      sa;                         /* spad address */
+    uint32      dev;                        /* device entry */
+    uint32      intr;                       /* interrupt entry */
+    uint32      data;                       /* entry data */
+    uint32      cls;                        /* device class */
+    uint32      ivl;                        /* Interrupt Vector Location */
+    uint32      i;                          /* just a tmp */
+    char        buf[120];                   /* input buffer */
 
     /* read file input records until the end */
     while (fgets(&buf[0], 120, fileref) != 0) {
         /* skip any white spaces */
         for(cp = &buf[0]; *cp == ' ' || *cp == '\t'; cp++);
         if (*cp++ != '*')
-            continue;           /* if line does not start with *, ignore */
+            continue;                       /* if line does not start with *, ignore */
         if(sim_strncasecmp(cp, "END", 3) == 0) {
-            return SCPE_OK;         /* we are done */
+            return SCPE_OK;                 /* we are done */
         }
         else
         if(sim_strncasecmp(cp, "DEV", 3) == 0) {
@@ -402,47 +402,48 @@ t_stat load_icl(FILE *fileref)
             */
             for(cp += 3; *cp == ' ' || *cp == '\t'; cp++);  /* skip white spaces */
             if (get_2hex(cp, &dev) != SCPE_OK)      /* get the device address */
-                return SCPE_ARG;        /* unknown input, argument error */
-            if (dev > 0x7f)             /* devices are 0-7f (0-127) */
-                return SCPE_ARG;        /* argument error */
-            sa = dev + 0x00;            /* device entry spad address is dev# + 0x00 */
-            cp += 2;                    /* skip the 2 processed chars */
-            if (*cp++ != '=')           /* must have = sign */
-                return SCPE_ARG;        /* unknown input, argument error */
+                return SCPE_ARG;            /* unknown input, argument error */
+            if (dev > 0x7f)                 /* devices are 0-7f (0-127) */
+                return SCPE_ARG;            /* argument error */
+            sa = dev + 0x00;                /* device entry spad address is dev# + 0x00 */
+            cp += 2;                        /* skip the 2 processed chars */
+            if (*cp++ != '=')               /* must have = sign */
+                return SCPE_ARG;            /* unknown input, argument error */
             if (get_2hex(cp, &cls) != SCPE_OK)  /* get unused '0" and class */
-                return SCPE_ARG;        /* unknown input, argument error */
-            cp += 2;                    /* skip the 2 processed chars */
+                return SCPE_ARG;            /* unknown input, argument error */
+            cp += 2;                        /* skip the 2 processed chars */
             if (get_2hex(cp, &intr) != SCPE_OK) /* get the interrupt level value */
-                return SCPE_ARG;        /* unknown input, argument error */
-            if (intr > 0x6f)            /* ints are 0-6f (0-111) */
-                return SCPE_ARG;        /* argument error */
-            dev = ((~intr & 0x7f) << 16) | ((cls & 0x0f) << 24);    /* put class and 1's intr in place */
-            cp += 2;                    /* skip the 2 processed chars */
+                return SCPE_ARG;            /* unknown input, argument error */
+            if (intr > 0x6f)                /* ints are 0-6f (0-111) */
+                return SCPE_ARG;            /* argument error */
+            /* put class and 1's intr in place */
+            dev = ((~intr & 0x7f) << 16) | ((cls & 0x0f) << 24);
+            cp += 2;                        /* skip the 2 processed chars */
             if (get_2hex(cp, &data) != SCPE_OK) /* get the selbus physical address */
-                return SCPE_ARG;        /* unknown input, argument error */
-            if (data > 0x7f)            /* address is 0-7f (0-127) */
-                return SCPE_ARG;        /* argument error */
-            dev |= (data & 0x7f) << 8;  /* insert the physical address */
-            cp += 2;                    /* skip the 2 processed chars */
+                return SCPE_ARG;            /* unknown input, argument error */
+            if (data > 0x7f)                /* address is 0-7f (0-127) */
+                return SCPE_ARG;            /* argument error */
+            dev |= (data & 0x7f) << 8;      /* insert the physical address */
+            cp += 2;                        /* skip the 2 processed chars */
             if (get_2hex(cp, &data) != SCPE_OK) /* get the starting sub address 0-ff (255) */
-                return SCPE_ARG;        /* unknown input, argument error */
-            if (data > 0x7f)            /* sub address is 0-ff (0-256) */
-                return SCPE_ARG;        /* argument error */
-            if ((cls & 0xf) != 0xf)     /* sub addr must be zero for class F */
-                dev |= (data & 0xff);   /* insert the starting sub address for non f class */
-            SPAD[sa] = dev;             /* put the first device entry into the spad */
+                return SCPE_ARG;            /* unknown input, argument error */
+            if (data > 0x7f)                /* sub address is 0-ff (0-256) */
+                return SCPE_ARG;            /* argument error */
+            if ((cls & 0xf) != 0xf)         /* sub addr must be zero for class F */
+                dev |= (data & 0xff);       /* insert the starting sub address for non f class */
+            SPAD[sa] = dev;                 /* put the first device entry into the spad */
             /* see if there is an optional device count for class 'E' I/O */
             if ((cls & 0xf) == 0xe) {
-                cp += 2;                /* skip the 2 processed chars */
-                if (*cp++ == ',') {     /* must have comma if optional parameters */
+                cp += 2;                    /* skip the 2 processed chars */
+                if (*cp++ == ',') {         /* must have comma if optional parameters */
                     /* check for optional sub addr cnt */
                     if (get_2hex(cp, &data) != SCPE_OK) /* get the count */
-                        return SCPE_ARG;        /* unknown input, argument error */
-                    if (data > 0x10)            /* sub address is max of 16 */
-                        return SCPE_ARG;        /* argument error */
+                        return SCPE_ARG;    /* unknown input, argument error */
+                    if (data > 0x10)        /* sub address is max of 16 */
+                        return SCPE_ARG;    /* argument error */
                     for (i=0; i<data-1; i++) {  /* 1st is already stored, redice cnt by 1 */
                         /* each of the devices will share the same interrupt */
-                        SPAD[++sa] = ++dev;     /* put next device entry in spad for the controller */
+                        SPAD[++sa] = ++dev; /* put next device entry in spad for the controller */
                     }   /* done with 'E' class device with multiple devices */
                 }
             }   /* done with device entry */
@@ -454,10 +455,10 @@ t_stat load_icl(FILE *fileref)
             */
 /* TODO call function here to create 32/7x IVL location for interrupt */
 /* if (CPU_MODEL < MODEL_27) get_IVL(intr, &ivl); */
-            sa = intr + 0x80;           /* interrupt entry spad address is int# + 0x80 */
-            ivl = (intr << 2) + 0x100;  /* default IVL base is 0x100 for Concept machines */
-            intr = (intr << 16) | ivl;  /* combine int level and ivl */
-            SPAD[sa] = intr;            /* put the device interrupt entry into the spad */
+            sa = intr + 0x80;               /* interrupt entry spad address is int# + 0x80 */
+            ivl = (intr << 2) + 0x100;      /* default IVL base is 0x100 for Concept machines */
+            intr = (intr << 16) | ivl;      /* combine int level and ivl */
+            SPAD[sa] = intr;                /* put the device interrupt entry into the spad */
         }
         else
         if(sim_strncasecmp(cp, "INT", 3) == 0) {
@@ -469,30 +470,30 @@ t_stat load_icl(FILE *fileref)
             */
             for(cp += 3; *cp == ' ' || *cp == '\t'; cp++);  /* skip white spaces */
             if (get_2hex(cp, &intr) != SCPE_OK) /* get the interrupt level value */
-                return SCPE_ARG;        /* unknown input, argument error */
-            if (intr > 0x6f)            /* ints are 0-6f (0-111) */
-                return SCPE_ARG;        /* argument error */
-            sa = intr + 0x80;           /* interrupt entry spad address is int# + 0x80 */
+                return SCPE_ARG;            /* unknown input, argument error */
+            if (intr > 0x6f)                /* ints are 0-6f (0-111) */
+                return SCPE_ARG;            /* argument error */
+            sa = intr + 0x80;               /* interrupt entry spad address is int# + 0x80 */
 /* TODO call function here to create 32/7x IVL location for interrupt */
 /* if (CPU_MODEL < MODEL_27) get_IVL(intr, &ivl); */
-            ivl = (intr << 2) + 0x100;  /* default IVL base is 0x100 for Concept machines */
-            cp += 2;                    /* skip the 2 processed chars */
-            if (*cp++ != '=')           /* must have = sign */
-                return SCPE_ARG;        /* unknown input, argument error */
+            ivl = (intr << 2) + 0x100;      /* default IVL base is 0x100 for Concept machines */
+            cp += 2;                        /* skip the 2 processed chars */
+            if (*cp++ != '=')               /* must have = sign */
+                return SCPE_ARG;            /* unknown input, argument error */
             if (get_2hex(cp, &data) != SCPE_OK)
-                return SCPE_ARG;        /* unknown input, argument error */
+                return SCPE_ARG;            /* unknown input, argument error */
             /* first digit is 3 ls bits of RTOM addr 0x79 is 001 */
             intr = 0x00800000 | ((data & 0x70) << 16);  /* put the RTOM 3 LSBs into entry */
             /* second digit is subaddress on RTOM board for interrupt connection, ~6 = 9 */
-            intr |= (data & 0xf) << 16; /* put in 1's comp of RTOM subaddress */
+            intr |= (data & 0xf) << 16;     /* put in 1's comp of RTOM subaddress */
             /* add in the correct IVL for 32/7x or concelt machines */
-            intr |= ivl;                /* set the IVL location */
-            SPAD[sa] = intr;            /* put the interrupt entry into the spad */
+            intr |= ivl;                    /* set the IVL location */
+            SPAD[sa] = intr;                /* put the interrupt entry into the spad */
         }
         else
-            return SCPE_ARG;            /* unknown input, argument error */
+            return SCPE_ARG;                /* unknown input, argument error */
     }
-    return SCPE_OK;                     /* file done */
+    return SCPE_OK;                         /* file done */
 }
 
 
@@ -513,42 +514,42 @@ t_stat sim_load (FILE *fileref, CONST char *cptr, CONST char *fnam, int flag)
 {
     int32 fmt;
 
-    fmt = FMT_NONE;                     /* no format */
+    fmt = FMT_NONE;                         /* no format */
     /* match the extension to .mem for this file */
     if (match_ext(fnam, "MEM"))
-        fmt = FMT_MEM;                  /* we have binary format */
+        fmt = FMT_MEM;                      /* we have binary format */
     else
 #ifdef NO_TAP_FOR_NOW
     if (match_ext(fnam, "TAP"))
-        fmt = FMT_TAP;                  /* we have tap tape format */
+        fmt = FMT_TAP;                      /* we have tap tape format */
     else
 #endif
     /* match the extension to .icl for this file */
     if (match_ext(fnam, "ICL"))
-        fmt = FMT_ICL;                  /* we have initial configuration load (ICL) format */
+        fmt = FMT_ICL;                      /* we have initial configuration load (ICL) format */
     else
-        return SCPE_FMT;                /* format error */
+        return SCPE_FMT;                    /* format error */
 
     switch (fmt) {
 
-    case FMT_MEM:                       /* binary memory image */
+    case FMT_MEM:                           /* binary memory image */
         return load_mem(fileref);
 
 #ifdef NO_TAP_FOR_NOW
-    case FMT_TAP:                       /* tape file image */
+    case FMT_TAP:                           /* tape file image */
         return load_tap(fileref);
 #endif
 
-    case FMT_ICL:                       /* icl file image */
+    case FMT_ICL:                           /* icl file image */
         return load_icl(fileref);
 
 #ifdef NO_TAP_FOR_NOW
-    case FMT_NONE:                      /* nothing */
+    case FMT_NONE:                          /* nothing */
 #endif
     default:
         break;
     }
-    return SCPE_FMT;                    /* format error */
+    return SCPE_FMT;                        /* format error */
 }
 
 /* Symbol tables */
@@ -556,21 +557,21 @@ t_stat sim_load (FILE *fileref, CONST char *cptr, CONST char *fnam, int flag)
 /*
  * The SEL 32 supports the following instruction formats.
  * 
- * TYPE         Format   Normal          Base Mode
- *  A           ADR      d,[*]o,x        d,o[(b)],x  FC = extra
- *  B           BRA      [*]o,x          o[(b)],x
- *  C           IMM      d,o             d,o
- *  D           BIT      d,[*]o          d,o[(b)]
- *  E           ADR      [*]o,x          o[(b)],x  FC = extra
+ * TYPE     Format   Normal     Base Mode
+ *  A       ADR      d,[*]o,x   d,o[(b)],x  FC = extra
+ *  B       BRA      [*]o,x     o[(b)],x
+ *  C       IMM      d,o        d,o
+ *  D       BIT      d,[*]o     d,o[(b)]
+ *  E       ADR      [*]o,x     o[(b)],x  FC = extra
  *  HALFWORD
- *  F           REG      s,d             s,d           Half Word
- *  G           RG1      s               s
- *  H           HLF
- *  I           SHF      d,v             d,v
- *  K           RBT      d,b             d,b
- *  L           EXR      s               s
- *  M           IOP      n,b             n,b  
- *  N           SVC      n,b             n,b  
+ *  F       REG      s,d        s,d         Half Word
+ *  G       RG1      s          s
+ *  H       HLF
+ *  I       SHF      d,v        d,v
+ *  K       RBT      d,b        d,b
+ *  L       EXR      s          s
+ *  M       IOP      n,b        n,b  
+ *  N       SVC      n,b        n,b  
  */
 
 #define TYPE_A          0
@@ -586,11 +587,11 @@ t_stat sim_load (FILE *fileref, CONST char *cptr, CONST char *fnam, int flag)
 #define TYPE_L          10 
 #define TYPE_M          11 
 #define TYPE_N          12 
-#define H               0x10    /* halfword instruction */
+#define H               0x10                /* halfword instruction */
 /* all instruction unless specified as base/nobase only will be either */
-#define B               0x20    /* base register mode only */
-#define N               0x40    /* non base register mode only */
-#define X               0x80    /* 32/55 or 32/75 only */
+#define B               0x20                /* base register mode only */
+#define N               0x40                /* non base register mode only */
+#define X               0x80                /* 32/55 or 32/75 only */
 
 typedef struct _opcode {
        uint16       opbase;
@@ -599,212 +600,210 @@ typedef struct _opcode {
        const char   *name;
 } t_opcode;
 
-
 t_opcode  optab[] = {
-    {  0x0000,      0xFFFF,   H|TYPE_H,   "HALT", },     /* Halt # * */
-    {  0x0001,      0xFFFF,   H|TYPE_H,   "WAIT", },     /* Wait # * */
-    {  0x0002,      0xFFFF,   H|TYPE_H,   "NOP", },      /* Nop # */
-    {  0x0003,      0xFC0F,   H|TYPE_G,   "LCS", },      /* Load Control Switches */
-    {  0x0004,      0xFC0F,   H|TYPE_G,   "ES", },       /* Extend Sign # */
-    {  0x0005,      0xFC0F,   H|TYPE_G,   "RND", },      /* Round Register # */
-    {  0x0006,      0xFFFF,   H|TYPE_H,   "BEI", },      /* Block External Interrupts # */
-    {  0x0007,      0xFFFF,   H|TYPE_H,   "UEI", },      /* Unblock External Interrupts # */
-    {  0x0008,      0xFFFF,   H|TYPE_H,   "EAE", },      /* Enable Arithmetic Exception Trap # */
-    {  0x0009,      0xFC0F,   H|TYPE_G,   "RDSTS", },    /* Read CPU Status Word * */
-    {  0x000A,      0xFFFF,   H|TYPE_H,   "SIPU", },     /* Signal IPU # */
-    {  0x000B,      0xFC0F,   H|TYPE_F,   "RWCS", },     /* Read Writable Control Store # */
-    {  0x000C,      0xFC0F,   H|TYPE_F,   "WWCS", },     /* Write Writable Control Store # */
-    {  0x000D,      0xFFFF, N|H|TYPE_H,   "SEA", },      /* Set Extended Addressing # NBR Only */
-    {  0x000E,      0xFFFF,   H|TYPE_H,   "DAE", },      /* Disable Arithmetic Exception Trap # */
-    {  0x000F,      0xFFFF, N|H|TYPE_H,   "CEA", },      /* Clear Extended Addressing # NBR Only */
-    {  0x0400,      0xFC0F,   H|TYPE_F,   "ANR", },      /* And Register # */
-    {  0x0407,      0xFC0F,   H|TYPE_G,   "SMC", },      /* Shared Memory Control # */
-    {  0x040A,      0xFC0F,   H|TYPE_G,   "CMC", },      /* Cache Memory Control # */
-    {  0x040B,      0xFC0F,   H|TYPE_G,   "RPSWT", },    /* Read Processor Status Word Two # */
-    {  0x0800,      0xFC0F,   H|TYPE_F,   "ORR", },      /* Or Register # */
-    {  0x0808,      0xFC0F,   H|TYPE_F,   "ORRM", },     /* Or Register Masked # */
-    {  0x0C00,      0xFC0F,   H|TYPE_F,   "EOR", },      /* Exclusive Or Register # */
-    {  0x0C08,      0xFC0F,   H|TYPE_F,   "EORM", },     /* Exclusive Or Register Masked # */
-    {  0x1000,      0xFC0F,   H|TYPE_F,   "CAR", },      /* Compare Arithmetic Register # */
-    {  0x1008,      0xFC0F, B|H|TYPE_F,   "SACZ", },     /* Shift and Count Zeros # BR */
-    {  0x1400,      0xFC0F,   H|TYPE_F,   "CMR", },      /* Compare masked with register */
-    {  0x1800,      0xFC0C,   H|TYPE_K,   "SBR", },      /* Set Bit in Register # */
-    {  0x1804,      0xFC0C, B|H|TYPE_K,   "ZBR", },      /* Zero Bit In register # BR */
-    {  0x1808,      0xFC0C, B|H|TYPE_K,   "ABR", },      /* Add Bit In Register # BR */
-    {  0x180C,      0xFC0C, B|H|TYPE_K,   "TBR", },      /* Test Bit in Register # BR */
-    {  0x1C00,      0xFC0C, N|H|TYPE_K,   "ZBR", },      /* Zero Bit in Register # NBR */ /* CON SRABR */
-    {  0x1C00,      0xFC60, B|H|TYPE_I,   "SRABR", },    /* Shift Right Arithmetic # BR */ /* CON ZBM */
-    {  0x1C20,      0xFC60, B|H|TYPE_I,   "SRLBR", },    /* Shift Right Logical # BR */
-    {  0x1C40,      0xFC60, B|H|TYPE_I,   "SLABR", },    /* Shift Left Arithmetic # BR */
-    {  0x1C60,      0xFC60, B|H|TYPE_I,   "SLLBR", },    /* Shift Left Logical # BR */
-    {  0x2000,      0xFC0C, N|H|TYPE_K,   "ABR", },      /* Add Bit in Register # NBR */ /* CON SRADBR */
-    {  0x2000,      0xFC60, B|H|TYPE_I,   "SRADBR", },   /* Shift Right Arithmetic Double # BR */ /* CON ABR */
-    {  0x2020,      0xFC60, B|H|TYPE_I,   "SRLDBR", },   /* Shift Left Logical Double # BR */
-    {  0x2040,      0xFC60, B|H|TYPE_I,   "SLADBR", },   /* Shift Right Arithmetic Double # BR */
-    {  0x2060,      0xFC60, B|H|TYPE_I,   "SLLDBR", },   /* Shift Left Logical Double # BR */
-    {  0x2400,      0xFC0C, N|H|TYPE_K,   "TBR", },      /* Test Bit in Register # NBR */ /* CON SRCBR */
-    {  0x2400,      0xFC60, B|H|TYPE_I,   "SRCBR", },    /* Shift Right Circular # BR */ /* CON TBR */
-    {  0x2440,      0xFC60, B|H|TYPE_F,   "SLCBR", },    /* Shift Left Circular # BR */
-    {  0x2800,      0xFC0F,   H|TYPE_G,   "TRSW", },     /* Transfer GPR to PSD */
-    {  0x2802,      0xFC0F, B|H|TYPE_F,   "XCBR", },     /* Exchange Base Registers # BR Only */
-    {  0x2804,      0xFC0F, B|H|TYPE_G,   "TCCR", },     /* Transfer CC to GPR # BR Only */
-    {  0x2805,      0xFC0F, B|H|TYPE_G,   "TRCC", },     /* Transfer GPR to CC # BR */
-    {  0x2808,      0xFF8F, B|H|TYPE_F,   "BSUB", },     /* Branch Subroutine # BR Only */
-    {  0x2808,      0xFC0F, B|H|TYPE_F,   "CALL", },     /* Procedure Call # BR Only */
-    {  0x280C,      0xFC0F, B|H|TYPE_G,   "TPCBR", },    /* Transfer Program Counter to Base # BR Only */
-    {  0x280E,      0xFC7F, B|H|TYPE_G,   "RETURN", },   /* Procedure Return # BR Only */
-    {  0x2C00,      0xFC0F,   H|TYPE_F,   "TRR", },      /* Transfer Register to Register # */
-    {  0x2C01,      0xFC0F, B|H|TYPE_F,   "TRBR", },     /* Transfer GPR to BR # */
-    {  0x2C02,      0xFC0F, B|H|TYPE_F,   "TBRR", },     /* Transfer BR to GPR # BR Only */
-    {  0x2C03,      0xFC0F,   H|TYPE_F,   "TRC", },      /* Transfer Register Complement # */
-    {  0x2C04,      0xFC0F,   H|TYPE_F,   "TRN", },      /* Transfer Register Negative # */
-    {  0x2C05,      0xFC0F,   H|TYPE_F,   "XCR", },      /* Exchange Registers # */
-    {  0x2C07,      0xFC0F,   H|TYPE_G,   "LMAP", },     /* Load MAP * */
-    {  0x2C08,      0xFC0F,   H|TYPE_F,   "TRRM", },     /* Transfer Register to Register Masked # */
-    {  0x2C09,      0xFC0F,   H|TYPE_G,   "SETCPU", },   /* Set CPU Mode # * */
-    {  0x2C0A,      0xFC0F,   H|TYPE_F,   "TMAPR", },    /* Transfer MAP to Register # * */
-    {  0x2C0B,      0xFC0F,   H|TYPE_F,   "TRCM", },     /* Transfer Register Complement Masked # */
-    {  0x2C0C,      0xFC0F,   H|TYPE_F,   "TRNM", },     /* Transfer Register Negative Masked # */
-    {  0x2C0D,      0xFC0F,   H|TYPE_F,   "XCRM", },     /* Exchange Registers Masked # */
-    {  0x2C0E,      0xFC0F,   H|TYPE_F,   "TRSC", },     /* Transfer Register to Scratchpad # * */
-    {  0x2C0F,      0xFC0F,   H|TYPE_F,   "TSCR", },     /* Transfer Scratchpad to Register # * */
-    {  0x3000,      0xFC0F, X|H|TYPE_F,   "CALM", },     /* Call Monitor 32/55 # */
-    {  0x3400,      0xFC00,   N|TYPE_D,   "LA", },       /* Load Address NBR Note! FW instruction */
-    {  0x3800,      0xFC0F,   H|TYPE_F,   "ADR", },      /* Add Register to Register # */
-    {  0x3801,      0xFC0F,   H|TYPE_F,   "ADRFW", },    /* Add Floating Point to Register # */
-    {  0x3802,      0xFC0F, B|H|TYPE_F,   "MPR", },      /* Multiply Register BR # */
-    {  0x3803,      0xFC0F,   H|TYPE_F,   "SURFW", },    /* Subtract Floating Point Register # */
-    {  0x3804,      0xFC0F,   H|TYPE_F,   "DVRFW", },    /* Divide Floating Point Register # */
-    {  0x3805,      0xFC0F,   H|TYPE_F,   "FIXW", },     /* Fix Floating Point Register # */
-    {  0x3806,      0xFC0F,   H|TYPE_F,   "MPRFW", },    /* Multiply Floating Point Register # */
-    {  0x3807,      0xFC0F,   H|TYPE_F,   "FLTW", },     /* Float Floating Point Register # */
-    {  0x3808,      0xFC0F,   H|TYPE_F,   "ADRM", },     /* Add Register to Register Masked # */
-    {  0x3809,      0xFC0F,   H|TYPE_F,   "ADRFD", },    /* Add Floating Point Register to Register # */
-    {  0x380A,      0xFC0F, B|H|TYPE_F,   "DVR", },      /* Divide Register by Registier BR # */
-    {  0x380B,      0xFC0F,   H|TYPE_F,   "SURFD", },    /* Subtract Floating Point Double # */
-    {  0x380C,      0xFC0F,   H|TYPE_F,   "DVRFD", },    /* Divide Floating Point Double # */
-    {  0x380D,      0xFC0F,   H|TYPE_F,   "FIXD", },     /* Fix Double Register # */
-    {  0x380E,      0xFC0F,   H|TYPE_F,   "MPRFD", },    /* Multiply Double Register # */
-    {  0x380F,      0xFC0F,   H|TYPE_F,   "FLTD", },     /* Float Double # */
-    {  0x3C00,      0xFC0F,   H|TYPE_F,   "SUR", },      /* Subtract Register to Register # */
-    {  0x3C08,      0xFC0F,   H|TYPE_F,   "SURM", },     /* Subtract Register to Register Masked # */
-    {  0x4000,      0xFC0F, N|H|TYPE_F,   "MPR", },      /* Multiply Register to Register # NBR */
-    {  0x4400,      0xFC0F, N|H|TYPE_F,   "DVR", },      /* Divide Register to Register # NBR */
-    {  0x5000,      0xFC08,   B|TYPE_D,   "LABRM", },    /* Load Address BR Mode */
-    {  0x5400,      0xFC08,   B|TYPE_A,   "STWBR", },    /* Store Base Register BR Only */
-    {  0x5800,      0xFC08,   B|TYPE_A,   "SUABR", },    /* Subtract Base Register BR Only */
-    {  0x5808,      0xFC08,   B|TYPE_D,   "LABR", },     /* Load Address Base Register BR Only */
-    {  0x5C00,      0xFC08,   B|TYPE_A,   "LWBR", },     /* Load Base Register BR Only */
-    {  0x5C08,      0xFF88,   B|TYPE_B,   "BSUBM", },    /* Branch Subroutine Memory BR Only */
-    {  0x5C08,      0xFC08,   B|TYPE_B,   "CALLM", },    /* Call Memory BR Only */
-    {  0x6000,      0xFC0F, N|H|TYPE_F,   "NOR", },      /* Normalize # NBR Only */
-    {  0x6400,      0xFC0F, N|H|TYPE_F,   "NORD", },     /* Normalize Double #  NBR Only */
-    {  0x6800,      0xFC0F, N|H|TYPE_F,   "SCZ", },      /* Shift and Count Zeros # */
-    {  0x6C00,      0xFC40, N|H|TYPE_I,   "SRA", },      /* Shift Right Arithmetic # NBR */
-    {  0x6C40,      0xFC40, N|H|TYPE_I,   "SLA", },      /* Shift Left Arithmetic # NBR */
-    {  0x7000,      0xFC40, N|H|TYPE_I,   "SRL", },      /* Shift Right Logical # NBR */
-    {  0x7040,      0xFC40, N|H|TYPE_I,   "SLL", },      /* Shift Left Logical # NBR */
-    {  0x7400,      0xFC40, N|H|TYPE_I,   "SRC", },      /* Shift Right Circular # NBR */
-    {  0x7440,      0xFC40, N|H|TYPE_I,   "SLC", },      /* Shift Left Circular # NBR */
-    {  0x7800,      0xFC40, N|H|TYPE_I,   "SRAD", },     /* Shift Right Arithmetic Double # NBR */
-    {  0x7840,      0xFC40, N|H|TYPE_I,   "SLAD", },     /* Shift Left Arithmetic Double # NBR */
-    {  0x7C00,      0xFC40, N|H|TYPE_I,   "SRLD", },     /* Shift Right Logical Double # NBR */
-    {  0x7C40,      0xFC40, N|H|TYPE_I,   "SLLD", },     /* Shift Left Logical Double # NBR */
-    {  0x8000,      0xFC08,   TYPE_A,     "LEAR", },     /* Load Effective Address Real * */
-    {  0x8400,      0xFC00,   TYPE_A,     "ANM", },      /* And Memory B,H,W,D */
-    {  0x8800,      0xFC00,   TYPE_A,     "ORM", },      /* Or Memory B,H,W,D */
-    {  0x8C00,      0xFC00,   TYPE_A,     "EOM", },      /* Exclusive Or Memory */
-    {  0x9000,      0xFC00,   TYPE_A,     "CAM", },      /* Compare Arithmetic with Memory */
-    {  0x9400,      0xFC00,   TYPE_A,     "CMM", },      /* Compare Masked with Memory */
-    {  0x9800,      0xFC00,   TYPE_D,     "SBM", },      /* Set Bit in Memory */
-    {  0x9C00,      0xFC00,   TYPE_D,     "ZBM", },      /* Zero Bit in Memory */
-    {  0xA000,      0xFC00,   TYPE_D,     "ABM", },      /* Add Bit in Memory */
-    {  0xA400,      0xFC00,   TYPE_D,     "TBM", },      /* Test Bit in Memory */
-    {  0xA800,      0xFC00,   TYPE_B,     "EXM", },      /* Execute Memory */
-    {  0xAC00,      0xFC00,   TYPE_A,     "L", },        /* Load B,H,W,D */
-    {  0xB000,      0xFC00,   TYPE_A,     "LM", },       /* Load Masked B,H,W,D */
-    {  0xB400,      0xFC00,   TYPE_A,     "LN", },       /* Load Negative B,H,W,D */
-    {  0xB800,      0xFC00,   TYPE_A,     "ADM", },      /* Add Memory B,H,W,D */
-    {  0xBC00,      0xFC00,   TYPE_A,     "SUM", },      /* Subtract Memory B,H,W,D */
-    {  0xC000,      0xFC00,   TYPE_A,     "MPM", },      /* Multiply Memory B,H,W,D */
-    {  0xC400,      0xFC00,   TYPE_A,     "DVM", },      /* Divide Memory B,H,W,D */
-    {  0xC800,      0xFC0F,   TYPE_C,     "LI", },       /* Load Immediate */
-    {  0xC801,      0xFC0F,   TYPE_C,     "ADI", },      /* Add Immediate */
-    {  0xC802,      0xFC0F,   TYPE_C,     "SUI", },      /* Subtract Immediate */
-    {  0xC803,      0xFC0F,   TYPE_C,     "MPI", },      /* Multiply Immediate */
-    {  0xC804,      0xFC0F,   TYPE_C,     "DVI", },      /* Divide Immediate */
-    {  0xC805,      0xFC0F,   TYPE_C,     "CI", },       /* Compare Immediate */
-    {  0xC806,      0xFC0F,   TYPE_N,     "SVC", },      /* Supervisor Call */
-    {  0xC807,      0xFC0F,   TYPE_G,     "EXR", },      /* Execute Register/ Right */
-    {  0xC808,      0xFC0F, X|TYPE_A,     "SEM", },      /* Store External Map 32/7X * */
-    {  0xC809,      0xFC0F, X|TYPE_A,     "LEM", },      /* Load External Map 32/7X * */
-    {  0xC80A,      0xFC0F, X|TYPE_A,     "CEMA", },     /* Convert External Map 32/7X * */
-    {  0xCC00,      0xFC08,   TYPE_A,     "LF", },       /* Load File */
-    {  0xCC08,      0xFC08,   TYPE_A,     "LFBR", },     /* Load Base File */
-    {  0xD000,      0xFC00, N|TYPE_A,     "LEA", },      /* Load Effective Address # NBR */
-    {  0xD400,      0xFC00,   TYPE_A,     "ST", },       /* Store B,H,W,D */
-    {  0xD800,      0xFC00,   TYPE_A,     "STM", },      /* Store Masked B,H,W,D */
-    {  0xDC00,      0xFC08,   TYPE_A,     "STF", },      /* Store File */
-    {  0xDC08,      0xFC08,   TYPE_A,     "STFBR", },    /* Store Base File */
-    {  0xE000,      0xFC08,   TYPE_A,     "SUF", },      /* Subtract Floating Memory D,W */
-    {  0xE008,      0xFC08,   TYPE_A,     "ADF", },      /* Add Floating Memory D,W */
-    {  0xE400,      0xFC08,   TYPE_A,     "DVF", },      /* Divide Floating Memory D,W */
-    {  0xE408,      0xFC08,   TYPE_A,     "MPF", },      /* Multiply Floating Memory D,W */
-    {  0xE800,      0xFC00,   TYPE_A,     "ARM", },      /* Add Register to Memory B,H,W,D */
-    {  0xEC00,      0xFF80,   TYPE_B,     "BU", },       /* Branch Unconditional */
-    {  0xEC00,      0xFF80,   TYPE_A,     "BCT", },      /* Branch Condition True */
-    {  0xEC80,      0xFF80,   TYPE_B,     "BS", },       /* Branch Condition True CC1 = 1 */
-    {  0xED00,      0xFF80,   TYPE_B,     "BGT", },      /* Branch Condition True CC2 = 1 */
-    {  0xED80,      0xFF80,   TYPE_B,     "BLT", },      /* Branch Condition True CC3 = 1 */
-    {  0xEE00,      0xFF80,   TYPE_B,     "BEQ", },      /* Branch Condition True CC4 = 1 */
-    {  0xEE80,      0xFF80,   TYPE_B,     "BGE", },      /* Branch Condition True CC2|CC4 = 1 */
-    {  0xEF00,      0xFF80,   TYPE_B,     "BLE", },      /* Branch Condition True CC3|CC4 = 1 */
-    {  0xEF80,      0xFF80,   TYPE_B,     "BANY", },     /* Branch Condition True CC1|CC2|CC3|CC4 */
-    {  0xF000,      0XFF80,   TYPE_B,     "BFT", },      /* Branch Function True */
-    {  0xF000,      0xFF80,   TYPE_A,     "BCF", },      /* Branch Condition False */
-    {  0xF080,      0xFF80,   TYPE_B,     "BNS", },      /* Branch Condition False CC1 = 0 */
-    {  0xF100,      0xFF80,   TYPE_B,     "BNP", },      /* Branch Condition False CC2 = 0 */
-    {  0xF180,      0xFF80,   TYPE_B,     "BNN", },      /* Branch Condition False CC3 = 0 */
-    {  0xF200,      0xFF80,   TYPE_B,     "BNE", },      /* Branch Condition False CC4 = 0 */
-    {  0xF280,      0xFF80,   TYPE_B,     "BCF 5,", },   /* Branch Condition False CC2|CC4 = 0 */
-    {  0xF300,      0xFF80,   TYPE_B,     "BCF 6,", },   /* Branch Condition False CC3|CC4 = 0 */
-    {  0xF380,      0xFF80,   TYPE_B,     "BAZ", },      /* Branch Condition False CC1|CC2|CC3|CC4=0*/
-    {  0xF400,      0xFC70,   TYPE_D,     "BIB", },      /* Branch after Incrementing Byte */
-    {  0xF420,      0xFC70,   TYPE_D,     "BIH", },      /* Branch after Incrementing Half */
-    {  0xF440,      0xFC70,   TYPE_D,     "BIW", },      /* Branch after Incrementing Word */
-    {  0xF460,      0xFC70,   TYPE_D,     "BID", },      /* Branch after Incrementing Double */
-    {  0xF800,      0xFF80,   TYPE_E,     "ZM", },       /* Zero Memory B,H,W,D */
-    {  0xF880,      0xFF80,   TYPE_B,     "BL", },       /* Branch and Link */
-    {  0xF900,      0xFCC0, X|TYPE_B,     "BRI", },      /* Branch and Reset Interrupt 32/55 * */
-    {  0xF980,      0xFF80,   TYPE_B,     "LPSD", },     /* Load Program Status Double * */
-    {  0xFA08,      0xFC00,   TYPE_B,     "JWCS", },     /* Jump to Writable Control Store * */
-    {  0xFA80,      0xFF80,   TYPE_B,     "LPSDCM", },   /* LPSD and Change Map * */
-    {  0xFB00,      0xFCC0, X|TYPE_A,     "TRP", },      /* Transfer Register to Protect Register 32/7X */
-    {  0xFB80,      0xFCC0, X|TYPE_A,     "TPR", },      /* Transfer Protect Register to Register 32/7X */
-    {  0xFC00,      0xFC07,   TYPE_L,     "EI", },       /* Enable Interrupt */
-    {  0xFC01,      0xFC07,   TYPE_L,     "DI", },       /* Disable Interrupt */
-    {  0xFC02,      0xFC07,   TYPE_L,     "RI", },       /* Request Interrupt */
-    {  0xFC03,      0xFC07,   TYPE_L,     "AI", },       /* Activate Interrupt */
-    {  0xFC04,      0xFC07,   TYPE_L,     "DAI", },      /* Deactivate Interrupt */
-    {  0xFC05,      0xFC07,   TYPE_M,     "TD", },       /* Test Device */
-    {  0xFC06,      0xFC07,   TYPE_M,     "CD", },       /* Command Device */
-    {  0xFC17,      0xFC7F,   TYPE_C,     "SIO", },      /* Start I/O */
-    {  0xFC1F,      0xFC7F,   TYPE_C,     "TIO", },      /* Test I/O */
-    {  0xFC27,      0xFC7F,   TYPE_C,     "STPIO", },    /* Stop I/O */
-    {  0xFC2F,      0xFC7F,   TYPE_C,     "RSCHNL", },   /* Reset Channel */
-    {  0xFC37,      0xFC7F,   TYPE_C,     "HIO", },      /* Halt I/O */
-    {  0xFC3F,      0xFC7F,   TYPE_C,     "GRIO", },     /* Grab Controller */
-    {  0xFC47,      0xFC7F,   TYPE_C,     "RSCTL", },    /* Reset Controller */
-    {  0xFC4F,      0xFC7F,   TYPE_C,     "ECWCS", },    /* Enable Channel WCS Load */
-    {  0xFC5F,      0xFC7F,   TYPE_C,     "WCWCS", },    /* Write Channel WCS */
-    {  0xFC67,      0xFC7F,   TYPE_C,     "ECI", },      /* Enable Channel Interrupt */
-    {  0xFC6F,      0xFC7F,   TYPE_C,     "DCI", },      /* Disable Channel Interrupt */
-    {  0xFC77,      0xFC7F,   TYPE_C,     "ACI", },      /* Activate Channel Interrupt */
-    {  0xFC7F,      0xFC7F,   TYPE_C,     "DACI", },     /* Deactivate Channel Interrupt */
+    {  0x0000,  0xFFFF,   H|TYPE_H,   "HALT", },    /* Halt # * */
+    {  0x0001,  0xFFFF,   H|TYPE_H,   "WAIT", },    /* Wait # * */
+    {  0x0002,  0xFFFF,   H|TYPE_H,   "NOP", },     /* Nop # */
+    {  0x0003,  0xFC0F,   H|TYPE_G,   "LCS", },     /* Load Control Switches */
+    {  0x0004,  0xFC0F,   H|TYPE_G,   "ES", },      /* Extend Sign # */
+    {  0x0005,  0xFC0F,   H|TYPE_G,   "RND", },     /* Round Register # */
+    {  0x0006,  0xFFFF,   H|TYPE_H,   "BEI", },     /* Block External Interrupts # */
+    {  0x0007,  0xFFFF,   H|TYPE_H,   "UEI", },     /* Unblock External Interrupts # */
+    {  0x0008,  0xFFFF,   H|TYPE_H,   "EAE", },     /* Enable Arithmetic Exception Trap # */
+    {  0x0009,  0xFC0F,   H|TYPE_G,   "RDSTS", },   /* Read CPU Status Word * */
+    {  0x000A,  0xFFFF,   H|TYPE_H,   "SIPU", },    /* Signal IPU # */
+    {  0x000B,  0xFC0F,   H|TYPE_F,   "RWCS", },    /* Read Writable Control Store # */
+    {  0x000C,  0xFC0F,   H|TYPE_F,   "WWCS", },    /* Write Writable Control Store # */
+    {  0x000D,  0xFFFF, N|H|TYPE_H,   "SEA", },     /* Set Extended Addressing # NBR Only */
+    {  0x000E,  0xFFFF,   H|TYPE_H,   "DAE", },     /* Disable Arithmetic Exception Trap # */
+    {  0x000F,  0xFFFF, N|H|TYPE_H,   "CEA", },     /* Clear Extended Addressing # NBR Only */
+    {  0x0400,  0xFC0F,   H|TYPE_F,   "ANR", },     /* And Register # */
+    {  0x0407,  0xFC0F,   H|TYPE_G,   "SMC", },     /* Shared Memory Control # */
+    {  0x040A,  0xFC0F,   H|TYPE_G,   "CMC", },     /* Cache Memory Control # */
+    {  0x040B,  0xFC0F,   H|TYPE_G,   "RPSWT", },   /* Read Processor Status Word Two # */
+    {  0x0800,  0xFC0F,   H|TYPE_F,   "ORR", },     /* Or Register # */
+    {  0x0808,  0xFC0F,   H|TYPE_F,   "ORRM", },    /* Or Register Masked # */
+    {  0x0C00,  0xFC0F,   H|TYPE_F,   "EOR", },     /* Exclusive Or Register # */
+    {  0x0C08,  0xFC0F,   H|TYPE_F,   "EORM", },    /* Exclusive Or Register Masked # */
+    {  0x1000,  0xFC0F,   H|TYPE_F,   "CAR", },     /* Compare Arithmetic Register # */
+    {  0x1008,  0xFC0F, B|H|TYPE_F,   "SACZ", },    /* Shift and Count Zeros # BR */
+    {  0x1400,  0xFC0F,   H|TYPE_F,   "CMR", },     /* Compare masked with register */
+    {  0x1800,  0xFC0C,   H|TYPE_K,   "SBR", },     /* Set Bit in Register # */
+    {  0x1804,  0xFC0C, B|H|TYPE_K,   "ZBR", },     /* Zero Bit In register # BR */
+    {  0x1808,  0xFC0C, B|H|TYPE_K,   "ABR", },     /* Add Bit In Register # BR */
+    {  0x180C,  0xFC0C, B|H|TYPE_K,   "TBR", },     /* Test Bit in Register # BR */
+    {  0x1C00,  0xFC0C, N|H|TYPE_K,   "ZBR", },     /* Zero Bit in Register # NBR */ /* CON SRABR */
+    {  0x1C00,  0xFC60, B|H|TYPE_I,   "SRABR", },   /* Shift Right Arithmetic # BR */ /* CON ZBM */
+    {  0x1C20,  0xFC60, B|H|TYPE_I,   "SRLBR", },   /* Shift Right Logical # BR */
+    {  0x1C40,  0xFC60, B|H|TYPE_I,   "SLABR", },   /* Shift Left Arithmetic # BR */
+    {  0x1C60,  0xFC60, B|H|TYPE_I,   "SLLBR", },   /* Shift Left Logical # BR */
+    {  0x2000,  0xFC0C, N|H|TYPE_K,   "ABR", },     /* Add Bit in Register # NBR */ /* CON SRADBR */
+    {  0x2000,  0xFC60, B|H|TYPE_I,   "SRADBR", },  /* Shift Right Arithmetic Double # BR */ /* CON ABR */
+    {  0x2020,  0xFC60, B|H|TYPE_I,   "SRLDBR", },  /* Shift Left Logical Double # BR */
+    {  0x2040,  0xFC60, B|H|TYPE_I,   "SLADBR", },  /* Shift Right Arithmetic Double # BR */
+    {  0x2060,  0xFC60, B|H|TYPE_I,   "SLLDBR", },  /* Shift Left Logical Double # BR */
+    {  0x2400,  0xFC0C, N|H|TYPE_K,   "TBR", },     /* Test Bit in Register # NBR */ /* CON SRCBR */
+    {  0x2400,  0xFC60, B|H|TYPE_I,   "SRCBR", },   /* Shift Right Circular # BR */ /* CON TBR */
+    {  0x2440,  0xFC60, B|H|TYPE_F,   "SLCBR", },   /* Shift Left Circular # BR */
+    {  0x2800,  0xFC0F,   H|TYPE_G,   "TRSW", },    /* Transfer GPR to PSD */
+    {  0x2802,  0xFC0F, B|H|TYPE_F,   "XCBR", },    /* Exchange Base Registers # BR Only */
+    {  0x2804,  0xFC0F, B|H|TYPE_G,   "TCCR", },    /* Transfer CC to GPR # BR Only */
+    {  0x2805,  0xFC0F, B|H|TYPE_G,   "TRCC", },    /* Transfer GPR to CC # BR */
+    {  0x2808,  0xFF8F, B|H|TYPE_F,   "BSUB", },    /* Branch Subroutine # BR Only */
+    {  0x2808,  0xFC0F, B|H|TYPE_F,   "CALL", },    /* Procedure Call # BR Only */
+    {  0x280C,  0xFC0F, B|H|TYPE_G,   "TPCBR", },   /* Transfer Program Counter to Base # BR Only */
+    {  0x280E,  0xFC7F, B|H|TYPE_G,   "RETURN", },  /* Procedure Return # BR Only */
+    {  0x2C00,  0xFC0F,   H|TYPE_F,   "TRR", },     /* Transfer Register to Register # */
+    {  0x2C01,  0xFC0F, B|H|TYPE_F,   "TRBR", },    /* Transfer GPR to BR # */
+    {  0x2C02,  0xFC0F, B|H|TYPE_F,   "TBRR", },    /* Transfer BR to GPR # BR Only */
+    {  0x2C03,  0xFC0F,   H|TYPE_F,   "TRC", },     /* Transfer Register Complement # */
+    {  0x2C04,  0xFC0F,   H|TYPE_F,   "TRN", },     /* Transfer Register Negative # */
+    {  0x2C05,  0xFC0F,   H|TYPE_F,   "XCR", },     /* Exchange Registers # */
+    {  0x2C07,  0xFC0F,   H|TYPE_G,   "LMAP", },    /* Load MAP * */
+    {  0x2C08,  0xFC0F,   H|TYPE_F,   "TRRM", },    /* Transfer Register to Register Masked # */
+    {  0x2C09,  0xFC0F,   H|TYPE_G,   "SETCPU", },  /* Set CPU Mode # * */
+    {  0x2C0A,  0xFC0F,   H|TYPE_F,   "TMAPR", },   /* Transfer MAP to Register # * */
+    {  0x2C0B,  0xFC0F,   H|TYPE_F,   "TRCM", },    /* Transfer Register Complement Masked # */
+    {  0x2C0C,  0xFC0F,   H|TYPE_F,   "TRNM", },    /* Transfer Register Negative Masked # */
+    {  0x2C0D,  0xFC0F,   H|TYPE_F,   "XCRM", },    /* Exchange Registers Masked # */
+    {  0x2C0E,  0xFC0F,   H|TYPE_F,   "TRSC", },    /* Transfer Register to Scratchpad # * */
+    {  0x2C0F,  0xFC0F,   H|TYPE_F,   "TSCR", },    /* Transfer Scratchpad to Register # * */
+    {  0x3000,  0xFC0F, X|H|TYPE_F,   "CALM", },    /* Call Monitor 32/55 # */
+    {  0x3400,  0xFC00,   N|TYPE_D,   "LA", },      /* Load Address NBR Note! FW instruction */
+    {  0x3800,  0xFC0F,   H|TYPE_F,   "ADR", },     /* Add Register to Register # */
+    {  0x3801,  0xFC0F,   H|TYPE_F,   "ADRFW", },   /* Add Floating Point to Register # */
+    {  0x3802,  0xFC0F, B|H|TYPE_F,   "MPR", },     /* Multiply Register BR # */
+    {  0x3803,  0xFC0F,   H|TYPE_F,   "SURFW", },   /* Subtract Floating Point Register # */
+    {  0x3804,  0xFC0F,   H|TYPE_F,   "DVRFW", },   /* Divide Floating Point Register # */
+    {  0x3805,  0xFC0F,   H|TYPE_F,   "FIXW", },    /* Fix Floating Point Register # */
+    {  0x3806,  0xFC0F,   H|TYPE_F,   "MPRFW", },   /* Multiply Floating Point Register # */
+    {  0x3807,  0xFC0F,   H|TYPE_F,   "FLTW", },    /* Float Floating Point Register # */
+    {  0x3808,  0xFC0F,   H|TYPE_F,   "ADRM", },    /* Add Register to Register Masked # */
+    {  0x3809,  0xFC0F,   H|TYPE_F,   "ADRFD", },   /* Add Floating Point Register to Register # */
+    {  0x380A,  0xFC0F, B|H|TYPE_F,   "DVR", },     /* Divide Register by Registier BR # */
+    {  0x380B,  0xFC0F,   H|TYPE_F,   "SURFD", },   /* Subtract Floating Point Double # */
+    {  0x380C,  0xFC0F,   H|TYPE_F,   "DVRFD", },   /* Divide Floating Point Double # */
+    {  0x380D,  0xFC0F,   H|TYPE_F,   "FIXD", },    /* Fix Double Register # */
+    {  0x380E,  0xFC0F,   H|TYPE_F,   "MPRFD", },   /* Multiply Double Register # */
+    {  0x380F,  0xFC0F,   H|TYPE_F,   "FLTD", },    /* Float Double # */
+    {  0x3C00,  0xFC0F,   H|TYPE_F,   "SUR", },     /* Subtract Register to Register # */
+    {  0x3C08,  0xFC0F,   H|TYPE_F,   "SURM", },    /* Subtract Register to Register Masked # */
+    {  0x4000,  0xFC0F, N|H|TYPE_F,   "MPR", },     /* Multiply Register to Register # NBR */
+    {  0x4400,  0xFC0F, N|H|TYPE_F,   "DVR", },     /* Divide Register to Register # NBR */
+    {  0x5000,  0xFC08,   B|TYPE_D,   "LABRM", },   /* Load Address BR Mode */
+    {  0x5400,  0xFC08,   B|TYPE_A,   "STWBR", },   /* Store Base Register BR Only */
+    {  0x5800,  0xFC08,   B|TYPE_A,   "SUABR", },   /* Subtract Base Register BR Only */
+    {  0x5808,  0xFC08,   B|TYPE_D,   "LABR", },    /* Load Address Base Register BR Only */
+    {  0x5C00,  0xFC08,   B|TYPE_A,   "LWBR", },    /* Load Base Register BR Only */
+    {  0x5C08,  0xFF88,   B|TYPE_B,   "BSUBM", },   /* Branch Subroutine Memory BR Only */
+    {  0x5C08,  0xFC08,   B|TYPE_B,   "CALLM", },   /* Call Memory BR Only */
+    {  0x6000,  0xFC0F, N|H|TYPE_F,   "NOR", },     /* Normalize # NBR Only */
+    {  0x6400,  0xFC0F, N|H|TYPE_F,   "NORD", },    /* Normalize Double #  NBR Only */
+    {  0x6800,  0xFC0F, N|H|TYPE_F,   "SCZ", },     /* Shift and Count Zeros # */
+    {  0x6C00,  0xFC40, N|H|TYPE_I,   "SRA", },     /* Shift Right Arithmetic # NBR */
+    {  0x6C40,  0xFC40, N|H|TYPE_I,   "SLA", },     /* Shift Left Arithmetic # NBR */
+    {  0x7000,  0xFC40, N|H|TYPE_I,   "SRL", },     /* Shift Right Logical # NBR */
+    {  0x7040,  0xFC40, N|H|TYPE_I,   "SLL", },     /* Shift Left Logical # NBR */
+    {  0x7400,  0xFC40, N|H|TYPE_I,   "SRC", },     /* Shift Right Circular # NBR */
+    {  0x7440,  0xFC40, N|H|TYPE_I,   "SLC", },     /* Shift Left Circular # NBR */
+    {  0x7800,  0xFC40, N|H|TYPE_I,   "SRAD", },    /* Shift Right Arithmetic Double # NBR */
+    {  0x7840,  0xFC40, N|H|TYPE_I,   "SLAD", },    /* Shift Left Arithmetic Double # NBR */
+    {  0x7C00,  0xFC40, N|H|TYPE_I,   "SRLD", },    /* Shift Right Logical Double # NBR */
+    {  0x7C40,  0xFC40, N|H|TYPE_I,   "SLLD", },    /* Shift Left Logical Double # NBR */
+    {  0x8000,  0xFC08,   TYPE_A,     "LEAR", },    /* Load Effective Address Real * */
+    {  0x8400,  0xFC00,   TYPE_A,     "ANM", },     /* And Memory B,H,W,D */
+    {  0x8800,  0xFC00,   TYPE_A,     "ORM", },     /* Or Memory B,H,W,D */
+    {  0x8C00,  0xFC00,   TYPE_A,     "EOM", },     /* Exclusive Or Memory */
+    {  0x9000,  0xFC00,   TYPE_A,     "CAM", },     /* Compare Arithmetic with Memory */
+    {  0x9400,  0xFC00,   TYPE_A,     "CMM", },     /* Compare Masked with Memory */
+    {  0x9800,  0xFC00,   TYPE_D,     "SBM", },     /* Set Bit in Memory */
+    {  0x9C00,  0xFC00,   TYPE_D,     "ZBM", },     /* Zero Bit in Memory */
+    {  0xA000,  0xFC00,   TYPE_D,     "ABM", },     /* Add Bit in Memory */
+    {  0xA400,  0xFC00,   TYPE_D,     "TBM", },     /* Test Bit in Memory */
+    {  0xA800,  0xFC00,   TYPE_B,     "EXM", },     /* Execute Memory */
+    {  0xAC00,  0xFC00,   TYPE_A,     "L", },       /* Load B,H,W,D */
+    {  0xB000,  0xFC00,   TYPE_A,     "LM", },      /* Load Masked B,H,W,D */
+    {  0xB400,  0xFC00,   TYPE_A,     "LN", },      /* Load Negative B,H,W,D */
+    {  0xB800,  0xFC00,   TYPE_A,     "ADM", },     /* Add Memory B,H,W,D */
+    {  0xBC00,  0xFC00,   TYPE_A,     "SUM", },     /* Subtract Memory B,H,W,D */
+    {  0xC000,  0xFC00,   TYPE_A,     "MPM", },     /* Multiply Memory B,H,W,D */
+    {  0xC400,  0xFC00,   TYPE_A,     "DVM", },     /* Divide Memory B,H,W,D */
+    {  0xC800,  0xFC0F,   TYPE_C,     "LI", },      /* Load Immediate */
+    {  0xC801,  0xFC0F,   TYPE_C,     "ADI", },     /* Add Immediate */
+    {  0xC802,  0xFC0F,   TYPE_C,     "SUI", },     /* Subtract Immediate */
+    {  0xC803,  0xFC0F,   TYPE_C,     "MPI", },     /* Multiply Immediate */
+    {  0xC804,  0xFC0F,   TYPE_C,     "DVI", },     /* Divide Immediate */
+    {  0xC805,  0xFC0F,   TYPE_C,     "CI", },      /* Compare Immediate */
+    {  0xC806,  0xFC0F,   TYPE_N,     "SVC", },     /* Supervisor Call */
+    {  0xC807,  0xFC0F,   TYPE_G,     "EXR", },     /* Execute Register/ Right */
+    {  0xC808,  0xFC0F, X|TYPE_A,     "SEM", },     /* Store External Map 32/7X * */
+    {  0xC809,  0xFC0F, X|TYPE_A,     "LEM", },     /* Load External Map 32/7X * */
+    {  0xC80A,  0xFC0F, X|TYPE_A,     "CEMA", },    /* Convert External Map 32/7X * */
+    {  0xCC00,  0xFC08,   TYPE_A,     "LF", },      /* Load File */
+    {  0xCC08,  0xFC08,   TYPE_A,     "LFBR", },    /* Load Base File */
+    {  0xD000,  0xFC00, N|TYPE_A,     "LEA", },     /* Load Effective Address # NBR */
+    {  0xD400,  0xFC00,   TYPE_A,     "ST", },      /* Store B,H,W,D */
+    {  0xD800,  0xFC00,   TYPE_A,     "STM", },     /* Store Masked B,H,W,D */
+    {  0xDC00,  0xFC08,   TYPE_A,     "STF", },     /* Store File */
+    {  0xDC08,  0xFC08,   TYPE_A,     "STFBR", },   /* Store Base File */
+    {  0xE000,  0xFC08,   TYPE_A,     "SUF", },     /* Subtract Floating Memory D,W */
+    {  0xE008,  0xFC08,   TYPE_A,     "ADF", },     /* Add Floating Memory D,W */
+    {  0xE400,  0xFC08,   TYPE_A,     "DVF", },     /* Divide Floating Memory D,W */
+    {  0xE408,  0xFC08,   TYPE_A,     "MPF", },     /* Multiply Floating Memory D,W */
+    {  0xE800,  0xFC00,   TYPE_A,     "ARM", },     /* Add Register to Memory B,H,W,D */
+    {  0xEC00,  0xFF80,   TYPE_B,     "BU", },      /* Branch Unconditional */
+    {  0xEC00,  0xFF80,   TYPE_A,     "BCT", },     /* Branch Condition True */
+    {  0xEC80,  0xFF80,   TYPE_B,     "BS", },      /* Branch Condition True CC1 = 1 */
+    {  0xED00,  0xFF80,   TYPE_B,     "BGT", },     /* Branch Condition True CC2 = 1 */
+    {  0xED80,  0xFF80,   TYPE_B,     "BLT", },     /* Branch Condition True CC3 = 1 */
+    {  0xEE00,  0xFF80,   TYPE_B,     "BEQ", },     /* Branch Condition True CC4 = 1 */
+    {  0xEE80,  0xFF80,   TYPE_B,     "BGE", },     /* Branch Condition True CC2|CC4 = 1 */
+    {  0xEF00,  0xFF80,   TYPE_B,     "BLE", },     /* Branch Condition True CC3|CC4 = 1 */
+    {  0xEF80,  0xFF80,   TYPE_B,     "BANY", },    /* Branch Condition True CC1|CC2|CC3|CC4 */
+    {  0xF000,  0XFF80,   TYPE_B,     "BFT", },     /* Branch Function True */
+    {  0xF000,  0xFF80,   TYPE_A,     "BCF", },     /* Branch Condition False */
+    {  0xF080,  0xFF80,   TYPE_B,     "BNS", },     /* Branch Condition False CC1 = 0 */
+    {  0xF100,  0xFF80,   TYPE_B,     "BNP", },     /* Branch Condition False CC2 = 0 */
+    {  0xF180,  0xFF80,   TYPE_B,     "BNN", },     /* Branch Condition False CC3 = 0 */
+    {  0xF200,  0xFF80,   TYPE_B,     "BNE", },     /* Branch Condition False CC4 = 0 */
+    {  0xF280,  0xFF80,   TYPE_B,     "BCF 5,", },  /* Branch Condition False CC2|CC4 = 0 */
+    {  0xF300,  0xFF80,   TYPE_B,     "BCF 6,", },  /* Branch Condition False CC3|CC4 = 0 */
+    {  0xF380,  0xFF80,   TYPE_B,     "BAZ", },     /* Branch Condition False CC1|CC2|CC3|CC4=0*/
+    {  0xF400,  0xFC70,   TYPE_D,     "BIB", },     /* Branch after Incrementing Byte */
+    {  0xF420,  0xFC70,   TYPE_D,     "BIH", },     /* Branch after Incrementing Half */
+    {  0xF440,  0xFC70,   TYPE_D,     "BIW", },     /* Branch after Incrementing Word */
+    {  0xF460,  0xFC70,   TYPE_D,     "BID", },     /* Branch after Incrementing Double */
+    {  0xF800,  0xFF80,   TYPE_E,     "ZM", },      /* Zero Memory B,H,W,D */
+    {  0xF880,  0xFF80,   TYPE_B,     "BL", },      /* Branch and Link */
+    {  0xF900,  0xFCC0, X|TYPE_B,     "BRI", },     /* Branch and Reset Interrupt 32/55 * */
+    {  0xF980,  0xFF80,   TYPE_B,     "LPSD", },    /* Load Program Status Double * */
+    {  0xFA08,  0xFC00,   TYPE_B,     "JWCS", },    /* Jump to Writable Control Store * */
+    {  0xFA80,  0xFF80,   TYPE_B,     "LPSDCM", },  /* LPSD and Change Map * */
+    {  0xFB00,  0xFCC0, X|TYPE_A,     "TRP", },     /* Transfer Register to Protect Register 32/7X */
+    {  0xFB80,  0xFCC0, X|TYPE_A,     "TPR", },     /* Transfer Protect Register to Register 32/7X */
+    {  0xFC00,  0xFC07,   TYPE_L,     "EI", },      /* Enable Interrupt */
+    {  0xFC01,  0xFC07,   TYPE_L,     "DI", },      /* Disable Interrupt */
+    {  0xFC02,  0xFC07,   TYPE_L,     "RI", },      /* Request Interrupt */
+    {  0xFC03,  0xFC07,   TYPE_L,     "AI", },      /* Activate Interrupt */
+    {  0xFC04,  0xFC07,   TYPE_L,     "DAI", },     /* Deactivate Interrupt */
+    {  0xFC05,  0xFC07,   TYPE_M,     "TD", },      /* Test Device */
+    {  0xFC06,  0xFC07,   TYPE_M,     "CD", },      /* Command Device */
+    {  0xFC17,  0xFC7F,   TYPE_C,     "SIO", },     /* Start I/O */
+    {  0xFC1F,  0xFC7F,   TYPE_C,     "TIO", },     /* Test I/O */
+    {  0xFC27,  0xFC7F,   TYPE_C,     "STPIO", },   /* Stop I/O */
+    {  0xFC2F,  0xFC7F,   TYPE_C,     "RSCHNL", },  /* Reset Channel */
+    {  0xFC37,  0xFC7F,   TYPE_C,     "HIO", },     /* Halt I/O */
+    {  0xFC3F,  0xFC7F,   TYPE_C,     "GRIO", },    /* Grab Controller */
+    {  0xFC47,  0xFC7F,   TYPE_C,     "RSCTL", },   /* Reset Controller */
+    {  0xFC4F,  0xFC7F,   TYPE_C,     "ECWCS", },   /* Enable Channel WCS Load */
+    {  0xFC5F,  0xFC7F,   TYPE_C,     "WCWCS", },   /* Write Channel WCS */
+    {  0xFC67,  0xFC7F,   TYPE_C,     "ECI", },     /* Enable Channel Interrupt */
+    {  0xFC6F,  0xFC7F,   TYPE_C,     "DCI", },     /* Disable Channel Interrupt */
+    {  0xFC77,  0xFC7F,   TYPE_C,     "ACI", },     /* Activate Channel Interrupt */
+    {  0xFC7F,  0xFC7F,   TYPE_C,     "DACI", },    /* Deactivate Channel Interrupt */
 };
 
 /* Instruction decode printing routine
-
    Inputs:
     *of       =       output stream
     val       =       16/32 bit instruction to print left justified
@@ -816,7 +815,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
 {
     uint16   inst = (val >> 16) & 0xFFFF;
     int      i;
-    int      mode = 0;                              /* assume non base mode instructions */
+    int      mode = 0;                      /* assume non base mode instructions */
     t_opcode *tab;
 
     if ((PSD[0] & 0x02000000) || (sw & SWMASK('M'))) /* bit 6 is base mode */
@@ -825,14 +824,14 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
     for (tab = optab; tab->name != NULL; tab++) {
         if (tab->opbase == (inst & tab->mask)) {
             if (mode && (tab->type & (X | N)))
-                continue;                           /* non basemode instruction in base mode, skip */
+                continue;                   /* non basemode instruction in base mode, skip */
             if (!mode && (tab->type & B))
-                continue;                           /* basemode instruction in nonbase mode, skip */
+                continue;                   /* basemode instruction in nonbase mode, skip */
 
             /* TODO?  Maybe want to make sure MODEL is 32/7X for X type instructions */
 
             /* match found */
-            fputs(tab->name, of);                   /* output the base opcode */
+            fputs(tab->name, of);           /* output the base opcode */
 
             /* process the other fields of the instruction */
             switch(tab->type & 0xF) {
@@ -844,7 +843,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
                 i = (val & 3) | ((inst >> 1) & 04);
                 if (((inst&0xfc00) == 0xe000) ||
                     ((inst&0xfc00) == 0xe400))
-                    i &= ~4;                        /* remove f bit from fpt instr */
+                    i &= ~4;                /* remove f bit from fpt instr */
                 if (((inst&0xfc00) != 0xdc00) &&
                     ((inst&0xfc00) != 0xd000) &&
                     ((inst&0xfc00) != 0x5400) &&
@@ -856,10 +855,10 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
                 /* Fall through */
 
             /* BIx instructions or bit in memory reference instructions */
-            case TYPE_D:                 /* r,[*]o[,x] or r,o[(b)],[,x] */
+            case TYPE_D:                    /* r,[*]o[,x] or r,o[(b)],[,x] */
                 if ((tab->type & 0xF) != TYPE_E) {
                     fputc(' ', of);
-//                    fputc('R', of);
+//                  fputc('R', of);
                     /* output the reg or bit number */
                     fputc('0'+((inst>>7) & 07), of);
                     fputc(',', of);
@@ -867,7 +866,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
                 /* Fall through */
 
             /* branch instruction */
-            case TYPE_B:                 /* [*]o[,x] or o[(b)],[,x] */
+            case TYPE_B:                    /* [*]o[,x] or o[(b)],[,x] */
                 if (((tab->type & 0xf) != TYPE_A) && ((tab->type & 0xf) != TYPE_D))
                     fputc(' ', of);
                 if (mode) {
@@ -875,23 +874,23 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
                     fprint_val(of, val&0xffff, 16, 16, PV_LEFT);    /* output 16 bit offset */
                     if (inst & 07) {
                         fputc('(', of);
-//                        fputc('B', of);
-                        fputc(('0'+(inst & 07)), of);           /* output the base reg number */
+//                      fputc('B', of);
+                        fputc(('0'+(inst & 07)), of);   /* output the base reg number */
                         fputc(')', of);
                     }
                     if (inst & 0x70) {
                         fputc(',', of);
-//                        fputc('R', of);
+//                      fputc('R', of);
                         fputc(('0'+((inst >> 4) & 07)), of);    /* output the index reg number */
                     }
                 } else {
                     /* nonbase reg mode */
                     if (inst & 0x10)
-                        fputc('*', of);                         /* show indirection */
+                        fputc('*', of);     /* show indirection */
                     fprint_val(of, val&0x7ffff, 16, 19, PV_LEFT);   /* 19 bit offset */
                     if (inst & 0x60) {
-                        fputc(',', of);                         /* register coming */
-//                        fputc('R', of);
+                        fputc(',', of);     /* register coming */
+//                      fputc('R', of);
                         if (tab->type != TYPE_D)
                             fputc('0'+((inst & 0x60) >> 5), of);    /* output the index reg number */
                         else { 
@@ -905,8 +904,8 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
             /* immediate or XIO instructions */
             case TYPE_C:                    /* r,v */
                 fputc(' ', of);
-//                fputc('R', of);
-                fputc('0'+((inst>>7) & 07), of);                /* index reg number */
+//              fputc('R', of);
+                fputc('0'+((inst>>7) & 07), of);    /* index reg number */
                 fputc(',', of);
                 fprint_val(of, val&0xffff, 16, 16, PV_LEFT);    /* 16 bit imm val or chan/suba */
                 break;
@@ -914,18 +913,18 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
             /* reg - reg instructions */
             case TYPE_F:                    /* rs,rd */
                 fputc(' ', of);
-//                fputc('R', of);
-                fputc('0'+((inst>>4) & 07), of);                /* src reg */
+//              fputc('R', of);
+                fputc('0'+((inst>>4) & 07), of);    /* src reg */
                 fputc(',', of);
-//                fputc('R', of);
-                fputc('0'+((inst>>7) & 07), of);                /* dest reg */
+//              fputc('R', of);
+                fputc('0'+((inst>>7) & 07), of);    /* dest reg */
                 break;
 
             /* single reg instructions */
             case TYPE_G:                    /* op r */
                 fputc(' ', of);
-//                fputc('R', of);
-                fputc('0'+((inst>>7) & 07), of);                /* output src/dest reg  num */
+//              fputc('R', of);
+                fputc('0'+((inst>>7) & 07), of);    /* output src/dest reg  num */
                 break;
 
             /* just output the instruction */
@@ -935,30 +934,30 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
             /* reg and bit shift cnt */
             case TYPE_I:                    /* r,b */
                 fputc(' ', of);
-//                fputc('R', of);
-                fputc('0'+((inst>>7) & 07), of);                /* reg number */
+//              fputc('R', of);
+                fputc('0'+((inst>>7) & 07), of);    /* reg number */
                 fputc(',', of);
-                fprint_val(of, inst&0x1f, 10, 5, PV_LEFT);      /* 5 bit shift count */
+                fprint_val(of, inst&0x1f, 10, 5, PV_LEFT);  /* 5 bit shift count */
                 break; 
 
             /* register bit operations */
-            case TYPE_K:                 /* r,rb */
+            case TYPE_K:                    /* r,rb */
                 fputc(' ', of);
-//                fputc('R', of);
-                fputc('0'+((inst>>4) & 07), of);                /* register number */
+//              fputc('R', of);
+                fputc('0'+((inst>>4) & 07), of);    /* register number */
                 fputc(',', of);
                 i = ((inst & 3) << 3) | ((inst >> 7) & 07);
-                fprint_val(of, i, 10, 5, PV_LEFT);              /* reg bit number to operate on */
+                fprint_val(of, i, 10, 5, PV_LEFT);  /* reg bit number to operate on */
                 break; 
 
             /* interrupt control instructions */
-            case TYPE_L:                  /* i */
+            case TYPE_L:                    /* i */
                 fputc(' ', of);
                 fprint_val(of, (inst>>3)&0x7f, 16, 7, PV_RZRO); /* output 7 bit priority level value */
                 break;
 
             /* CD/TD Class E I/O instructions */
-            case TYPE_M:                  /* i,v */
+            case TYPE_M:                    /* i,v */
                 fputc(' ', of);
                 fprint_val(of, (inst>>3)&0x7f, 16, 7, PV_RZRO); /* output 7 bit device address */
                 fputc(',', of);
@@ -966,7 +965,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
                 break;
 
             /* SVC  instructions */
-            case TYPE_N:                  /* i,v */
+            case TYPE_N:                    /* i,v */
                 fputc(' ', of);
                 fprint_val(of, (val>>12)&0xf, 16, 4, PV_RZRO);  /* output 4 bit svc number */
                 fputc(',', of);
@@ -976,7 +975,7 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
             default:
                 /* FIXME - return error code here? */
 //              /* fputs(" unknown type", of);  /* output error message */
-//              return SCPE_ARG;                /* unknown type */
+//              return SCPE_ARG;            /* unknown type */
                 break;
             }
             /* return the size of the instruction */
@@ -986,11 +985,11 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
     /* FIXME - should we just return error here? or dump as hex data? */
     /* we get here if opcode not found, print data value */
     if (mode)
-        fputs(" Binvld ", of);                  /* output basemode error message */
+        fputs(" Binvld ", of);              /* output basemode error message */
     else
-        fputs(" Ninvld ", of);                  /* output non-basmode error message */
-    fprint_val(of, val, 16, 32, PV_RZRO);       /* output unknown 32 bit instruction code */
-    return 4;                                   /* show as full word size */
+        fputs(" Ninvld ", of);              /* output non-basmode error message */
+    fprint_val(of, val, 16, 32, PV_RZRO);   /* output unknown 32 bit instruction code */
+    return 4;                               /* show as full word size */
 }
 
 /* Symbolic decode
@@ -1007,53 +1006,53 @@ int fprint_inst(FILE *of, uint32 val, int32 sw)
 t_stat fprint_sym (FILE *of, t_addr addr, t_value *val, UNIT *uptr, int32 sw)
 {
     int         i;
-    int         l = 4;                          /* default to full words */
-    int         rdx = 16;                       /* default radex is hex */
+    int         l = 4;                      /* default to full words */
+    int         rdx = 16;                   /* default radex is hex */
     uint32      num;
-//  uint32      tmp=*val;                       /* for debug */
+//  uint32      tmp=*val;                   /* for debug */
 
     if (addr & 0x02)
         l = 2;
     /* determine base for number output */
     if (sw & SWMASK ('D')) 
-        rdx = 10;                               /* decimal */
+        rdx = 10;                           /* decimal */
     else
     if (sw & SWMASK ('O')) 
-        rdx = 8;                                /* octal */
+        rdx = 8;                            /* octal */
     else
     if (sw & SWMASK ('H')) 
-        rdx = 16;                               /* hex */
+        rdx = 16;                           /* hex */
 
-    if (sw & SWMASK ('M')) {                    /* machine base mode? */
-//      sw &= ~ SWMASK('F');                    /* Can't do F and M at same time */
-//      sw &= ~ SWMASK('W');                    /* Can't do W and M at same time */
-        sw &= ~ SWMASK('B');                    /* Can't do B and M at same time */
-        sw &= ~ SWMASK('C');                    /* Can't do C and M at same time */
+    if (sw & SWMASK ('M')) {                /* machine base mode? */
+//      sw &= ~ SWMASK('F');                /* Can't do F and M at same time */
+//      sw &= ~ SWMASK('W');                /* Can't do W and M at same time */
+        sw &= ~ SWMASK('B');                /* Can't do B and M at same time */
+        sw &= ~ SWMASK('C');                /* Can't do C and M at same time */
         if (addr & 0x02)
             l = 2;
         else
             l = 4;
     } else
     if (sw & SWMASK('F')) {
-        l = 4;                                  /* words are 4 bytes */
+        l = 4;                              /* words are 4 bytes */
     } else
     if (sw & SWMASK('W')) {
-        l = 2;                                  /* halfwords are 2 bytes */
+        l = 2;                              /* halfwords are 2 bytes */
     } else
     if (sw & SWMASK('B')) { 
-        l = 1;                                  /* bytes */
+        l = 1;                              /* bytes */
     }
 
     if (sw & SWMASK ('C')) {
-        fputc('\'', of);                        /* opening apostorphe */
+        fputc('\'', of);                    /* opening apostorphe */
         for(i = 0; i < l; i++) {
-            int ch = val[i] & 0xff;             /* get the char */
-            if (ch >= 0x20 && ch <= 0x7f)       /* see if printable */
-                fprintf(of, "%c", ch);          /* output the ascii char */
+            int ch = val[i] & 0xff;         /* get the char */
+            if (ch >= 0x20 && ch <= 0x7f)   /* see if printable */
+                fprintf(of, "%c", ch);      /* output the ascii char */
             else
-                fputc('_', of);                 /* use underscore for unprintable char */
+                fputc('_', of);             /* use underscore for unprintable char */
         }
-        fputc('\'', of);                        /* closing apostorphe */
+        fputc('\'', of);                    /* closing apostorphe */
     } else
     /* go print the symbolic instruction for base or nonbase mode */
     if (sw & (SWMASK('M') | SWMASK('N'))) { 
@@ -1062,12 +1061,12 @@ t_stat fprint_sym (FILE *of, t_addr addr, t_value *val, UNIT *uptr, int32 sw)
             num |= (uint32)val[i] << ((l-i-1) * 8); /* collect 8-32 bit data value to print */
         }
         if (addr & 0x02)
-            num <<= 16;                         /* use rt hw */
-        l = fprint_inst(of, num, sw);           /* go print the instruction */
+            num <<= 16;                     /* use rt hw */
+        l = fprint_inst(of, num, sw);       /* go print the instruction */
         if (((addr & 2) == 0) && (l == 2)) {    /* did we execute a left halfword instruction */
             fprintf(of, "; ");
             l = fprint_inst(of, num<<16, sw);   /* go print right halfword instruction */
-            l = 4;                              /* next word address */
+            l = 4;                          /* next word address */
         }
     } else {
         /* print the numeric value of the memory data */
@@ -1076,7 +1075,7 @@ t_stat fprint_sym (FILE *of, t_addr addr, t_value *val, UNIT *uptr, int32 sw)
             num |= (uint32)val[i] << ((l-i-1) * 8); /* collect 8-32 bit data value to print */
         fprint_val(of, num, rdx, l*8, PV_RZRO); /* print it in requested radix */
     }
-    return -(l-1);                              /* will be negative if we did anything */
+    return -(l-1);                          /* will be negative if we did anything */
 }
 
 /* 
@@ -1084,24 +1083,24 @@ t_stat fprint_sym (FILE *of, t_addr addr, t_value *val, UNIT *uptr, int32 sw)
  */
 t_stat get_off (CONST char *cptr, CONST char **tptr, uint32 radix, t_value *val, char *m)
 {
-    t_stat r = SCPE_OK;                         /* assume OK return */
+    t_stat r = SCPE_OK;                     /* assume OK return */
 
-    *m = 0;                                     /* left parend found flag if set */
+    *m = 0;                                 /* left parend found flag if set */
     *val = (uint32)strtotv(cptr, tptr, radix);  /* convert to value */
     if (cptr == *tptr)
-        r = SCPE_ARG;                           /* no argument found error */
+        r = SCPE_ARG;                       /* no argument found error */
     else {
-        cptr = *tptr;                           /* where to start looking */
+        cptr = *tptr;                       /* where to start looking */
         while (sim_isspace(*cptr))
-            cptr++;                             /* skip any spaces */
+            cptr++;                         /* skip any spaces */
         if (*cptr++ == '(') {
-           *m = 1;                              /* show we found a left parend */
+           *m = 1;                          /* show we found a left parend */
             while (sim_isspace(*cptr))
-                cptr++;                         /* skip any spaces */
+                cptr++;                     /* skip any spaces */
         }
-        *tptr = cptr;                           /* return next char pointer */
+        *tptr = cptr;                       /* return next char pointer */
     }
-    return r;                                   /* return status */
+    return r;                               /* return status */
 }
 
 /* 
@@ -1124,7 +1123,6 @@ t_stat get_imm (CONST char *cptr, CONST char **tptr, uint32 radix, t_value *val)
 }
 
 /* Symbolic input
-
    Inputs:
        *cptr      =       pointer to input string
        addr       =       current PC
@@ -1139,8 +1137,8 @@ t_stat parse_sym (CONST char *cptr, t_addr addr, UNIT *uptr, t_value *val, int32
 {
     int        i;
     int        x;
-    int        l = 4;                           /* default to full words */
-    int        rdx = 16;                        /* default radex is hex */
+    int        l = 4;                       /* default to full words */
+    int        rdx = 16;                    /* default radex is hex */
     char       mod = 0;
     t_opcode   *tab;
     t_stat     r;
@@ -1151,13 +1149,13 @@ t_stat parse_sym (CONST char *cptr, t_addr addr, UNIT *uptr, t_value *val, int32
 
     /* determine base for numbers */
     if (sw & SWMASK ('D')) 
-        rdx = 10;                               /* decimal */
+        rdx = 10;                           /* decimal */
     else
     if (sw & SWMASK ('O')) 
-        rdx = 8;                                /* octal */
+        rdx = 8;                            /* octal */
     else
     if (sw & SWMASK ('H')) 
-        rdx = 16;                               /* hex */
+        rdx = 16;                           /* hex */
 
     /* set instruction size */
     if (sw & SWMASK('F')) {
@@ -1169,9 +1167,9 @@ t_stat parse_sym (CONST char *cptr, t_addr addr, UNIT *uptr, t_value *val, int32
 
     /* process a character string */
     if (sw & SWMASK ('C')) {
-        cptr = get_glyph_quoted(cptr, gbuf, 0);     /* Get string */
+        cptr = get_glyph_quoted(cptr, gbuf, 0); /* Get string */
         for(i = 0; gbuf[i] != 0; i++) {
-            val[i] = gbuf[i];                       /* copy in the string */
+            val[i] = gbuf[i];               /* copy in the string */
         }
         return -(i - 1);
     }
@@ -1179,448 +1177,448 @@ t_stat parse_sym (CONST char *cptr, t_addr addr, UNIT *uptr, t_value *val, int32
     /* see if we are processing a nonbase instruction */
     if (sw & SWMASK ('N')) {
         /* process nonbased instruction */
-        cptr = get_glyph(cptr, gbuf, 0);            /* Get uppercase opcode */
-        l = strlen(gbuf);                           /* opcode length */
+        cptr = get_glyph(cptr, gbuf, 0);    /* Get uppercase opcode */
+        l = strlen(gbuf);                   /* opcode length */
         /* try to find the opcode in the table */
         for (tab = optab; tab->name != NULL; tab++) {
-            i = tab->type & 0xf;                    /* get the instruction type */
+            i = tab->type & 0xf;            /* get the instruction type */
             /* check for memory reference instruction */
             if (i == TYPE_A || i == TYPE_E) {
                 /* test for base opcode name without B, H, W, D applied */
                 if (sim_strncasecmp(tab->name, gbuf, l - 1) == 0)
-                    break;                          /* found */
+                    break;                  /* found */
             } else
             /* test the full opcode name */
             if (sim_strcasecmp(tab->name, gbuf) == 0) 
-                break;                              /* found */
+                break;                      /* found */
         }
-        if (tab->name == NULL)                      /* see if anything found */
-            return SCPE_ARG;                        /* no, return invalid argument error */
-        num = tab->opbase<<16;                      /* get the base opcode value */
+        if (tab->name == NULL)              /* see if anything found */
+            return SCPE_ARG;                /* no, return invalid argument error */
+        num = tab->opbase<<16;              /* get the base opcode value */
 
         /* process each instruction type */
         switch(i) {
         /* mem ref instruction */
-        case TYPE_A:                    /* c r,[*]o[,x] */
+        case TYPE_A:                        /* c r,[*]o[,x] */
         /* zero memory instruction */
-        case TYPE_E:                    /* c [*]o[,x] */
+        case TYPE_E:                        /* c [*]o[,x] */
             switch(gbuf[l]) {
-            case 'B': num |= 0x80000; break;        /* byte, set F bit */
-            case 'H': num |= 0x00001; break;        /* halfword */
-            case 'W': num |= 0x00000; break;        /* word */
-            case 'D': num |= 0x00002; break;        /* doubleword */
+            case 'B': num |= 0x80000; break;    /* byte, set F bit */
+            case 'H': num |= 0x00001; break;    /* halfword */
+            case 'W': num |= 0x00000; break;    /* word */
+            case 'D': num |= 0x00002; break;    /* doubleword */
             default:
-                return SCPE_ARG;                    /* base op suffix error */
+                return SCPE_ARG;            /* base op suffix error */
             }
             /* Fall through */
 
         /* BIx instructions or memory reference */
-        case TYPE_D:                    /* r,[*]o[,x] */
+        case TYPE_D:                        /* r,[*]o[,x] */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip leading blanks */
+                cptr++;                     /* skip leading blanks */
             if (i != TYPE_E) {
                 /* get reg number except for zero memory instruction */
                 if (*cptr >= '0' || *cptr <= '7') { /* reg# is 0-7 */
-                    x = *cptr++ - '0';              /* get the reg# */
+                    x = *cptr++ - '0';      /* get the reg# */
                     while (sim_isspace(*cptr))
-                        cptr++;                     /* skip any blanks */
-                    if (*cptr++ != ',')             /* check for required comma */
-                        return SCPE_ARG;            /* anything else is an argument error */
-                    num |= x << 23;                 /* position reg number in instruction */
+                        cptr++;             /* skip any blanks */
+                    if (*cptr++ != ',')     /* check for required comma */
+                        return SCPE_ARG;    /* anything else is an argument error */
+                    num |= x << 23;         /* position reg number in instruction */
                 } else 
-                    return SCPE_ARG;                /* invalid reg number is an argument error */
+                    return SCPE_ARG;        /* invalid reg number is an argument error */
             }
             /* Fall through */
 
         /* branch instruction */
-        case TYPE_B:                    /* [*]o[,x] */
-        if (*cptr == '*') {                         /* test for indirection */
-            num |= 0x100000;                        /* set indirect flag */
-            cptr++;                                 /* skip past the '*' */
+        case TYPE_B:                        /* [*]o[,x] */
+        if (*cptr == '*') {                 /* test for indirection */
+            num |= 0x100000;                /* set indirect flag */
+            cptr++;                         /* skip past the '*' */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip blanks */
+                cptr++;                     /* skip blanks */
         }
         if ((r = get_off(cptr, &tptr, 16, val, &mod)))  /* get operand address */
-            return r;                               /* argument error if a problem */
-        cptr = tptr;                                /* set pointer to returned next char pointer */
-        if (*val > 0x7FFFF)                         /* 19 bit address max */
-            return SCPE_ARG;                        /* argument error */
-        num |= *val;                                /* or our address into instruction */
+            return r;                       /* argument error if a problem */
+        cptr = tptr;                        /* set pointer to returned next char pointer */
+        if (*val > 0x7FFFF)                 /* 19 bit address max */
+            return SCPE_ARG;                /* argument error */
+        num |= *val;                        /* or our address into instruction */
         if (mod) {
-            return SCPE_ARG;                        /* if a '(' found, that is an arg error */
+            return SCPE_ARG;                /* if a '(' found, that is an arg error */
         }
-        if (*cptr++ == ',') {                       /* test for optional index reg number */
-            if (*cptr >= '0' || *cptr <= '7') {     /* reg# is 0-7 */
-                x = *cptr++ - '0';                  /* get reg number */
-                num |= x << 20;                     /* position and put into instruction */
+        if (*cptr++ == ',') {               /* test for optional index reg number */
+            if (*cptr >= '0' || *cptr <= '7') { /* reg# is 0-7 */
+                x = *cptr++ - '0';          /* get reg number */
+                num |= x << 20;             /* position and put into instruction */
             } else 
-                return SCPE_ARG;                    /* reg# not 0-7, so arg error */
+                return SCPE_ARG;            /* reg# not 0-7, so arg error */
         }
         break;
 
         /* immediate or XIO instruction */
-        case TYPE_C:                    /* r,v */
+        case TYPE_C:                        /* r,v */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip spaces */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* get reg# */
+                cptr++;                     /* skip spaces */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* get reg# */
                 while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                if (*cptr++ != ',')                 /* next char need to be a comma */
-                    return SCPE_ARG;                /* it's not, so arg error */
-                num |= x << 23;                     /* position and put into instruction */
+                    cptr++;                 /* skip spaces */
+                if (*cptr++ != ',')         /* next char need to be a comma */
+                    return SCPE_ARG;        /* it's not, so arg error */
+                num |= x << 23;             /* position and put into instruction */
             } else 
-                return SCPE_ARG;                    /* invalid reg#, so arg error */
+                return SCPE_ARG;            /* invalid reg#, so arg error */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
+                cptr++;                     /* skip any blanks */
             if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 16 bit immediate value */
-                return r;                           /* return error from conversion */
-            num |= *val;                            /* or in the 16 bit value */
+                return r;                   /* return error from conversion */
+            num |= *val;                    /* or in the 16 bit value */
             break;
 
         /* reg-reg instructions */
-        case TYPE_F:                  /* r,r */
+        case TYPE_F:                        /* r,r */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip blanks */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
+                cptr++;                     /* skip blanks */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
                 while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                if (*cptr++ != ',')                 /* test for required ',' */
-                    return SCPE_ARG;                /* it's not there, so error */
-                num |= x << 23;                     /* insert first reg# into instruction */
+                    cptr++;                 /* skip spaces */
+                if (*cptr++ != ',')         /* test for required ',' */
+                    return SCPE_ARG;        /* it's not there, so error */
+                num |= x << 23;             /* insert first reg# into instruction */
             } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
+                return SCPE_ARG;            /* reg# invalid, so arg error */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip more spaces */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
+                cptr++;                     /* skip more spaces */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
                 while (sim_isspace(*cptr))
-                    cptr++;                         /* skip any spaces */
-                num |= x << 20;                     /* insert 2nd reg# into instruction */
+                    cptr++;                 /* skip any spaces */
+                num |= x << 20;             /* insert 2nd reg# into instruction */
             } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
+                return SCPE_ARG;            /* reg# invalid, so arg error */
             break;
 
         /* single reg instructions */
-        case TYPE_G:                 /* r */
+        case TYPE_G:                        /* r */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip blanks */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
+                cptr++;                     /* skip blanks */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
                 while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                num |= x << 23;                     /* insert first reg# into instruction */
+                    cptr++;                 /* skip spaces */
+                num |= x << 23;             /* insert first reg# into instruction */
             } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
+                return SCPE_ARG;            /* reg# invalid, so arg error */
             break;
 
         /* opcode only instructions */
-        case TYPE_H:            /* empty */
+        case TYPE_H:                        /* empty */
             break;
 
         /* reg and bit shift instructions */
-        case TYPE_I:            /* r,b */
+        case TYPE_I:                        /* r,b */
             while (sim_isspace (*cptr))
-                cptr++;                             /* skip blanks */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
+                cptr++;                     /* skip blanks */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
                 while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                if (*cptr++ != ',')                 /* test for required ',' */
-                    return SCPE_ARG;                /* it's not there, so error */
-                num |= (x << 23);                   /* insert first reg# into instruction */
+                    cptr++;                 /* skip spaces */
+                if (*cptr++ != ',')         /* test for required ',' */
+                    return SCPE_ARG;        /* it's not there, so error */
+                num |= (x << 23);           /* insert first reg# into instruction */
             } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
+                return SCPE_ARG;            /* reg# invalid, so arg error */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
+                cptr++;                     /* skip any blanks */
             if ((r = get_imm(cptr, &tptr, 10, val)))    /* get 5 bit shift value */
-                return r;                           /* return error from conversion */
-            if (*val > 0x1f)                        /* 5 bit max count */
-                return SCPE_ARG;                    /* invalid shift count */
-            num |= (*val << 16);                    /* or in the 5 bit value */
+                return r;                   /* return error from conversion */
+            if (*val > 0x1f)                /* 5 bit max count */
+                return SCPE_ARG;            /* invalid shift count */
+            num |= (*val << 16);            /* or in the 5 bit value */
             break; 
 
         /* register bit operations */
-        case TYPE_K:        /* r,rb */
+        case TYPE_K:                        /* r,rb */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip blanks */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
+                cptr++;                     /* skip blanks */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
                 while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                if (*cptr++ != ',')                 /* test for required ',' */
-                    return SCPE_ARG;                /* it's not there, so error */
-                num |= (x << 20);                   /* insert reg# into instruction */
+                    cptr++;                 /* skip spaces */
+                if (*cptr++ != ',')         /* test for required ',' */
+                    return SCPE_ARG;        /* it's not there, so error */
+                num |= (x << 20);           /* insert reg# into instruction */
             } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
+                return SCPE_ARG;            /* reg# invalid, so arg error */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
+                cptr++;                     /* skip any blanks */
             if ((r = get_imm(cptr, &tptr, 10, val)))    /* get 5 bit bit number */
-                return r;                           /* return error from conversion */
-            if (*val > 0x1f)                        /* 5 bit max count */
-                return SCPE_ARG;                    /* invalid bit count */
-            x = *val / 8;                           /* get 2 bit byte number */
-            num |= (x & 3) << 16;                   /* insert 2 bit byte code into instruction */
-            x = *val % 8;                           /* get bit in byte value */
-            num |= (x & 7) << 23;                   /* or in the bit value */
-            break; 
-
-        /* interrupt control instructions */
-        case TYPE_L:        /* i */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
-            if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 7 bit bit number */
-                return r;                           /* return error from conversion */
-            if (*val > 0x7f)                        /* 7 bit max count */
-                return SCPE_ARG;                    /* invalid value */
-            num |= (*val & 0x7f) << 19;             /* or in the interrupt level */
-            break;
-
-        /* CD/TD Class E I/O instructions */
-        case TYPE_M:        /* d,v */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
-            if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 7 bit bit number */
-                return r;                           /* return error from conversion */
-            if (*val > 0x7f)                        /* 7 bit max count */
-                return SCPE_ARG;                    /* invalid value */
-            num |= (*val & 0x7f) << 19;             /* or in the device address */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
-            if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 16 bit command code */
-                return r;                           /* return error from conversion */
-            num |= *val;                            /* or in the 16 bit value */
-            break;
-        }
-        return (tab->type & H) ? 2 : 4;             /* done with nonbased instructions */
-    }
-
-    /* see if we are processing a base mode instruction */
-    if (sw & SWMASK ('M')) {                    /* base mode? */
-        /* process base mode instruction */
-        cptr = get_glyph(cptr, gbuf, 0);            /* Get uppercase opcode */
-        l = strlen(gbuf);                           /* save the num of char in opcode */
-        /* loop through the instruction table for an opcode match and get the type */ 
-        for (tab = optab; tab->name != NULL; tab++) {
-            i = tab->type & 0xf;                    /* get the type */
-            /* check for memory reference instruction */
-            if (i == TYPE_A || i == TYPE_E) {
-                /* test for base opcode name without B, H, W, D applied */
-                if (sim_strncasecmp(tab->name, gbuf, l - 1) == 0)
-                    break;                          /* found */
-            } else
-            /* test the full opcode name */
-            if (sim_strcasecmp(tab->name, gbuf) == 0) 
-                break;                              /* found */
-        }
-        if (tab->name == NULL)                      /* see if anything found */
-            return SCPE_ARG;                        /* no, return invalid argument error */
-        num = tab->opbase<<16;                      /* get the base opcode value */
-
-        /* process each instruction type */
-        switch(i) {
-        /* mem ref instruction */
-        case TYPE_A:                 /* c r,o[(b)][,x] */
-        /* zero memory instruction */
-        case TYPE_E:                 /* c o[(b)][,x] */
-        switch(gbuf[l]) {
-            case 'B': num |= 0x80000; break;        /* byte, set F bit */
-            case 'H': num |= 0x00001; break;        /* halfword */
-            case 'W': num |= 0x00000; break;        /* word */
-            case 'D': num |= 0x00002; break;        /* doubleword */
-            default:
-                return SCPE_ARG;                    /* base op suffix error */
-        }
-        /* Fall through */
-
-        /* BIx instructions or memory reference */
-        case TYPE_D:                 /* r,o[(b)],[,x] */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip leading blanks */
-            if (i != TYPE_E) {
-                /* get reg number except for zero memory instruction */
-                if (*cptr >= '0' || *cptr <= '7') { /* reg# is 0-7 */
-                    x = *cptr++ - '0';              /* get the reg# */
-                    while (sim_isspace(*cptr))
-                        cptr++;                     /* skip any blanks */
-                    if (*cptr++ != ',')             /* check for required comma */
-                        return SCPE_ARG;            /* anything else is an argument error */
-                    num |= x << 23;                 /* position reg number in instruction */
-                } else 
-                    return SCPE_ARG;                /* invalid reg number is an argument error */
-            }
-          /* Fall through */
-
-        /* branch instruction */
-        case TYPE_B:                 /* o[(b)],[,x] */
-            if ((r = get_off(cptr, &tptr, 16, val, &mod)))  /* get offset */
-                return r;                           /* argument error if a problem */
-            cptr = tptr;                            /* set pointer to returned next char pointer */
-            if (*val > 0xFFFF)                      /* 16 bit offset max */
-                return SCPE_ARG;                    /* argument error */
-            num |= *val;                            /* or offset into instruction */
-            if (mod) {                              /* see if '(' found in input */
-                if (*cptr >= '0' || *cptr <= '7') { /* base reg# 0-7 */
-                    x = *cptr++ - '0';              /* get reg number */
-                    while (sim_isspace(*cptr))
-                        cptr++;                     /* skip any spaces */
-                    if (*cptr++ != ')')             /* test for closing right parend */
-                        return SCPE_ARG;            /* arg error if not found */
-                   num |= x << 16;                  /* put base reg number into instruction */
-                } else
-                    return SCPE_ARG;                /* no '(' found, so arg error */
-            }
-            if (*cptr++ == ',') {                   /* test for optional index reg number */
-                if (*cptr >= '0' || *cptr <= '7') { /* reg# is 0-7 */
-                    x = *cptr++ - '0';              /* get reg number */
-                    num |= x << 20;                 /* position and put into instruction */
-                } else 
-                    return SCPE_ARG;                /* reg# not 0-7, so arg error */
-            }
-            break;
-
-        /* immediate or XIO instruction */
-        case TYPE_C:                 /* r,v */
-            while (sim_isspace(*cptr))
-                cptr++;     /* skip spaces */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* get reg# */
-                while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                if (*cptr++ != ',')                 /* next char need to be a comma */
-                    return SCPE_ARG;                /* it's not, so arg error */
-                num |= x << 23;                     /* position and put into instruction */
-            } else 
-                return SCPE_ARG;                    /* invalid reg#, so arg error */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
-            if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 16 bit immediate value */
-                return r;                           /* return error from conversion */
-            num |= *val;                            /* or in the 16 bit value */
-            break;
-
-        /* reg-reg instructions */
-        case TYPE_F:                  /* r,r */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip blanks */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
-                while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                if (*cptr++ != ',')                 /* test for required ',' */
-                    return SCPE_ARG;                /* it's not there, so error */
-                num |= x << 23;                     /* insert first reg# into instruction */
-            } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip more spaces */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
-                while (sim_isspace(*cptr))
-                    cptr++;                         /* skip any spaces */
-                num |= x << 20;                     /* insert 2nd reg# into instruction */
-            } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
-            break;
-
-        /* single reg instructions */
-        case TYPE_G:                    /* r */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip blanks */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
-                while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                num |= x << 23;                     /* insert first reg# into instruction */
-            } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
-            break;
-
-        /* opcode only instructions */
-        case TYPE_H:                    /* empty */
-            break;
-
-        /* reg and bit shift instructions */
-        case TYPE_I:                    /* r,b */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip blanks */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
-                while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                if (*cptr++ != ',')                 /* test for required ',' */
-                    return SCPE_ARG;                /* it's not there, so error */
-                num |= (x << 23);                   /* insert first reg# into instruction */
-            } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
-            if ((r = get_imm(cptr, &tptr, 10, val)))    /* get 5 bit shift value */
-                return r;                           /* return error from conversion */
-            if (*val > 0x1f)                        /* 5 bit max count */
-                return SCPE_ARG;                    /* invalid shift count */
-            num |= (*val << 16);                    /* or in the 5 bit value */
-            break; 
-
-        /* register bit operations */
-        case TYPE_K:                    /* r,rb */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip blanks */
-            if (*cptr >= '0' || *cptr <= '7') {     /* test for valid reg# */
-                x = *cptr++ - '0';                  /* calc reg# */
-                while (sim_isspace(*cptr))
-                    cptr++;                         /* skip spaces */
-                if (*cptr++ != ',')                 /* test for required ',' */
-                    return SCPE_ARG;                /* it's not there, so error */
-                num |= (x << 20);                   /* insert reg# into instruction */
-            } else 
-                return SCPE_ARG;                    /* reg# invalid, so arg error */
-            while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
-            if ((r = get_imm(cptr, &tptr, 10, val)))    /* get 5 bit bit number */
-                return r;                           /* return error from conversion */
-            if (*val > 0x1f)                        /* 5 bit max count */
-                return SCPE_ARG;                    /* invalid bit count */
-            x = *val / 8;                           /* get 2 bit byte number */
-            num |= (x & 3) << 16;                   /* insert 2 bit byte code into instruction */
-            x = *val % 8;                           /* get bit in byte value */
-            num |= (x & 7) << 23;                   /* or in the bit value */
+                return r;                   /* return error from conversion */
+            if (*val > 0x1f)                /* 5 bit max count */
+                return SCPE_ARG;            /* invalid bit count */
+            x = *val / 8;                   /* get 2 bit byte number */
+            num |= (x & 3) << 16;           /* insert 2 bit byte code into instruction */
+            x = *val % 8;                   /* get bit in byte value */
+            num |= (x & 7) << 23;           /* or in the bit value */
             break; 
 
         /* interrupt control instructions */
         case TYPE_L:                        /* i */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
+                cptr++;                     /* skip any blanks */
             if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 7 bit bit number */
-                return r;                           /* return error from conversion */
-            if (*val > 0x7f)                        /* 7 bit max count */
-                return SCPE_ARG;                    /* invalid value */
-            num |= (*val & 0x7f) << 19;             /* or in the interrupt level */
+                return r;                   /* return error from conversion */
+            if (*val > 0x7f)                /* 7 bit max count */
+                return SCPE_ARG;            /* invalid value */
+            num |= (*val & 0x7f) << 19;     /* or in the interrupt level */
             break;
 
         /* CD/TD Class E I/O instructions */
-        case TYPE_M:                    /* d,v */
+        case TYPE_M:                        /* d,v */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
+                cptr++;                     /* skip any blanks */
             if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 7 bit bit number */
-                return r;                           /* return error from conversion */
-            if (*val > 0x7f)                        /* 7 bit max count */
-                return SCPE_ARG;                    /* invalid value */
-            num |= (*val & 0x7f) << 19;             /* or in the device address */
+                return r;                   /* return error from conversion */
+            if (*val > 0x7f)                /* 7 bit max count */
+                return SCPE_ARG;            /* invalid value */
+            num |= (*val & 0x7f) << 19;     /* or in the device address */
             while (sim_isspace(*cptr))
-                cptr++;                             /* skip any blanks */
+                cptr++;                     /* skip any blanks */
             if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 16 bit command code */
-                return r;                           /* return error from conversion */
-            num |= *val;                            /* or in the 16 bit value */
+                return r;                   /* return error from conversion */
+            num |= *val;                    /* or in the 16 bit value */
             break;
         }
-        return (tab->type & H) ? 2 : 4;             /* done with base mode insrructions */
+        return (tab->type & H) ? 2 : 4;     /* done with nonbased instructions */
+    }
+
+    /* see if we are processing a base mode instruction */
+    if (sw & SWMASK ('M')) {                /* base mode? */
+        /* process base mode instruction */
+        cptr = get_glyph(cptr, gbuf, 0);    /* Get uppercase opcode */
+        l = strlen(gbuf);                   /* save the num of char in opcode */
+        /* loop through the instruction table for an opcode match and get the type */ 
+        for (tab = optab; tab->name != NULL; tab++) {
+            i = tab->type & 0xf;            /* get the type */
+            /* check for memory reference instruction */
+            if (i == TYPE_A || i == TYPE_E) {
+                /* test for base opcode name without B, H, W, D applied */
+                if (sim_strncasecmp(tab->name, gbuf, l - 1) == 0)
+                    break;                  /* found */
+            } else
+            /* test the full opcode name */
+            if (sim_strcasecmp(tab->name, gbuf) == 0) 
+                break;                      /* found */
+        }
+        if (tab->name == NULL)              /* see if anything found */
+            return SCPE_ARG;                /* no, return invalid argument error */
+        num = tab->opbase<<16;              /* get the base opcode value */
+
+        /* process each instruction type */
+        switch(i) {
+        /* mem ref instruction */
+        case TYPE_A:                        /* c r,o[(b)][,x] */
+        /* zero memory instruction */
+        case TYPE_E:                        /* c o[(b)][,x] */
+        switch(gbuf[l]) {
+            case 'B': num |= 0x80000; break;    /* byte, set F bit */
+            case 'H': num |= 0x00001; break;    /* halfword */
+            case 'W': num |= 0x00000; break;    /* word */
+            case 'D': num |= 0x00002; break;    /* doubleword */
+            default:
+                return SCPE_ARG;            /* base op suffix error */
+        }
+        /* Fall through */
+
+        /* BIx instructions or memory reference */
+        case TYPE_D:                        /* r,o[(b)],[,x] */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip leading blanks */
+            if (i != TYPE_E) {
+                /* get reg number except for zero memory instruction */
+                if (*cptr >= '0' || *cptr <= '7') { /* reg# is 0-7 */
+                    x = *cptr++ - '0';      /* get the reg# */
+                    while (sim_isspace(*cptr))
+                        cptr++;             /* skip any blanks */
+                    if (*cptr++ != ',')     /* check for required comma */
+                        return SCPE_ARG;    /* anything else is an argument error */
+                    num |= x << 23;         /* position reg number in instruction */
+                } else 
+                    return SCPE_ARG;        /* invalid reg number is an argument error */
+            }
+          /* Fall through */
+
+        /* branch instruction */
+        case TYPE_B:                        /* o[(b)],[,x] */
+            if ((r = get_off(cptr, &tptr, 16, val, &mod)))  /* get offset */
+                return r;                   /* argument error if a problem */
+            cptr = tptr;                    /* set pointer to returned next char pointer */
+            if (*val > 0xFFFF)              /* 16 bit offset max */
+                return SCPE_ARG;            /* argument error */
+            num |= *val;                    /* or offset into instruction */
+            if (mod) {                      /* see if '(' found in input */
+                if (*cptr >= '0' || *cptr <= '7') { /* base reg# 0-7 */
+                    x = *cptr++ - '0';      /* get reg number */
+                    while (sim_isspace(*cptr))
+                        cptr++;             /* skip any spaces */
+                    if (*cptr++ != ')')     /* test for closing right parend */
+                        return SCPE_ARG;    /* arg error if not found */
+                   num |= x << 16;          /* put base reg number into instruction */
+                } else
+                    return SCPE_ARG;        /* no '(' found, so arg error */
+            }
+            if (*cptr++ == ',') {           /* test for optional index reg number */
+                if (*cptr >= '0' || *cptr <= '7') { /* reg# is 0-7 */
+                    x = *cptr++ - '0';      /* get reg number */
+                    num |= x << 20;         /* position and put into instruction */
+                } else 
+                    return SCPE_ARG;        /* reg# not 0-7, so arg error */
+            }
+            break;
+
+        /* immediate or XIO instruction */
+        case TYPE_C:                        /* r,v */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip spaces */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* get reg# */
+                while (sim_isspace(*cptr))
+                    cptr++;                 /* skip spaces */
+                if (*cptr++ != ',')         /* next char need to be a comma */
+                    return SCPE_ARG;        /* it's not, so arg error */
+                num |= x << 23;             /* position and put into instruction */
+            } else 
+                return SCPE_ARG;            /* invalid reg#, so arg error */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip any blanks */
+            if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 16 bit immediate value */
+                return r;                   /* return error from conversion */
+            num |= *val;                    /* or in the 16 bit value */
+            break;
+
+        /* reg-reg instructions */
+        case TYPE_F:                        /* r,r */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip blanks */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
+                while (sim_isspace(*cptr))
+                    cptr++;                 /* skip spaces */
+                if (*cptr++ != ',')         /* test for required ',' */
+                    return SCPE_ARG;        /* it's not there, so error */
+                num |= x << 23;             /* insert first reg# into instruction */
+            } else 
+                return SCPE_ARG;            /* reg# invalid, so arg error */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip more spaces */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
+                while (sim_isspace(*cptr))
+                    cptr++;                 /* skip any spaces */
+                num |= x << 20;             /* insert 2nd reg# into instruction */
+            } else 
+                return SCPE_ARG;            /* reg# invalid, so arg error */
+            break;
+
+        /* single reg instructions */
+        case TYPE_G:                        /* r */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip blanks */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
+                while (sim_isspace(*cptr))
+                    cptr++;                 /* skip spaces */
+                num |= x << 23;             /* insert first reg# into instruction */
+            } else 
+                return SCPE_ARG;            /* reg# invalid, so arg error */
+            break;
+
+        /* opcode only instructions */
+        case TYPE_H:                        /* empty */
+            break;
+
+        /* reg and bit shift instructions */
+        case TYPE_I:                        /* r,b */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip blanks */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
+                while (sim_isspace(*cptr))
+                    cptr++;                 /* skip spaces */
+                if (*cptr++ != ',')         /* test for required ',' */
+                    return SCPE_ARG;        /* it's not there, so error */
+                num |= (x << 23);           /* insert first reg# into instruction */
+            } else 
+                return SCPE_ARG;            /* reg# invalid, so arg error */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip any blanks */
+            if ((r = get_imm(cptr, &tptr, 10, val)))    /* get 5 bit shift value */
+                return r;                   /* return error from conversion */
+            if (*val > 0x1f)                /* 5 bit max count */
+                return SCPE_ARG;            /* invalid shift count */
+            num |= (*val << 16);            /* or in the 5 bit value */
+            break; 
+
+        /* register bit operations */
+        case TYPE_K:                        /* r,rb */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip blanks */
+            if (*cptr >= '0' || *cptr <= '7') { /* test for valid reg# */
+                x = *cptr++ - '0';          /* calc reg# */
+                while (sim_isspace(*cptr))
+                    cptr++;                 /* skip spaces */
+                if (*cptr++ != ',')         /* test for required ',' */
+                    return SCPE_ARG;        /* it's not there, so error */
+                num |= (x << 20);           /* insert reg# into instruction */
+            } else 
+                return SCPE_ARG;            /* reg# invalid, so arg error */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip any blanks */
+            if ((r = get_imm(cptr, &tptr, 10, val)))    /* get 5 bit bit number */
+                return r;                   /* return error from conversion */
+            if (*val > 0x1f)                /* 5 bit max count */
+                return SCPE_ARG;            /* invalid bit count */
+            x = *val / 8;                   /* get 2 bit byte number */
+            num |= (x & 3) << 16;           /* insert 2 bit byte code into instruction */
+            x = *val % 8;                   /* get bit in byte value */
+            num |= (x & 7) << 23;           /* or in the bit value */
+            break; 
+
+        /* interrupt control instructions */
+        case TYPE_L:                        /* i */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip any blanks */
+            if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 7 bit bit number */
+                return r;                   /* return error from conversion */
+            if (*val > 0x7f)                /* 7 bit max count */
+                return SCPE_ARG;            /* invalid value */
+            num |= (*val & 0x7f) << 19;     /* or in the interrupt level */
+            break;
+
+        /* CD/TD Class E I/O instructions */
+        case TYPE_M:                        /* d,v */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip any blanks */
+            if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 7 bit bit number */
+                return r;                   /* return error from conversion */
+            if (*val > 0x7f)                /* 7 bit max count */
+                return SCPE_ARG;            /* invalid value */
+            num |= (*val & 0x7f) << 19;     /* or in the device address */
+            while (sim_isspace(*cptr))
+                cptr++;                     /* skip any blanks */
+            if ((r = get_imm(cptr, &tptr, rdx, val)))   /* get 16 bit command code */
+                return r;                   /* return error from conversion */
+            num |= *val;                    /* or in the 16 bit value */
+            break;
+        }
+        return (tab->type & H) ? 2 : 4;     /* done with base mode insrructions */
     }
 
     /* get here for any other switch value */
     /* this code will get a value based on length specified in switches */
-    num = get_uint(cptr, rdx, max[l], &r);          /* get the unsigned value */
+    num = get_uint(cptr, rdx, max[l], &r);  /* get the unsigned value */
     for (i = 0; i < l && i < 4; i++) 
         val[i] = (num >> ((l - (1 + i)) * 8)) & 0xff; /* get 1-4 bytes of data */
     return -(l-1);

--- a/SEL32/taptools/README.md
+++ b/SEL32/taptools/README.md
@@ -162,7 +162,7 @@ tapdump -  This program reads a metadata .tap file and prints a side
            output - stdout
 
 tape2disk - This program reads a tape assigned as input device.  It
-           generated a .tap metadata file.  Stdout will contain a
+           generates a .tap metadata file.  Stdout will contain a
            listing of the files and sizes written to disk.  The define
            #define FILEMGR must be compiled in for tapes ending with
            two EOFs.  Unix and MPX 1.x filemgr tapes use that format.
@@ -173,6 +173,15 @@ tape2disk - This program reads a tape assigned as input device.  It
            input -  mag tape device being read
            output - list of files and sizes read from input tape
            output - metadata .tap file optionally specified
+
+disk2tap - This program reads a file assigned as input device.  It
+           generates a .tap formatted metadata file.  Stdout will
+           display the file name and size written to disk.
+
+           command: disk2tap file [dest.tap]
+           input -  input filename being read
+           output - filename and size read from input
+           output - metadata .tap file specified
 
 tapscan -  This program scans a metadata .tap file and prints the
            file count and sizes.  Used to determine the file

--- a/SEL32/taptools/disk2tap.c
+++ b/SEL32/taptools/disk2tap.c
@@ -1,0 +1,226 @@
+/*
+ * MPX uses 2 EOF in a row to separate sections of MPX3.x master SDT tapes.
+ * It uses 3 EOF in a row to indicate the EOT on MPX 3.X tapes.  So we
+ * cannot assume EOT is at the 1st or 2nd EOF in a row.  Keep looking
+ * for a third one.  Comment out the #define FMGRTAPE below to read an
+ * MPX 3.x master SDT.  For user SDT tapes or MPX 1.X master SDT tapes
+ * leave the #define FMGRTAPE uncommented so it will be defined.  The
+ * program will stop on two EOFs.  For non MPX tapes, the 2nd EOF means
+ * EOT. Some tapes have only one EOT and will terminate on EOT detected.
+ * Leave off the output file name to just scan the tape and output record
+ * sizes and counts.
+ */
+
+#include <stdio.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/file.h>
+#include <sys/fcntl.h>
+#include <sys/mtio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include <errno.h>
+
+//#define FMGRTAPE              /* defined for filemgr tapes, undefined for volmgr tape */
+
+char *buff;                     /* buffer for read/write */
+int filen = 1;                  /* file number being processed */
+long count=0, lcount=0;         /* number of blocks for file */
+extern void RUBOUT();           /* handle user DELETE key signal */
+off_t size=0, tsize=0;          /* number of bytes in file, total */
+int ln;
+char *inf, *outf;
+int copy;
+int32_t size_1K = 1024;
+#if 0
+int32_t size_128K = 128 * 1024;
+int32_t size_256K = 256 * 1024;
+#endif
+
+int main(argc, argv)
+int argc;
+char **argv;
+{
+    int n, nw, inp, outp;
+    struct mtop op;
+//  int32_t buf_size = size_256K;
+    int32_t buf_size = size_1K;
+    int EOFcnt = 0;     /* count the number of EOFs in a row. */
+
+    if (argc <= 1 || argc > 3) {
+        (void)fprintf(stderr, "Usage: disk2tap src [dest]\n");
+        return (1);
+    }
+    inf = argv[1];
+    if (argc == 3) {
+        outf = argv[2];
+        copy = 1;
+    }
+    if ((inp = open(inf, O_RDONLY, 0666)) < 0) {
+        (void)fprintf(stderr, "Can't open %s\n", inf);
+        return (1);
+    }
+    if (copy) {
+        /* open output file, create it if necessary */
+        if ((outp = open(outf, O_WRONLY|O_CREAT, 0666)) < 0) {
+            (void)fprintf(stderr, "Can't open %s\n", outf);
+            return (3);
+        }
+    }
+    /* get a 1k buffer */
+    if ((buff = malloc(buf_size)) == NULL) {
+        (void)fprintf(stderr, "Can't allocate memory for disk2tap\n");
+        return (4);
+    }
+    if (signal(SIGINT, SIG_IGN) != SIG_IGN)
+        (void)signal(SIGINT, RUBOUT);
+
+    ln = -2;
+    for (;;) {
+        count++;
+        errno = 0;
+        /* read first record to get size for buffer, doubling each time unsuccessful */
+        while ((n = read(inp, buff, buf_size)) < 0) {
+            if (errno == ENOMEM) {
+#if 0
+                if (buf_size < size_256K)
+                    buf_size = size_256K;
+                else
+                    buf_size *= 2;
+#endif
+                free(buff);
+                if ((buff = malloc(buf_size)) == NULL) {
+                    (void)fprintf(stderr, "Can't allocate memory for tapecopy\n");
+                    return (4);
+                }
+                op.mt_op = MTFSF;   /* Rewind to start of file */
+                op.mt_count = (daddr_t) 0;
+                if (ioctl(inp, MTIOCTOP, (char *)&op) < 0) {
+                    perror("Read buffer size error");
+                    return (6);
+                }
+                errno = 0;
+                continue;
+            }
+            perror("Unknown read error");
+            errno = 0;
+//          return (6);     /* abort on error, comment out to ignore taoe errors */
+        }
+        if (n > 0) {
+            /* we read some data, see if scanning or writing */
+            EOFcnt = 0;     /* not at EOF anymore */
+            if (copy) {
+                int32_t n1, n2;
+                /* we have data to write */
+                int32_t hc = (n + 1) & ~1;      /* make byte count even */
+                int32_t wc = n;                 /* get actual byte count */
+                /* write actual byte count to 32 bit word as header */
+                n1 = write(outp, (char *)(&wc), (int32_t)4);
+                /* write the data mod 2 */
+                nw = write(outp, buff, (int32_t)hc);
+                /* write the byte count in 32 bit word as footer */
+                n2 = write(outp, (char *)(&wc), (int32_t)4);
+                if (n1 != 4 || nw != hc || n2 != 4) {
+                    fprintf(stderr, "write (%d) !=" " read (%d)\n", nw, n);
+                    fprintf(stderr, "COPY " "Aborted\n");
+                    return (5);
+                }
+            }
+            size += n;      /* update bytes read */
+            if (n != ln) {  /* must be last record of file if different */
+                if (ln > 0) {
+                    /* we read something */
+                    if ((count - lcount) > 1)
+                        (void)printf("file %d: records %ld to %ld: size %d\n", filen, lcount, count - 1, ln);
+                    else
+                        (void)printf("file %d: record %ld: size %d\n", filen, lcount, ln);
+                }
+                ln = n;             /* save last record size */
+                lcount = count;     /* also record count */
+            }
+        } else {
+            /* we did not read data, it must be an EOF */
+            /* if ln is -1, last operation was EOF, now we have a second */
+#ifdef FMGRTAPE
+            /* filemgr has 2 EOF's at end of tape */
+            if (++EOFcnt > 1) {
+                /* two EOFs mean we are at EOT */
+                (void)printf("fmgr eot\n");
+                break;
+            }
+#else
+            /* volmgr has 3 EOF's at end of tape */
+            if (++EOFcnt > 2) {
+                /* three EOFs mean we are at EOT on MPX */
+                (void)printf("volm eot\n");
+                break;
+            }
+#endif
+            if (ln > 0) {
+                if (count - lcount > 1)
+                    (void)printf("file %d: records %ld to %ld: size %d\n", filen, lcount, count - 1, ln);
+                else
+                    (void)printf("file %d: record %ld: size %d\n", filen, lcount, ln);
+            }
+#ifdef FMGRTAPE
+            (void)printf("file %d: eof after %ld records: %ld bytes\n", filen, count - 1, size);
+#else
+            if (EOFcnt == 2)        /* if 2nd EOF, print file info */
+                (void)printf("second eof after %d files: %ld bytes\n", filen, size);
+#endif
+            if (copy) {
+                /* write a sudo EOF to disk file as a zero 4 byte record */
+                int n1, hc = 0;
+                /* write the EOF */
+                /* write a zero as the byte count in 32 bit word as EOF */
+                n1 = write(outp, (char *)(&hc), (int32_t)4);
+                if (n1 != 4) {
+                    perror("Write EOF");
+                    return (6);
+                }
+            }
+#ifdef FMGRTAPE
+            filen++;            /* advance number of files */
+#else
+            if (EOFcnt < 2)     /* not really a file if 2nd EOF */
+                filen++;        /* advance number of files */
+#endif
+            count = 0;      /* file record count back to zero */
+            lcount = 0;     /* last record count back to zero */
+            tsize += size;  /* add to total tape size */
+            size = 0;       /* file size back to zero */
+            ln = n;         /* set ln to -1 showing we are at EOF */
+        }
+    }
+    if (copy) {
+        /* write a sudo EOM to disk file as a -1 4 byte record */
+        int32_t n1, hc = 0xffffffff;
+        /* write the EOM to disk */
+        /* write a -1 as the byte count in 32 bit word as EOM */
+        n1 = write(outp, (char *)(&hc), (int32_t)4);
+        if (n1 != 4) {
+            perror("Write EOM");
+            return (6);
+        }
+        (void)close(outp);
+    }
+    /* print out total tape size in bytes */
+    (void)printf("total length: %ld bytes\n", tsize);
+    return (0);
+}
+
+/* entered when user hit the DELETE key */
+void RUBOUT()
+{
+    if (count > lcount)
+        --count;
+    if (count)
+        if (count > lcount)
+            (void)printf("file %d: records %ld to %ld: size" " %d\n", filen, lcount, count, ln);
+        else
+            (void)printf("file %d: record %ld: size %d\n", filen, lcount, ln);
+    (void)printf("interrupted at file %d: record %ld\n", filen, count);
+    (void)printf("total length: %ld bytes\n", tsize + size);
+    exit(1);
+}

--- a/SEL32/taptools/makefile
+++ b/SEL32/taptools/makefile
@@ -32,6 +32,7 @@ PROGS =			\
 	$(ROOT)/mkdiagtape \
 	$(ROOT)/tapdump	\
 	$(ROOT)/tape2disk \
+	$(ROOT)/disk2tap \
 	$(ROOT)/tapscan \
 	$(ROOT)/eomtap \
 	$(ROOT)/volmcopy \
@@ -108,6 +109,12 @@ $B/tapdump:	$D tapdump.c
 	@echo $(@F) installed in $B
 
 $B/tape2disk:	$D tape2disk.c
+	@-$(CC) $(CFLAGS) $(@F).c $(LFLAGS) -o $@
+	@chmod 755 $@
+	@cp $(@F) $B
+	@echo $(@F) installed in $B
+
+$B/disk2tap:	$D disk2tap.c
 	@-$(CC) $(CFLAGS) $(@F).c $(LFLAGS) -o $@
 	@chmod 755 $@
 	@cp $(@F) $B


### PR DESCRIPTION
SEL32: Correct unused SPAD location test for interrupt control instructions.
SEL32: Correct HSDP test for formatted disk.
SEL32: Add reset channel command processing for each defined device.
SEL32: Add disk2tap utility to taptools.
SEL32: Test for UTX ZMAP in last sector of SCSI disk when formatting.
SEL32: General code cleanup in multiple modules.