### PR TITLE
KA10: Fix III invivible wholine

### DIFF
--- a/PDP10/ka10_iii.c
+++ b/PDP10/ka10_iii.c
@@ -647,7 +647,7 @@ t_stat iii_reset (DEVICE *dptr)
 static void
 draw_point(int x, int y, int b, UNIT *uptr)
 {
-   if (x < -512 || x > 512 || y < -512 || y > 512)
+   if (x < -512 || x > 512 || y < -501 || y > 522)
        uptr->STATUS |= WRP_FBIT;
    iii_point(x, y, b);
 }
@@ -656,9 +656,9 @@ draw_point(int x, int y, int b, UNIT *uptr)
 static void
 draw_line(int x1, int y1, int x2, int y2, int b, UNIT *uptr)
 {
-    if (x1 < -512 || x1 > 512 || y1 < -512 || y1 > 512)
+    if (x1 < -512 || x1 > 512 || y1 < -501 || y1 > 522)
        uptr->STATUS |= WRP_FBIT;
-    if (x2 < -512 || x2 > 512 || y2 < -512 || y2 > 512)
+    if (x2 < -512 || x2 > 512 || y2 < -501 || y2 > 522)
        uptr->STATUS |= WRP_FBIT;
     iii_draw_line(x1, y1, x2, y2, b);
 }

--- a/display/iii.c
+++ b/display/iii.c
@@ -39,7 +39,7 @@ int iii_init(void *dev, int debug)
 
 void iii_point (int x, int y, int l)
 {
-  display_point(x + 512, y + 512, l, 0);
+  display_point(x + 512, y + 501, l, 0);
 }
 
 int iii_cycle(int us, int slowdown)
@@ -59,9 +59,9 @@ iii_draw_line(int x1, int y1, int x2, int y2, int l)
 
     /* Origin us to 0 */
     x1 += 512;
-    y1 += 512;
+    y1 += 501;
     x2 += 512;
-    y2 += 512;
+    y2 += 501;
 
     /* Always draw top to bottom */
     if (y1 > y2) {


### PR DESCRIPTION
The III display looks suboptimal.

Actual:
![Bad III](https://user-images.githubusercontent.com/775050/111212045-6b4f0f80-85cf-11eb-8649-23c84b64b69d.png)

Expected:
![Good III](https://user-images.githubusercontent.com/775050/113518938-a1a5fc00-9589-11eb-8e62-5bd522540f5c.png)