### PR TITLE
SEL32: Fix SPAD address validation code for MPX3X.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ is operating correctly.  The diags are located in the tests directory.  Diag.tap
 contains the diagnostic programs and diag.ini contains the directives to
 configure and run the SEL32 simulator.
 
-This simulator is capable of running UTX2.1A, UTX2.1B, MPX 1.5F, and a
-test version of MPX 3.4.  It is capable of creating a disk image for the
+This simulator is capable of running UTX2.1A, UTX2.1B, MPX 1.5F, MPX 3.4,
+MPX 3.5 and MPX 3.6.  It is capable of creating a disk image for the
 O/S from a UTX or MPX SDT tape. The disk image can be booted, initialized,
 and can run many of the UTX and MPX utilities and programs. Ethernet is
-supported on UTX and may be added to MPX in the future.  Eight terminals
+supported on UTX and will be added to MPX in the future.  Eight terminals
 can be used to access MPX via Telnet port 4747. The sumulator has support
 for excess 64 floating point arithmetic and passes the 32/27 and 32/67 FP
 diags.  UTX is the SEL version of System V Unix and BSD Unix ported to the

--- a/SEL32/README.md
+++ b/SEL32/README.md
@@ -9,14 +9,18 @@ added in the future.
 
 # SEL Concept/32 
 
-This simulator is capable of running UTX2.1A, UTX2.1B, MPX 1.5F, and a
-test version of MPX 3.4.  It is capable of creating a disk image for the
+This simulator is capable of running UTX2.1A, UTX2.1B, MPX 1.5F, MPX 3.4,
+MPX 3.5, and MPX 3.6. It is capable of creating a disk image for the
 O/S from a UTX or MPX SDT tape. The disk image can be booted, initialized,
 and can run many of the UTX and MPX utilities and programs. Ethernet is
-supported on UTX and may be added to MPX in the future.  Eight terminals
+supported on UTX and will be added to MPX in the future.  Eight terminals
 can be used to access MPX or UTX via Telnet port 4747. The sumulator has
 support for excess 64 floating point arithmetic and passes the 32/27 and
-32/67 FP diags.
+32/67 FP diags.  UTX is the SEL version of System V Unix and BSD Unix
+ported to the V6 and V9 processors.  UTX utilizes the basemode instruction
+set and a virtual memory system supported by the V6 & V9 CPUs.  The system
+needs further testing to solidify the SEL32 simulator code in all of the
+supported environmenets.
 
 The sim32disk.gz file is a prebuilt MPX 1.5F system disk.  It can be
 uncompressed and booted with the sel32.27.sim32.disk.ini initialization
@@ -99,11 +103,14 @@ utx21a1.tap    bootable UTX install tape for testing basemode.  The current
                The virtual memory has been fully tested with the VM.MMM diag.
 
 Other MPX verions support:
-               I am still looking for an MPX 3.X user or master SDT tape.  I have
-               much of the source, but no loadable code to create a bootable system.
-               Please keep looking for anyone who can provide these tapes or a
-               disk image of a bootable MPX3.X system.
+               I have recently received some old MPX 3.X save tapes.  Using these
+               I have been able to hand build a MPX3.6 SDT tape that can be used
+               to install MPX3.6.  Once installed, the system can be used to build
+               a new user SDT tape and install it elsewhere.  Both based and non-
+               based O/S images can be created.  More images for installation will
+               be made available in the future as I work my way through the save
+               tapes. 
 
 James C. Bevier
-04/14/2021 
+06/20/2021 
 

--- a/SEL32/sel32_defs.h
+++ b/SEL32/sel32_defs.h
@@ -521,5 +521,8 @@ extern  int32   RDYQ_Put(uint32 entry);
 extern  int32   RDYQ_Get(uint32 *old);
 extern  int32   RDYQ_Num(void);
 
+extern  char *dump_mem(uint32 mp, int cnt);
+extern  char *dump_buf(uint8 *mp, int32 off, int cnt);
+
 #define get_chan(chsa)  ((chsa>>8)&0x7f)    /* get channel number from ch/sa */
 

--- a/SEL32/sel32_disk.c
+++ b/SEL32/sel32_disk.c
@@ -1142,6 +1142,7 @@ t_stat disk_srv(UNIT *uptr)
     uint8           ch;
     uint16          ssize = disk_type[type].ssiz * 4;   /* disk sector size in bytes */
     uint32          tstart;
+    char            *bufp;
     uint8           lbuf[32];
     uint8           buf[1024];
     uint8           buf2[1024];
@@ -1933,11 +1934,41 @@ iha_error:
             sim_debug(DEBUG_CMD, dptr,
                 "disk_srv after READ chsa %04x buffer %06x count %04x\n",
                 chsa, chp->ccw_addr, chp->ccw_count);
+            bufp = dump_buf(buf, 0, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+            bufp = dump_buf(buf, 16, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+            bufp = dump_buf(buf, 32, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+#ifdef EXTRA_WORDS
+            bufp = dump_buf(buf, 48, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+if ((chp->ccw_addr == 0x3cde0) && (buf[0] == 0x4a)) {
+            bufp = dump_buf(buf, 64, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+            bufp = dump_buf(buf, 80, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+            bufp = dump_buf(buf, 96, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+            bufp = dump_buf(buf, 112, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+            bufp = dump_buf(buf, 128, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+            bufp = dump_buf(buf, 144, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+            bufp = dump_buf(buf, 160, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+            bufp = dump_buf(buf, 176, 16);
+            sim_debug(DEBUG_CMD, dptr, "disk_srv READ buf %s\n", bufp);
+}
+#endif
+#if 0
             sim_debug(DEBUG_DETAIL, dptr,
                 "disk_srv READ data %02x%02x%02x%02x %02x%02x%02x%02x "
                 "%02x%02x%02x%02x %02x%02x%02x%02x\n",
                 buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
                 buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15]);
+#endif
 
             uptr->CHS++;                        /* next sector number */
             /* process the next sector of data */

--- a/SEL32/taptools/makefile
+++ b/SEL32/taptools/makefile
@@ -32,7 +32,6 @@ PROGS =			\
 	$(ROOT)/mkdiagtape \
 	$(ROOT)/tapdump	\
 	$(ROOT)/tape2disk \
-##	$(ROOT)/fileread \
 	$(ROOT)/disk2tap \
 	$(ROOT)/tapscan \
 	$(ROOT)/eomtap \
@@ -46,6 +45,7 @@ PROGS =			\
 	$(ROOT)/tap2disk \
 	$(ROOT)/cutostap \
 	$(ROOT)/small
+##	$(ROOT)/fileread
 
 all:	$(PROGS)
 

--- a/SEL32/taptools/mkdiagtape.c
+++ b/SEL32/taptools/mkdiagtape.c
@@ -14,17 +14,42 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
-#include <unistd.h>
+#ifdef _WIN32
+#include <stddef.h>
+#endif
+//#include <unistd.h>
 
-#define BLKSIZE 768                 /* MPX file sector size */
-unsigned char data[7680];           /* room for 10*768=(7680) 768 byte sectors per 7680 byte block */
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+typedef __int8           int8;
+typedef __int16          int16;
+typedef __int32          int32;
+typedef unsigned __int8  uint8;
+typedef unsigned __int16 uint16;
+typedef unsigned __int32 uint32;
+typedef signed __int64   t_int64;
+typedef unsigned __int64 t_uint64;
+typedef t_int64          off_t;
+#else                                                   
+/* All modern/standard compiler environments */
+/* any other environment needa a special case above */
+#include <stdint.h>
+typedef int8_t          int8;
+typedef int16_t         int16;
+typedef int32_t         int32;
+typedef uint8_t         uint8;
+typedef uint16_t        uint16;
+typedef uint32_t        uint32;
+#endif                                      /* end standard integers */
+
+#define BLKSIZE 768                         /* MPX file sector size */
+unsigned char data[7680];                   /* room for 10*768=(7680) 768 byte sectors per 7680 byte block */
 
 /* write 1 file to tape in 768 byte records */
 /* mblks is the maximum blockes to write from a file, 0=all */
 /* chunks is the number of sectors to wrote at a time 1-8 */
-int writefile(FILE *tp, char *fnp, u_int32_t mblks, int32_t chunks) {
-    u_int32_t word, blks=mblks;             /* just a temp word variable */         
-    u_int32_t size, bsize, csize;           /* size in 768 byte sectors */
+int writefile(FILE *tp, char *fnp, uint32 mblks, int32 chunks) {
+    int32 word, blks=mblks;                 /* just a temp word variable */         
+    int32 size, bsize, csize;               /* size in 768 byte sectors */
     FILE *fp;
     int32_t n1, n2, hc, nw, cs;
 
@@ -82,6 +107,7 @@ int writefile(FILE *tp, char *fnp, u_int32_t mblks, int32_t chunks) {
 //printf("write file %s (size %d bytes) (%d sect) (%d blocks) (%d chunks)\n",
 //      fnp, word, size, mblks, blks);
     fclose(fp);
+    exit(0);
 }
 
 /* read program file and output to a simulated diagnostic tape */
@@ -90,15 +116,12 @@ int main(argc, argv)
 int argc;
 char *argv[];
 {
-    FILE    *dp, *fp, *cp, *fopen();
-    int     targc;
+    FILE    *dp, *fp, *fopen();
     char    **targv;
     char    *p, *cmdp;
     int     i;
-    unsigned char *fnp;                     /* file name pointer */
-    unsigned int size;                      /* size in 768 byte sectors */
     unsigned int word;                      /* just a temp word variable */         
-    int goteof, goteom;                     /* end flags */
+    int goteof;                             /* end flags */
     int writing;                            /* writing output */
 
     memset((char *)data, 0, 4608);          /* zero data storage */
@@ -159,8 +182,6 @@ char *argv[];
     /* got input tapefile and options, handle output file now */
 //  printf("AT 3 argc %d argv %s\n", argc, *argv);
     if (--argc > 0) {
-        int blks;
-
         p = *argv++;
         printf("argc %d argv3 %s\n", argc, p);
         if ((fp = fopen(p, "w")) == NULL) {

--- a/SEL32/taptools/tape2disk.c
+++ b/SEL32/taptools/tape2disk.c
@@ -13,7 +13,6 @@
 
 #include <stdio.h>
 #include <sys/types.h>
-#include <sys/signal.h>
 //#include <sys/mtio.h>
 #include <stdlib.h>                 /* for exit() */
 #ifdef _WIN32
@@ -26,6 +25,7 @@
 #else
 #include <sys/fcntl.h>              /* for O_RDONLY, O_WRONLY, O_CREAT */
 #include <unistd.h>                 /* for open, read, write */
+#include <sys/signal.h>
 #endif
 
 #if defined(_MSC_VER) && (_MSC_VER < 1600)
@@ -55,7 +55,9 @@ int  usefmgr = 1;                   /* use fmgr format with 2 EOF's, else 3 EOF'
 char *buff;                         /* buffer for read/write */
 int filen = 1;                      /* file number being processed */
 long count=0, lcount=0;             /* number of blocks for file */
+#ifndef _WIN32
 extern void RUBOUT();               /* handle user DELETE key signal */
+#endif
 off_t size=0, tsize=0;              /* number of bytes in file, total */
 int ln;
 char *inf, *outf;
@@ -112,8 +114,10 @@ char **argv;
         fprintf(stderr, "Can't allocate memory for tapecopy\n");
         exit(4);
     }
+#ifndef _WIN32
     if (signal(SIGINT, SIG_IGN) != SIG_IGN)
         (void)signal(SIGINT, RUBOUT);
+#endif
 
     ln = -2;
     for (;;) {
@@ -231,6 +235,7 @@ char **argv;
     exit(0);
 }
 
+#ifndef _WIN32
 /* entered when user hit the DELETE key */
 void RUBOUT()
 {
@@ -245,3 +250,4 @@ void RUBOUT()
     (void)printf("total length: %ld bytes\n", tsize + size);
     exit(1);
 }
+#endif


### PR DESCRIPTION
SEL32: Add debug dump memory functions.
SEL32: Correct line count in sel32_lpr.c.
SEL32: Correct BSR/BSF code in sel32_mt.c for MPX3X SDT handling.
SEL32: General cleanup/speedup of sel32_mt.c code.
SEL32: Add master SDT tape creation in taptools/mkvmtape.c.
SEL32: Fix EOF detection code in taptools/tapdump.c.