### PR TITLE
KA10: Fix Data Control to clear character count on DATAI/O.

### DIFF
--- a/PDP10/pdp6_dct.c
+++ b/PDP10/pdp6_dct.c
@@ -118,7 +118,7 @@ dct_devio(uint32 dev, uint64 *data) {
           clr_interrupt(dev);
           if (uptr->STATUS & DB_RQ) {
               *data = dct_buf[u];
-              uptr->STATUS &= ~(DB_RQ);
+              uptr->STATUS &= ~(NUM_CHARS|DB_RQ);
               uptr->STATUS |= DB_MV;
               sim_activate(uptr, 10);
           }
@@ -132,7 +132,7 @@ dct_devio(uint32 dev, uint64 *data) {
                   dev, *data, u, PC);
           if (uptr->STATUS & DB_RQ) {
               dct_buf[u] = *data;
-              uptr->STATUS &= ~(DB_RQ);
+              uptr->STATUS &= ~(NUM_CHARS|DB_RQ);
               uptr->STATUS |= DB_MV;
               sim_activate(uptr, 10);
           }


### PR DESCRIPTION
After reading a tape record, WAITS checks the count and fetches any remaining characters.  It's expected that the count be zero if an even number of 36-bit words have been read.

Resolves #242 