### PR TITLE
KS10: Fix rh_boot global variables.

### DIFF
--- a/PDP10/kx10_defs.h
+++ b/PDP10/kx10_defs.h
@@ -606,8 +606,8 @@ void    rh_writecw(struct rh_if *rh, int nxm);
 void    rh_finish_op(struct rh_if *rh, int flags);
 int     rh_read(struct rh_if *rh);
 int     rh_write(struct rh_if *rh);
-DEVICE  *rh_boot_dev;
-int     rh_boot_unit;
+extern DEVICE  *rh_boot_dev;
+extern int     rh_boot_unit;
 #else
 extern t_stat (*dev_tab[128])(uint32 dev, t_uint64 *data);
 

--- a/PDP10/kx10_rh.c
+++ b/PDP10/kx10_rh.c
@@ -193,7 +193,7 @@ int rh_map[] = { 0,   /* 776700 */
 #if KS
 
 DEVICE  *rh_boot_dev = NULL;
-int      rh_boot_num = 0;
+int      rh_boot_unit = 0;
 
 
 int


### PR DESCRIPTION
This is what I did to fix the build problem. I'm posting it as a pull request because it's convenient.