### PR TITLE
SEL32: Update sel32_disk to only do sector/track replacement for disk.

### DIFF
--- a/SEL32/README.md
+++ b/SEL32/README.md
@@ -14,9 +14,9 @@ test version of MPX 3.4.  It is capable of creating a disk image for the
 O/S from a UTX or MPX SDT tape. The disk image can be booted, initialized,
 and can run many of the UTX and MPX utilities and programs. Ethernet is
 supported on UTX and may be added to MPX in the future.  Eight terminals
-can be used to access MPX via Telnet port 4747. The sumulator has support
-for excess 64 floating point arithmetic and passes the 32/27 and 32/67 FP
-diags.
+can be used to access MPX or UTX via Telnet port 4747. The sumulator has
+support for excess 64 floating point arithmetic and passes the 32/27 and
+32/67 FP diags.
 
 The sim32disk.gz file is a prebuilt MPX 1.5F system disk.  It can be
 uncompressed and booted with the sel32.27.sim32.disk.ini initialization
@@ -33,8 +33,8 @@ UTX 2.1B system.  These files are only available from my sims project at
 https://github.com/AZBevier/sims.  A MPX 3.X test version will be added
 in the future when testing is complete.
 
-Available tap tools:
-taptools.tgz - set of tools to work with .tap formatted tapes.  Also tools
+Available tap tools in taptools directory:
+./taptools   - set of tools to work with .tap formatted tapes.  Also tools
                to convert between MPX and UNIX file formats.  See README
                file and source for descriptions.
 
@@ -56,14 +56,14 @@ sim32sdt.tap - MPX 1.5f user SDT install tape.  Uses 300mb disk, IOP 8-line
                FIL> RESTORE
                FIL> X
 
-Available Level One Diagnostic boot tape:
-diag.ini       command file to start diags. Type "./sel32 tests/diag.ini"
-diag.tap       bootable level one diagnostic tape w/auto testing.  Set
-               cpu type to 32/27, 32/67, 32/87, 32/97, V6 or V9.  All
+Available Level One Diagnostic boot tape in tests directory:
+diag.ini     - command file to start diags. Type "./sel32 tests/diag.ini"
+diag.tap     - bootable level one diagnostic tape w/auto testing.
+               Set cpu type to 32/27, 32/67, 32/87, 32/97, V6 or V9.  All
                cpu models now run all diagnostics provided on the
                diagnostic tape.  Running DEXP stand alone causes input
-               to stop after a few characters are entered.  More
-               testing is still required.
+               to stop after a few characters are entered.  More testing
+               is still required.
 
                CV.CSL - Firmware control diag.  Disabled in auto testing.
                CV.CP1 - CPU diag part 1 runs OK.
@@ -105,5 +105,5 @@ Other MPX verions support:
                disk image of a bootable MPX3.X system.
 
 James C. Bevier
-02/13/2021 
+04/14/2021 
 

--- a/SEL32/sel32_cpu.c
+++ b/SEL32/sel32_cpu.c
@@ -1959,7 +1959,7 @@ wait_loop:
             goto wait_loop;                         /* continue waiting */
         }
 
-//#define NEW_WAIT
+#define NEW_WAIT
 #ifdef NEW_WAIT
         /* process IOCL entries that are waiting */
         /* loop through the IOCL ready Q and decrement wait counts */
@@ -1978,7 +1978,7 @@ wait_loop:
                     continue;
                 if (chp->chan_byte != BUFF_NEXT) {
                     /* if not BUFF_NEXT, channel has been stopped, do nothing */
-                    sim_debug(DEBUG_XIO, &cpu_dev,
+                    sim_debug(DEBUG_EXP, &cpu_dev,
                         "scan_chan Bad CPU RDYQ entry for chsa %04x chan_byte %02x\n",
                         chsa, chp->chan_byte);
                     /* not BUFF_NEXT, just zero entry */
@@ -1992,17 +1992,20 @@ wait_loop:
                 /* process 0 wait entry */
                 if (chp->chan_qwait == 0)        {
                     int32 stat;
-                    sim_debug(DEBUG_XIO, &cpu_dev,
+//                  sim_debug(DEBUG_XIO, &cpu_dev,
+                    sim_debug(DEBUG_EXP, &cpu_dev,
                         "scan_chan CPU RDYQ entry for chsa %04x starting byte %02x\n",
                         chsa, chp->chan_byte);
                     /* if not BUFF_NEXT, channel has been stopped, do nothing */
                     stat = cont_chan(chsa);         /* resume the channel program */
                     if (stat == SCPE_OK)
-                        sim_debug(DEBUG_XIO, &cpu_dev,
+//                      sim_debug(DEBUG_XIO, &cpu_dev,
+                        sim_debug(DEBUG_EXP, &cpu_dev,
                         "scan_chan CPU RDYQ entry for chsa %04x processed byte %04x\n",
                         chsa, chp->chan_byte);
                     else
-                        sim_debug(DEBUG_XIO, &cpu_dev,
+//                      sim_debug(DEBUG_XIO, &cpu_dev,
+                        sim_debug(DEBUG_EXP, &cpu_dev,
                         "scan_chan CPU RDYQ entry for chsa %04x processed w/error byte %04x\n",
                         chsa, chp->chan_byte);
                     irq_pend = 1;                   /* start scanning interrupts again */
@@ -2017,7 +2020,8 @@ wait_loop:
         /* we get here when not booting */
         /* process any pending interrupts */
 #ifdef NEW_WAIT
-        if ((irq_pend || wait4int) && (RDYQ_Num() == 0) && (irq_auto == 0)) {
+//041321if ((irq_pend || wait4int) && (RDYQ_Num() == 0) && (irq_auto == 0)) {
+        if ((irq_pend || wait4int) && (irq_auto == 0)) {
 #else
         if ((irq_pend || wait4int) && (irq_auto == 0)) {
 #endif
@@ -2151,7 +2155,8 @@ wait_loop:
                     continue;
                 if (chp->chan_byte != BUFF_NEXT) {
                     /* if not BUFF_NEXT, channel has been stopped, do nothing */
-                    sim_debug(DEBUG_XIO, &cpu_dev,
+//                  sim_debug(DEBUG_XIO, &cpu_dev,
+                    sim_debug(DEBUG_EXP, &cpu_dev,
                         "scan_chan Bad CPU RDYQ entry for chsa %04x chan_byte %02x\n",
                         chsa, chp->chan_byte);
                     /* not BUFF_NEXT, just zero entry */
@@ -2163,17 +2168,20 @@ wait_loop:
                 /* process 0 wait entry */
                 if (chp->chan_qwait == 0)        {
                     int32 stat;
-                    sim_debug(DEBUG_XIO, &cpu_dev,
+//                  sim_debug(DEBUG_XIO, &cpu_dev,
+                    sim_debug(DEBUG_EXP, &cpu_dev,
                         "scan_chan CPU RDYQ entry for chsa %04x starting byte %02x\n",
                         chsa, chp->chan_byte);
                     /* if not BUFF_NEXT, channel has been stopped, do nothing */
                     stat = cont_chan(chsa);         /* resume the channel program */
                     if (stat == SCPE_OK)
-                        sim_debug(DEBUG_XIO, &cpu_dev,
+//                      sim_debug(DEBUG_XIO, &cpu_dev,
+                        sim_debug(DEBUG_EXP, &cpu_dev,
                         "scan_chan CPU RDYQ entry for chsa %04x processed byte %04x\n",
                         chsa, chp->chan_byte);
                     else
-                        sim_debug(DEBUG_XIO, &cpu_dev,
+//                      sim_debug(DEBUG_XIO, &cpu_dev,
+                        sim_debug(DEBUG_EXP, &cpu_dev,
                         "scan_chan CPU RDYQ entry for chsa %04x processed w/error byte %04x\n",
                         chsa, chp->chan_byte);
                     irq_pend = 1;                   /* start scanning interrupts again */

--- a/SEL32/sel32_ec.c
+++ b/SEL32/sel32_ec.c
@@ -1038,7 +1038,7 @@ wr_end:
         }
         sim_debug(DEBUG_DETAIL, &ec_dev,
             "ec_srv sent packet %d bytes tx_count=%08x SNS %08x\n",
-		    ec_data.snd_buff.len, ec_data.tx_count, uptr->SNS);
+            ec_data.snd_buff.len, ec_data.tx_count, uptr->SNS);
 
         if (pirq)
             chan_end(chsa, SNS_CHNEND|SNS_DEVEND|STATUS_PCHK);

--- a/SEL32/sel32_fltpt.c
+++ b/SEL32/sel32_fltpt.c
@@ -650,8 +650,8 @@ t_uint64 s_fltd(t_uint64 intv, uint32 *cc) {
 #define UMASK   0x0ffffff0              /* single fp mask */
 #define XMASK   0x0fffffff              /* single fp mask */
 #define MMASK   0x00ffffff              /* single mantissa mask */
-#define NMASK   0x0f000000  		    /* single nibble mask */
-#define ZMASK   0x00f00000  		    /* single nibble mask */
+#define NMASK   0x0f000000              /* single nibble mask */
+#define ZMASK   0x00f00000              /* single nibble mask */
 
 /* this new version is perfect against the diags, so good */
 /* do new SEL floating add derived from IBM370 code */

--- a/SEL32/sel32_hsdp.c
+++ b/SEL32/sel32_hsdp.c
@@ -34,7 +34,7 @@
 
 /* useful conversions */
 /* Fill STAR value from cyl, trk, sec data */
-#define CHS2STAR(c,h,s)	        (((c<<16) & LMASK)|((h<<8) & 0xff00)|(s & 0xff))
+#define CHS2STAR(c,h,s)         (((c<<16) & LMASK)|((h<<8) & 0xff00)|(s & 0xff))
 /* convert STAR value to number of sectors */
 #define STAR2SEC(star,spt,spc)  ((star&0xff)+(((star>>8)&0xff)*spt)+(((star>>16)&0xffff)*spc))
 /* convert STAR value to number of heads or tracks */
@@ -197,9 +197,9 @@ Byte 1 bits 7-15
     /* for track 0, write max cyl/head/sec values in 0-3 */
     /* otherwise write current values */
 /*
-0   short lcyl;	        cylinder
-2   char ltkn;			head or track number
-3   char lid;			track label id (0xff means last track)
+0   short lcyl;         cylinder
+2   char ltkn;          head or track number
+3   char lid;           track label id (0xff means last track)
 4   char lflg1;         track status flags
         bit 0           good trk
             1           alternate trk
@@ -229,7 +229,7 @@ Byte 1 bits 7-15
 22  short laltcyl;      alternate cylinder number or return cyl num
 24  char lalttk;        alrernate track number or return track num
 25  char ldscnt;        data sector count 16/20
-26  char ldatrflg;		device attributes
+26  char ldatrflg;      device attributes
         bit 0           n/u
             1           disk is mhd
             2           n/u
@@ -248,9 +248,9 @@ Byte 1 bits 7-15
 /*************************************/
 /* sector label definations 34 bytes */
 /*
-0   short lcyl;	        cylinder number
-2   char lhd;			head number
-3   char lsec;		    sec # 0-15 or 0-19 for 16/20 format
+0   short lcyl;         cylinder number
+2   char lhd;           head number
+3   char lsec;          sec # 0-15 or 0-19 for 16/20 format
 4   char lflg1;         track/sector status flags
         bit 0           good sec
             1           alternate sec
@@ -277,7 +277,7 @@ Byte 1 bits 7-15
 22  short laltcyl;      alternate cylinder number or return cyl num
 24  char lalttk;        alrernate track number or return track num
 25  char ldscnt;        data sector count 16/20
-26  char ldatrflg;		device attributes
+26  char ldatrflg;      device attributes
         bit 0           n/u
             1           disk is mhd
             2           n/u
@@ -295,9 +295,9 @@ Byte 1 bits 7-15
 
 /* track label / sector label definations */
 /*
- 0  short lcyl;	        cylinder
- 2  char ltkn;			track
- 3  char lid;			sector id
+ 0  short lcyl;         cylinder
+ 2  char ltkn;          track
+ 3  char lid;           sector id
  4  char lflg1;         track/sector status flags
         bit 0           good
             1           alternate
@@ -311,12 +311,12 @@ Byte 1 bits 7-15
  8  short lspar2;
 10  short ldef1;
 12  int ldeallp;        DMAP block number trk0
-16  int lumapp;			UMAP block number sec1
+16  int lumapp;         UMAP block number sec1
 20  short ladef3;
 22  short laltcyl;
 24  char lalttk;        sectors per track
 25  char ldscnt;        number of heads
-26  char ldatrflg;		device attributes
+26  char ldatrflg;      device attributes
         bit 0           n/u
             1           disk is mhd
             2           n/u
@@ -1437,12 +1437,13 @@ t_stat hsdp_srv(UNIT *uptr)
 
     case DSK_NOP:                               /* NOP 0x03 */
         if ((uptr->CMD & DSK_WAITING) == 0) {
-            /* Do a fake wait to kill time */
+            /* Do a fake wait to kill some time */
             uptr->CMD |= DSK_WAITING;           /* show waiting for NOP */
             sim_debug(DEBUG_CMD, dptr, "hsdp_srv cmd NOP stalling for 50 cnts\n");
 //          sim_activate(uptr, 250);            /* start waiting */
 //          sim_activate(uptr, 50);             /* start waiting */
-            sim_activate(uptr, 20);             /* start waiting */
+//30        sim_activate(uptr, 350);             /* start waiting */
+            sim_activate(uptr, 350);             /* start waiting */
             break;
         }
         /* NOP drop through after wait */

--- a/SEL32/sel32_lpr.c
+++ b/SEL32/sel32_lpr.c
@@ -1,4 +1,4 @@
-/* sel32_lpr.c: SEL 32 Line Printer
+/* sel32_lpr.c: SEL32 922x & 924x High Speed Line Printer
 
    Copyright (c) 2018-2021, James C. Bevier
    Portions provided by Richard Cornwell and other SIMH contributers
@@ -75,7 +75,7 @@ LPFCTBL  EQU       $
   
 #if NUM_DEVS_LPR > 0
 
-#define UNIT_LPR        UNIT_ATTABLE | UNIT_IDLE | UNIT_DISABLE
+#define UNIT_LPR    UNIT_ATTABLE | UNIT_IDLE | UNIT_DISABLE | UNIT_SEQ
 
 #define CMD u3
 /* u3 holds command and status information */
@@ -151,6 +151,8 @@ t_stat      lpr_attach(UNIT *, CONST char *);
 t_stat      lpr_detach(UNIT *);
 t_stat      lpr_setlpp(UNIT *, int32, CONST char *, void *);
 t_stat      lpr_getlpp(FILE *, UNIT *, int32, CONST void *);
+t_stat      lpr_help(FILE *, DEVICE *, UNIT *, int32, const char *);
+const char  *lpr_description (DEVICE *dptr);
 
 /* channel program information */
 CHANP       lpr_chp[NUM_DEVS_LPR] = {0};
@@ -197,8 +199,9 @@ DEVICE      lpr_dev = {
     NUM_DEVS_LPR, 8, 15, 1, 8, 8,
     NULL, NULL, NULL, NULL, &lpr_attach, &lpr_detach,
     /* ctxt is the DIB pointer */
-    &lpr_dib, DEV_DISABLE|DEV_DEBUG, 0, dev_debug
+    &lpr_dib, DEV_DISABLE|DEV_DEBUG, 0, dev_debug,
 //  &lpr_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS, 0, dev_debug
+    NULL, NULL, &lpr_help, NULL, NULL, &lpr_description,
 };
 
 /* initialize the line printer */
@@ -520,10 +523,28 @@ t_stat lpr_attach(UNIT *uptr, CONST char *file)
     return SCPE_OK;
 }
 
+/* help information for lpr */
+t_stat lpr_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr)
+{
+    fprintf (st, "SEL32 924x High Speed Line Printer\r\n");
+    fprintf (st, "The Line printer can be configured to any number of\n");
+    fprintf (st, "lines per page with the:\n");
+    fprintf (st, "sim> SET LPRn LINESPERPAGE=n\n\n");
+    fprintf (st, "The default is 66 lines per page.\n");
+    fprint_set_help(st, dptr);
+    fprint_show_help(st, dptr);
+    return SCPE_OK;
+}
+
 /* detach a file from the line printer */
 t_stat lpr_detach(UNIT * uptr)
 {
     return detach_unit(uptr);
+}
+
+const char *lpr_description (DEVICE *dptr)
+{
+    return "SEL32 924x High Speed Line Printer";
 }
 
 #endif

--- a/SEL32/sel32_scfi.c
+++ b/SEL32/sel32_scfi.c
@@ -34,7 +34,7 @@
 
 /* useful conversions */
 /* Fill STAR value from cyl, trk, sec data */
-#define CHS2STAR(c,h,s)	        (((c<<16) & LMASK)|((h<<8) & 0xff00)|(s & 0xff))
+#define CHS2STAR(c,h,s)         (((c<<16) & LMASK)|((h<<8) & 0xff00)|(s & 0xff))
 /* convert STAR value to number of sectors */
 #define STAR2SEC(star,spt,spc)  ((star&0xff)+(((star>>8)&0xff)*spt)+(((star>>16)&0xffff)*spc))
 /* convert STAR value to number of heads or tracks */

--- a/SEL32/sel32_scsi.c
+++ b/SEL32/sel32_scsi.c
@@ -32,7 +32,7 @@
 
 /* useful conversions */
 /* Fill STAR value from cyl, trk, sec data */
-#define CHS2STAR(c,h,s)	        (((c<<16) & LMASK)|((h<<8) & 0xff00)|(s & 0xff))
+#define CHS2STAR(c,h,s)         (((c<<16) & LMASK)|((h<<8) & 0xff00)|(s & 0xff))
 /* convert STAR value to number of sectors */
 #define STAR2SEC(star,spt,spc)  ((star&0xff)+(((star>>8)&0xff)*spt)+((star>>16)*spc))
 /* convert STAR value to number of heads or tracks */
@@ -97,9 +97,9 @@ bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option
 
 /* track label / sector label definations */
 /*
-    short lcyl;	        cylinder
-    char ltkn;			track
-    char lid;			sector id
+    short lcyl;         cylinder
+    char ltkn;          track
+    char lid;           sector id
     char lflg1;         track/sector status flags
         bit 0           good
             1           alternate
@@ -113,12 +113,12 @@ bits 24-31 - FHD head count (number of heads on FHD or number head on FHD option
     short lspar2;
     short ldef1;
     int ldeallp;        DMAP block number trk0
-    int lumapp;			UMAP block number sec1
+    int lumapp;         UMAP block number sec1
     short ladef3;
     short laltcyl;
     char lalttk;        sectors per track
     char ldscnt;        number of heads
-    char ldatrflg;		device attributes
+    char ldatrflg;      device attributes
         bit 0           n/u
             1           disk is mhd
             2           n/u
@@ -1387,8 +1387,8 @@ int scsi_format(UNIT *uptr) {
     uint32      umap[256] =
                 {
                     /* try to makeup a utx dmap */
-                    0x4e554d50,(cap-1),luaddr-1,0,0,0,0,0xe10,
-                    0,0x5320,0,0x4e60,0x46,luaddr,0,0xd360,
+                    0x4e554d50,(cap-1),(uint32)(luaddr-1),0,0,0,0,0xe10,
+                    0,0x5320,0,0x4e60,0x46,(uint32)luaddr,0,0xd360,
                     0x88,0x186b0,0x13a,0xd100,0x283,0,0,0,
                     0,0x22c2813e,0,0x06020000,0xf4,0,0x431b1c,0,
                 };

--- a/SEL32/tests/diag.ini
+++ b/SEL32/tests/diag.ini
@@ -72,9 +72,9 @@ set iop0 dev=7e00
 ;
 ; LPR
 ;set lpr debug=cmd;detail
-set lpr enable
+;set lpr enable
 ; LPR output file
-at lpr lprout
+;at lpr lprout
 ;
 ; CON Console
 ;set con debug=cmd;exp;detail

--- a/SEL32/util/makecode.c
+++ b/SEL32/util/makecode.c
@@ -2275,10 +2275,10 @@ void codedump(int sect)
         fprintf(stderr, "addr %0x - data %0x\n", (int32)tr_start, *memory);
 #else
         fprintf(stderr, "addr %0x - data %0.2x%0.2x%0.2x%0.2x\n", (int32)tr_start,
-        	(data >> 0) & 0xff,
-        	(data >> 8) & 0xff,
-        	(data >> 16) & 0xff,
-        	(data >> 24) & 0xff);
+            (data >> 0) & 0xff,
+            (data >> 8) & 0xff,
+            (data >> 16) & 0xff,
+            (data >> 24) & 0xff);
 #endif
 #ifdef NOBIGENDIAN
         byte = (data >> 24) & 0xff;


### PR DESCRIPTION
SEL32: Remove random tabs from sel32 source.
SEL32: Terminate WAITQ entries when CPU goes to wait state.
SEL32: Update sel32_chan.c to correct handling of IOCL queue prcessing.
SEL32: Add sel32_lpr description and help functions.
SEL32: Remove lpr output assignment in diags.ini.