### PR TITLE
KA10: Updates for the AUXCPU and TEN11 devices.

### DIFF
--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -3410,6 +3410,15 @@ int Mem_read_its(int flag, int cur_context, int fetch, int mod) {
     } else {
         if (!page_lookup_its(AB, flag, &addr, 0, cur_context, fetch, mod))
             return 1;
+#if NUM_DEVS_AUXCPU > 0
+        if (AUXCPURANGE(addr) && QAUXCPU) {
+            if (auxcpu_read (addr, &MB)) {
+                nxm_flag = 1;
+                check_apr_irq();
+                return 1;
+            }
+        }
+#endif
 #if NUM_DEVS_TEN11 > 0
         if (T11RANGE(addr) && QTEN11) {
             if (ten11_read (addr, &MB)) {
@@ -3418,15 +3427,6 @@ int Mem_read_its(int flag, int cur_context, int fetch, int mod) {
                 return 1;
             }
             return 0;
-        }
-#endif
-#if NUM_DEVS_AUXCPU > 0
-        if (AUXCPURANGE(addr) && QAUXCPU) {
-            if (auxcpu_read (addr, &MB)) {
-                nxm_flag = 1;
-                check_apr_irq();
-                return 1;
-            }
         }
 #endif
         if (addr >= MEMSIZE) {

--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -299,7 +299,7 @@ t_stat  tim_srv(UNIT * uptr);
 int32   tmxr_poll = 10000;
 
 /* Physical address range for Rubin 10-11 interface. */
-#define T11RANGE(addr)  ((addr) >= 03040000)
+#define T11RANGE(addr)  ((addr) >= ten11_base && (addr) < ten11_end)
 /* Physical address range for auxiliary PDP-6. */
 #define AUXCPURANGE(addr)  ((addr) >= auxcpu_base && (addr) < (auxcpu_base + 040000))
 

--- a/PDP10/kx10_defs.h
+++ b/PDP10/kx10_defs.h
@@ -696,9 +696,6 @@ int     rh_read(struct rh_if *rh);
 int     rh_write(struct rh_if *rh);
 
 
-int ten11_read (t_addr addr, t_uint64 *data);
-int ten11_write (t_addr addr, t_uint64 data);
-
 /* Console lights. */
 extern void ka10_lights_init (void);
 extern void ka10_lights_main (t_uint64);
@@ -794,6 +791,12 @@ extern t_uint64   FM[];
 extern uint32   PC;
 extern uint32   FLAGS;
 
+#if NUM_DEVS_TEN11
+int ten11_read (t_addr addr, t_uint64 *data);
+int ten11_write (t_addr addr, t_uint64 data);
+extern t_addr ten11_base;
+extern t_addr ten11_end;
+#endif
 #if NUM_DEVS_AUXCPU
 extern t_addr   auxcpu_base;
 int auxcpu_read (t_addr addr, uint64 *);


### PR DESCRIPTION
First, change order of the TEN11 and AUXCPU address range checks.  AUXCPU should be first so it can shadow part of the TEN11 memory.

Second, add a configurable TEN11 BASE parameter to set the base address of the TEN11 range.