### PR TITLE
KA10: Fix write access for auxiliary processor memory.

### DIFF
--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -3523,6 +3523,7 @@ int Mem_read_its(int flag, int cur_context, int fetch, int mod) {
                 check_apr_irq();
                 return 1;
             }
+            return 0;
         }
 #endif
 #if NUM_DEVS_TEN11 > 0
@@ -3577,6 +3578,16 @@ int Mem_write_its(int flag, int cur_context) {
         }
         if (!page_lookup_its(AB, flag, &addr, 1, cur_context, 0, 0))
             return 1;
+#if NUM_DEVS_AUXCPU > 0
+        if (AUXCPURANGE(addr) && QAUXCPU) {
+            if (auxcpu_write (addr, MB)) {
+                nxm_flag = 1;
+                check_apr_irq();
+                return 1;
+            }
+            return 0;
+        }
+#endif
 #if NUM_DEVS_TEN11 > 0
         if (T11RANGE(addr) && QTEN11) {
             if (ten11_write (addr, MB)) {
@@ -3585,15 +3596,6 @@ int Mem_write_its(int flag, int cur_context) {
                 return 1;
             }
             return 0;
-        }
-#endif
-#if NUM_DEVS_AUXCPU > 0
-        if (AUXCPURANGE(addr) && QAUXCPU) {
-            if (auxcpu_write (addr, MB)) {
-                nxm_flag = 1;
-                check_apr_irq();
-                return 1;
-            }
         }
 #endif
         if (addr >= MEMSIZE) {


### PR DESCRIPTION
They auxiliary memory may shadow a portion of the 10-11 range, so it must be checked first.