### PR TITLE
SEL32: Correct Coverity detected warning errors.

### DIFF
--- a/SEL32/README.md
+++ b/SEL32/README.md
@@ -95,13 +95,6 @@ diag.tap     - bootable level one diagnostic tape w/auto testing.
                Testing is extremely difficult without any source for the
                diagnostics.  Updates to follow as tests are corrected.
 
-# SEL32 tap tools available in the taptools directory:
-
-Available tap tools in taptools directory:
-./taptools   - set of tools to work with .tap formatted tapes.  Also tools
-               to convert between MPX and UNIX file formats.  See README
-               file in the taptools directory and source for descriptions.
-
 Other MPX versions support:
                I have recently received some old MPX 3.X save tapes.  Using
                these I have been able to hand build a MPX3.6 SDT tape that
@@ -116,5 +109,4 @@ Other MPX versions support:
                thankfull.  Please keep looking.
 
 James C. Bevier
-02/28/2022 
-
+03/10/2022 

--- a/SEL32/sel32_cpu.c
+++ b/SEL32/sel32_cpu.c
@@ -110,7 +110,7 @@ uint32          CC;                         /* Condition codes, bits 1-4 of PSD1
 uint32          CPUSTATUS;                  /* cpu status word */
 uint32          TRAPSTATUS;                 /* trap status word */
 uint32          SPAD[256];                  /* Scratch pad memory */
-uint32          INTS[112];                  /* Interrupt status flags */
+uint32          INTS[128];                  /* Interrupt status flags */
 uint32          pad[16];                    /* In case of wrong access */
 uint32          CMCR;                       /* Cache Memory Control Register */
 uint32          SMCR;                       /* Shared Memory Control Register */
@@ -277,7 +277,7 @@ REG cpu_reg[] = {
     {HRDATAD(TRAPSTATUS, TRAPSTATUS, 32, "TRAP Status Word"), REG_FIT},
     {HRDATAD(CC, CC, 32, "Condition Codes"), REG_FIT},
     {HRDATAD(MODES, MODES, 32, "Mode bits"), REG_FIT},
-    {BRDATAD(INTS, INTS, 16, 32, 112, "Interrupt Status"), REG_FIT},
+    {BRDATAD(INTS, INTS, 16, 32, 128, "Interrupt Status"), REG_FIT},
     {HRDATAD(CMCR, CMCR, 32, "Cache Memory Control Register"), REG_FIT},
     {HRDATAD(SMCR, SMCR, 32, "Shared Memory Control Register"), REG_FIT},
     {HRDATAD(CMSMC, CMSMC, 32, "V9 Cache/Shadow Memory Configuration Word"), REG_FIT},


### PR DESCRIPTION
SEL32: Update README.md to remove taptools reference.