### PR TITLE
KA10: Accept SOJx instructions in the idle loop.

### DIFF
--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -4880,7 +4880,7 @@ st_pi:
 
     /* Check if possible idle loop */
     if (sim_idle_enab &&
-          (((FLAGS & USER) != 0 && PC < 020 && AB < 020 && (IR & 0760) == 0340) ||
+          (((FLAGS & USER) != 0 && PC < 020 && AB < 020 && (IR & 0740) == 0340) ||
            (uuo_cycle && (IR & 0740) == 0 && IA == 041))) {
        sim_idle (TMR_RTC, FALSE);
     }


### PR DESCRIPTION
WAITS has this null job:

```
NULJ10:	0
	ROT 0,-1	; RING AROUND THE ACCUMULATOR
	TLNN 0,200000
	TLC 0,400000
	MOVEI 10,70000
	SOJGE 10,5
	JRST 1
```