### PR TITLE
KA10: Mask flag request bit with interrupt enable bits.

### DIFF
--- a/PDP10/kx10_dt.c
+++ b/PDP10/kx10_dt.c
@@ -504,7 +504,7 @@ t_stat dt_devio(uint32 dev, uint64 *data) {
 
      case CONI|04:
           *data = dtsb;
-          if (dtsb & 0770000) 
+          if (dtsb & 0770000 & (dtsb >> 18)) 
              *data |= DTB_FLGREQ;
           sim_debug(DEBUG_CONI, &dt_dev, "DTB %03o CONI %012llo PC=%o\n",
                dev, *data, PC);


### PR DESCRIPTION
As per table 2-4 on page 2-13, the flag request bit should only be set if the corresponding enable bits are set.

http://www.bitsavers.org/pdf/dec/pdp10/periph/TD10_DECtape_Control_Maint_Jun69.pdf

This makes TENEX read the DECtape directory block correctly.

```
gET FILE dta0:dluser.sav [Confirm]
```