### PR TITLE
There are 18 column bits

### DIFF
--- a/PDP10/ka10_pipanel.c
+++ b/PDP10/ka10_pipanel.c
@@ -341,7 +341,7 @@ void *blink(void *ptr)
     }
 
     /* Columns */
-    for (col = 0; col < 10; col++) {
+    for (col = 0; col < 18; col++) {
          gpio_set_fsel(cols[col], GPIO_FSEL_INPUT);
          gpio_set_pull(cols[col], PULL_UP);
     }


### PR DESCRIPTION
There appears to be a typo where ka10_pipanel.c only initializes 10 column bits. This should be 18.