### PR TITLE
SEL32: Remove use of DEV_DISK in unit flags instead.

### DIFF
--- a/SEL32/README.md
+++ b/SEL32/README.md
@@ -84,7 +84,7 @@ Use @@A to relogin to the console.
 #rundma1x67.ini - dsk/mpx1xdma0; type "../sel32 rundma1x67.ini" to run.
 The disk is booted up to the TSM> prompt and logged in as "SYSTEM".
 MPX can be accessed from a second Linux screen by using the command
-"telnet locallhost 4747".  This will bring up the "ENTER OWNERNAME
+"telnet localhost 4747".  This will bring up the "ENTER OWNERNAME
 AND KEY:".  Any name is valid, but SYSTEM should be used.  At the
 "TSM>" prompt, type "EXIT" to exit TSM.  Use ^G to get the login
 prompt when the "RING IN FOR SERVICE" message is displayed.
@@ -238,5 +238,5 @@ Other MPX versions support:
                SDT, I would be very thankfull.  Please keep looking.
 
 James C. Bevier
-12/31/2021 
+02/16/2022 
 

--- a/SEL32/sel32_chan.c
+++ b/SEL32/sel32_chan.c
@@ -1376,7 +1376,7 @@ t_stat startxio(uint16 lchsa, uint32 *status) {
     if (uptr != NULL) {
         dptr = get_dev(uptr);                   /* get device address */
         if ((dptr != NULL) &&
-            (DEV_TYPE(dptr) == DEV_DISK)) {     /* see if this is a disk */
+            (GET_SEL_DISK(dptr->flags))) {      /* see if this is a disk */
             chsa = chsa & 0x7ffe;               /* clear the odd subaddress */
         }
     }

--- a/SEL32/sel32_cpu.c
+++ b/SEL32/sel32_cpu.c
@@ -254,7 +254,7 @@ UNIT  cpu_unit =
     0,          /* uint32 dynflags */        /* dynamic flags */
     0x800000,   /* t_addr capac */           /* capacity */
     0,          /* t_addr pos */             /* file position */
-    NULL,       /* void (*io_flush) */       /* io flush routine */
+    0,          /* void (*io_flush) */       /* io flush routine */
     0,          /* uint32 iostarttime */     /* I/O start time */
     0,          /* int32 buf */              /* buffer */
     80,         /* int32 wait */             /* wait */

--- a/SEL32/sel32_defs.h
+++ b/SEL32/sel32_defs.h
@@ -278,8 +278,10 @@ typedef struct dib {
 extern  DIB     *dib_unit[MAX_DEV];     /* Pointer to Device info block */
 extern  DIB     *dib_chan[MAX_CHAN];    /* Pointer to channel mux dib */
 
-#define DEV_CHAN          (1 << DEV_V_UF)   /* Device is channel mux if set */
-#define DEV_V_UF2         (DEV_V_UF+1)  /* current usage */
+#define DEV_CHAN        (1 << DEV_V_UF) /* Device is channel mux if set */
+#define SEL_DISK        (1 << (DEV_V_UF+1)) /* Device is channel mux if set */
+#define DEV_V_UF2       (DEV_V_UF+2)    /* current usage */
+#define GET_SEL_DISK(x) (((x) >> (DEV_V_UF+1)) & 0x1)   /* get SEL_DISK flag */
 
 #ifdef NOT_USED_NOW
 //#define DEV_V_ADDR        DEV_V_UF              /* Pointer to device address (16) */

--- a/SEL32/sel32_disk.c
+++ b/SEL32/sel32_disk.c
@@ -476,7 +476,7 @@ DEVICE          dda_dev = {
     NUM_UNITS_DISK, 16, 24, 4, 16, 32,
     NULL, NULL, &disk_reset, &disk_boot, &disk_attach, &disk_detach,
     /* ctxt is the DIB pointer */
-    &dda_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|DEV_DISK, 0, dev_debug,
+    &dda_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|SEL_DISK, 0, dev_debug,
     NULL, NULL, &disk_help, NULL, NULL, &disk_description
 };
 
@@ -522,7 +522,7 @@ DEVICE          ddb_dev = {
     NUM_UNITS_DISK, 16, 24, 4, 16, 32,
     NULL, NULL, &disk_reset, &disk_boot, &disk_attach, &disk_detach,
     /* ctxt is the DIB pointer */
-    &ddb_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|DEV_DISK, 0, dev_debug,
+    &ddb_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|SEL_DISK, 0, dev_debug,
     NULL, NULL, &disk_help, NULL, NULL, &disk_description
 };
 #endif

--- a/SEL32/sel32_hsdp.c
+++ b/SEL32/sel32_hsdp.c
@@ -608,7 +608,7 @@ DEVICE          dpa_dev = {
     NUM_UNITS_HSDP, 16, 24, 4, 16, 32,
     NULL, NULL, &hsdp_reset, &hsdp_boot, &hsdp_attach, &hsdp_detach,
     /* ctxt is the DIB pointer */
-    &dpa_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|DEV_DISK, 0, dev_debug,
+    &dpa_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|SEL_DISK, 0, dev_debug,
     NULL, NULL, &hsdp_help, NULL, NULL, &hsdp_description
 };
 
@@ -657,7 +657,7 @@ DEVICE          dpb_dev = {
     NUM_UNITS_HSDP, 16, 24, 4, 16, 32,
     NULL, NULL, &hsdp_reset, &hsdp_boot, &hsdp_attach, &hsdp_detach,
     /* ctxt is the DIB pointer */
-    &dpb_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|DEV_DISK, 0, dev_debug,
+    &dpb_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|SEL_DISK, 0, dev_debug,
     NULL, NULL, &hsdp_help, NULL, NULL, &hsdp_description
 };
 #endif

--- a/SEL32/sel32_scfi.c
+++ b/SEL32/sel32_scfi.c
@@ -346,7 +346,7 @@ DEVICE          sda_dev = {
     NUM_UNITS_SCFI, 16, 24, 4, 16, 32,
     NULL, NULL, &scfi_reset, &scfi_boot, &scfi_attach, &scfi_detach,
     /* ctxt is the DIB pointer */
-    &sda_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|DEV_DISK, 0, dev_debug,
+    &sda_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|SEL_DISK, 0, dev_debug,
     NULL, NULL, &scfi_help, NULL, NULL, &scfi_description
 };
 
@@ -392,7 +392,7 @@ DEVICE          sdb_dev = {
     NUM_UNITS_SCFI, 16, 24, 4, 16, 32,
     NULL, NULL, &scfi_reset, &scfi_boot, &scfi_attach, &scfi_detach,
     /* ctxt is the DIB pointer */
-    &sdb_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|DEV_DISK, 0, dev_debug,
+    &sdb_dib, DEV_DISABLE|DEV_DEBUG|DEV_DIS|SEL_DISK, 0, dev_debug,
     NULL, NULL, &scfi_help, NULL, NULL, &scfi_description
 };
 #endif
@@ -925,8 +925,6 @@ t_stat scfi_srv(UNIT *uptr)
             }
             /* inch buffer address */
             mema = (buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | (buf[3]);
-            /* now call set_inch() function to write and test inch buffer addresses */
-            i = set_inch(uptr, mema, 1);           /* new address of 1 entry */
             goto gohere;
         }
 

--- a/SEL32/sel32_scsi.c
+++ b/SEL32/sel32_scsi.c
@@ -356,7 +356,7 @@ DEVICE  sba_dev = {
     NUM_UNITS_SCSI, 16, 24, 4, 16, 32,
     NULL, NULL, &scsi_reset, &scsi_boot, &scsi_attach, &scsi_detach,
     /* ctxt is the DIB pointer */
-    &sba_dib, DEV_BUF_NUM(0)|DEV_DISABLE|DEV_DEBUG|DEV_DIS, 0, dev_debug,
+    &sba_dib, DEV_BUF_NUM(0)|DEV_DISABLE|DEV_DEBUG|DEV_DIS|SEL_DISK, 0, dev_debug,
     NULL, NULL, &scsi_help, NULL, NULL, &scsi_description
 };
 


### PR DESCRIPTION
SEL32: Correct spelling error in README.md file.
SEL32: Fix Coverity warning error.
SEL32: Update to latest simh release.