### PR TITLE
B5500, I701, I704, I7010, I7070, I7080, I7090: Remove single UNIT DISABLE

### DIFF
--- a/B5500/b5500_urec.c
+++ b/B5500/b5500_urec.c
@@ -31,9 +31,9 @@
 #include "sim_defs.h"
 #include "sim_console.h"
 
-#define UNIT_CDR        UNIT_ATTABLE | UNIT_RO | UNIT_DISABLE | MODE_029
-#define UNIT_CDP        UNIT_ATTABLE | UNIT_SEQ | UNIT_DISABLE | MODE_029
-#define UNIT_LPR        UNIT_ATTABLE | UNIT_SEQ | UNIT_DISABLE
+#define UNIT_CDR        UNIT_ATTABLE | UNIT_RO | ((NUM_DEVS_CDR > 1) ? UNIT_DISABLE : 0) | MODE_029
+#define UNIT_CDP        UNIT_ATTABLE | UNIT_SEQ | ((NUM_DEVS_CDP > 1) ? UNIT_DISABLE : 0) | MODE_029
+#define UNIT_LPR        UNIT_ATTABLE | UNIT_SEQ | ((NUM_DEVS_LPR > 1) ? UNIT_DISABLE : 0)
 
 #define TMR_RTC         0
 

--- a/I7000/i7000_cdp.c
+++ b/I7000/i7000_cdp.c
@@ -34,7 +34,7 @@
 #include "sim_defs.h"
 #ifdef NUM_DEVS_CDP
 
-#define UNIT_CDP        UNIT_ATTABLE | UNIT_DISABLE | UNIT_SEQ | MODE_026
+#define UNIT_CDP        UNIT_ATTABLE | ((NUM_DEVS_CDP > 1) ? UNIT_DISABLE : 0) | UNIT_SEQ | MODE_026
 
 
 /* Flags for punch and reader. */

--- a/I7000/i7000_cdr.c
+++ b/I7000/i7000_cdr.c
@@ -34,7 +34,7 @@
 #include "sim_defs.h"
 #ifdef NUM_DEVS_CDR
 
-#define UNIT_CDR        UNIT_ATTABLE | UNIT_RO | UNIT_DISABLE | MODE_026
+#define UNIT_CDR        UNIT_ATTABLE | UNIT_RO | ((NUM_DEVS_CDR > 1) ? UNIT_DISABLE : 0) | MODE_026
 
 /* Flags for punch and reader. */
 #define ATTENA          (1 << (UNIT_V_UF+7))

--- a/I7000/i7000_chron.c
+++ b/I7000/i7000_chron.c
@@ -27,7 +27,7 @@
 #ifdef NUM_DEVS_CHRON
 #define BUFFSIZE        (12)
 
-#define UNIT_MT(x)      UNIT_DISABLE | UNIT_ROABLE | \
+#define UNIT_MT(x)      ((NUM_DEVS_CHRON > 1) ? UNIT_DISABLE : 0) | UNIT_ROABLE | \
                         UNIT_S_CHAN(x)
 
 /* in u3 is device address */

--- a/I7000/i7000_dsk.c
+++ b/I7000/i7000_dsk.c
@@ -47,7 +47,7 @@
 #include "i7000_defs.h"
 
 #ifdef NUM_DEVS_DSK
-#define UNIT_DSK        UNIT_ATTABLE | UNIT_DISABLE | UNIT_FIX
+#define UNIT_DSK        UNIT_ATTABLE | ((NUM_DEVS_DSK > 1) ? UNIT_DISABLE : 0) | UNIT_FIX
 #define FORMAT_OK       (1 << (UNIT_V_LOCAL+0))
 #define HA2_OK          (1 << (UNIT_V_LOCAL+1))
 #define CTSS_BOOT       (1 << (UNIT_V_MODE))

--- a/I7000/i7000_lpr.c
+++ b/I7000/i7000_lpr.c
@@ -34,7 +34,7 @@
 #include "sim_defs.h"
 #ifdef NUM_DEVS_LPR
 
-#define UNIT_LPR        UNIT_ATTABLE | UNIT_DISABLE | UNIT_SEQ
+#define UNIT_LPR        UNIT_ATTABLE | ((NUM_DEVS_LPR > 1) ? UNIT_DISABLE : 0) | UNIT_SEQ
 
 
 /* Flags for line printer. */

--- a/I7000/i7000_mt.c
+++ b/I7000/i7000_mt.c
@@ -44,7 +44,7 @@
 #if (NUM_DEVS_MT > 0) || defined(MT_CHANNEL_ZERO)
 
 #define BUFFSIZE        (MAXMEMSIZE * CHARSPERWORD)
-#define UNIT_MT(x)      UNIT_ATTABLE | UNIT_DISABLE | UNIT_ROABLE | \
+#define UNIT_MT(x)      UNIT_ATTABLE | ((NUM_DEVS_MT > 1) ? UNIT_DISABLE : 0) | UNIT_ROABLE | \
                         UNIT_S_CHAN(x)
 #define MTUF_LDN        (1 << MTUF_V_UF)
 #define MTUF_ONLINE     (1 << UNIT_V_UF_31)

--- a/I7000/i701_chan.c
+++ b/I7000/i701_chan.c
@@ -65,7 +65,7 @@ DIB                 dly_dib =
 
 UNIT                chan_unit[] = {
     /* Puesdo channel for 701 devices */
-    {UDATA(NULL, UNIT_DISABLE | CHAN_SET |
+    {UDATA(NULL, CHAN_SET |
                         CHAN_S_TYPE(CHAN_PIO)|UNIT_S_CHAN(0), 0)},
 };
 
@@ -85,7 +85,7 @@ DEVICE              chan_dev = {
     "CH", chan_unit, chan_reg, chan_mod,
     NUM_CHAN, 8, 15, 1, 8, 36,
     NULL, NULL, &chan_reset, NULL, NULL, NULL,
-    &dly_dib, DEV_DEBUG, 0, NULL,
+    &dly_dib, DEV_DISABLE | DEV_DEBUG, 0, NULL,
     NULL, NULL, &chan_help, NULL, NULL, &chan_description
 };
 

--- a/I7000/i7080_drum.c
+++ b/I7000/i7080_drum.c
@@ -36,7 +36,7 @@
 #include "i7080_defs.h"
 
 #ifdef NUM_DEVS_DR
-#define UNIT_DRM        UNIT_ATTABLE | UNIT_DISABLE | UNIT_FIX | \
+#define UNIT_DRM        UNIT_ATTABLE | ((NUM_DEVS_DR > 1) ? UNIT_DISABLE : 0) | UNIT_FIX | \
                         UNIT_BUFABLE | UNIT_MUSTBUF
 
 /* Device status information stored in u5 */

--- a/I7000/i7090_cdp.c
+++ b/I7000/i7090_cdp.c
@@ -26,7 +26,7 @@
 #include "i7090_defs.h"
 #include "sim_card.h"
 #ifdef NUM_DEVS_CDP
-#define UNIT_CDP        UNIT_ATTABLE | UNIT_DISABLE | UNIT_SEQ
+#define UNIT_CDP        UNIT_ATTABLE | ((NUM_DEVS_CDP > 1) ? UNIT_DISABLE : 0) | UNIT_SEQ
 
 
 /* std devices. data structures

--- a/I7000/i7090_cdr.c
+++ b/I7000/i7090_cdr.c
@@ -28,7 +28,7 @@
 
 #ifdef NUM_DEVS_CDR
 
-#define UNIT_CDR        UNIT_ATTABLE | UNIT_RO | UNIT_DISABLE | MODE_026
+#define UNIT_CDR        UNIT_ATTABLE | UNIT_RO | ((NUM_DEVS_CDR > 1) ? UNIT_DISABLE : 0) | MODE_026
 
 
 /* std devices. data structures

--- a/I7000/i7090_chan.c
+++ b/I7000/i7090_chan.c
@@ -148,7 +148,7 @@ DIB                 dly_dib =
 
 UNIT                chan_unit[] = {
     /* Puesdo channel for 704 devices */
-    {UDATA(NULL, UNIT_DISABLE | CHAN_SET |
+    {UDATA(NULL, ((NUM_CHAN > 1) ? UNIT_DISABLE : 0) | CHAN_SET |
                         CHAN_S_TYPE(CHAN_PIO)|UNIT_S_CHAN(0), 0)},
     /* Normal channels */
 #if NUM_CHAN > 1
@@ -215,7 +215,7 @@ DEVICE              chan_dev = {
     "CH", chan_unit, chan_reg, chan_mod,
     NUM_CHAN, 8, 15, 1, 8, 36,
     NULL, NULL, &chan_reset, NULL, NULL, NULL,
-    &dly_dib, DEV_DEBUG, 0, chn_debug,
+    &dly_dib, DEV_DISABLE | DEV_DEBUG, 0, chn_debug,
     NULL, NULL, &chan_help, NULL, NULL, &chan_description
 };
 

--- a/I7000/i7090_drum.c
+++ b/I7000/i7090_drum.c
@@ -26,7 +26,7 @@
 #include "i7090_defs.h"
 
 #ifdef NUM_DEVS_DR
-#define UNIT_DRM        UNIT_ATTABLE | UNIT_DISABLE | UNIT_FIX | \
+#define UNIT_DRM        UNIT_ATTABLE | ((NUM_DEVS_DR > 1) ? UNIT_DISABLE : 0) | UNIT_FIX | \
                         UNIT_BUFABLE | UNIT_MUSTBUF
 
 /* Device status information stored in u5 */

--- a/I7000/i7090_hdrum.c
+++ b/I7000/i7090_hdrum.c
@@ -26,7 +26,7 @@
 #include "i7090_defs.h"
 
 #ifdef NUM_DEVS_HD
-#define UNIT_DRM        UNIT_ATTABLE | UNIT_DISABLE | UNIT_FIX | \
+#define UNIT_DRM        UNIT_ATTABLE | ((NUM_DEVS_HD > 1) ? UNIT_DISABLE : 0) | UNIT_FIX | \
                         UNIT_BUFABLE | UNIT_MUSTBUF
 
 /* Device status information stored in u5 */

--- a/I7000/i7090_lpr.c
+++ b/I7000/i7090_lpr.c
@@ -40,7 +40,7 @@
 
 #ifdef NUM_DEVS_LPR
 
-#define UNIT_LPR        UNIT_ATTABLE | UNIT_DISABLE | UNIT_SEQ
+#define UNIT_LPR        UNIT_ATTABLE | ((NUM_DEVS_LPR > 1) ? UNIT_DISABLE : 0) | UNIT_SEQ
 #define ECHO            (1 << UNIT_V_LOCAL)
 
 

--- a/PDP10/ka10_pclk.c
+++ b/PDP10/ka10_pclk.c
@@ -44,7 +44,7 @@ t_stat         pclk_set_off(UNIT *uptr, int32 val, CONST char *cptr, void *desc)
 t_stat         pclk_show_on(FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 
 UNIT pclk_unit[] = {
-    {UDATA(pclk_srv, UNIT_IDLE|UNIT_DISABLE, 0)},  /* 0 */
+    {UDATA(pclk_srv, UNIT_IDLE, 0)},  /* 0 */
 };
 DIB pclk_dib = {PCLK_DEVNUM, 1, &pclk_devio, NULL};
 MTAB pclk_mod[] = {

--- a/PDP10/ka10_pd.c
+++ b/PDP10/ka10_pd.c
@@ -56,7 +56,7 @@ t_stat         pd_set_off(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 t_stat         pd_show_on(FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 
 UNIT                pd_unit[] = {
-    {UDATA(pd_srv, UNIT_IDLE|UNIT_DISABLE, 0)},  /* 0 */
+    {UDATA(pd_srv, UNIT_IDLE, 0)},  /* 0 */
 };
 DIB pd_dib = {PD_DEVNUM, 1, &pd_devio, NULL};
 

--- a/PDP10/ka10_stk.c
+++ b/PDP10/ka10_stk.c
@@ -52,7 +52,7 @@ static uint64 status = 0;
 static int key_code = 0;
 
 UNIT                stk_unit[] = {
-    {UDATA(stk_svc, UNIT_DISABLE, 0)},  /* 0 */
+    {UDATA(stk_svc, 0, 0)},  /* 0 */
 };
 DIB stk_dib = {STK_DEVNUM, 1, &stk_devio, NULL};
 

--- a/PDP10/ks10_dz.c
+++ b/PDP10/ks10_dz.c
@@ -127,7 +127,7 @@ const char *dz_description (DEVICE *dptr);
 DIB dz_dib = { 0760000, 077, 0340, 5, 3, &dz_read, &dz_write, 0, 0, 0 };
 
 UNIT dz_unit = {
-    UDATA (&dz_svc, TT_MODE_7B+UNIT_IDLE+UNIT_DISABLE+UNIT_ATTABLE, 0), KBD_POLL_WAIT
+    UDATA (&dz_svc, TT_MODE_7B+UNIT_IDLE+UNIT_ATTABLE, 0), KBD_POLL_WAIT
     };
 
 REG dz_reg[] = {

--- a/PDP10/ks10_tcu.c
+++ b/PDP10/ks10_tcu.c
@@ -46,7 +46,7 @@ t_stat tcu_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag,
 const char *tcu_description (DEVICE *dptr);
 DIB tcu_dib = { 0760770, 07, 0, 0, 3, &tcu_read, &tcu_write, NULL, 0, 0 };
 
-UNIT tcu_unit = {UDATA (NULL, UNIT_IDLE+UNIT_DISABLE, 0)};
+UNIT tcu_unit = {UDATA (NULL, UNIT_IDLE, 0)};
 
 MTAB tcu_mod[] = {
     {MTAB_XTD|MTAB_VDV|MTAB_VALR, 0, "addr", "addr",  &uba_set_addr, uba_show_addr,

--- a/PDP10/kx10_cp.c
+++ b/PDP10/kx10_cp.c
@@ -34,7 +34,7 @@
 #include "sim_defs.h"
 #if (NUM_DEVS_CP > 0)
 
-#define UNIT_CDP        UNIT_ATTABLE | UNIT_DISABLE | UNIT_SEQ | MODE_DEC29 
+#define UNIT_CDP        UNIT_ATTABLE | UNIT_SEQ | MODE_DEC29 
 
 #define CP_DEVNUM        0110
 

--- a/PDP10/kx10_cr.c
+++ b/PDP10/kx10_cr.c
@@ -34,7 +34,7 @@
 #include "sim_defs.h"
 #if (NUM_DEVS_CR > 0)
 
-#define UNIT_CDR        UNIT_ATTABLE | UNIT_RO | UNIT_DISABLE | MODE_DEC29 | MODE_LOWER
+#define UNIT_CDR        UNIT_ATTABLE | UNIT_RO | MODE_DEC29 | MODE_LOWER
 
 #define CR_DEVNUM        0150
 

--- a/PDP10/kx10_dc.c
+++ b/PDP10/kx10_dc.c
@@ -115,7 +115,7 @@ const char *dc_description (DEVICE *dptr);
 DIB dc_dib = { DC_DEVNUM, 1, &dc_devio, NULL };
 
 UNIT dc_unit = {
-    UDATA (&dc_svc, TT_MODE_7B+UNIT_IDLE+UNIT_DISABLE+UNIT_ATTABLE, 0), KBD_POLL_WAIT
+    UDATA (&dc_svc, TT_MODE_7B+UNIT_IDLE+UNIT_ATTABLE, 0), KBD_POLL_WAIT
     };
 
 REG dc_reg[] = {


### PR DESCRIPTION

If a simh DEVICE has the DEV_DISABLE flag set AND it has 1 UNIT, there really should never be a UNIT_DISABLE flag bit in the UNIT initializer.  The reason for this is that, for many things, the DEVICE name can be used equivalently to represent the single UNIT. What are we trying to achieve here?

- If the DEVICE is disabled, then the unit doesn't exist.  That's fine.

- If the UNIT is disabled (if the UNIT_DISABLE flag is present allowing SET <unit> DISABLE) what would that then mean about the DEVICE?

Bob Supnik's thoughts:

The rationale was that the device represents the controller logic, the unit the physical transducer. So you could disconnect or power down a paper tape reader, but its controller logic would still be there and would still respond in some way.

Mark Pizzolato said:
If the fidelity to the hardware in simulation really behaved precisely as the hardware worked, maybe, but I doubt that this has been a design goal.  Even if it had been a design goal, I see 2 issues:
   a) it would seem that it would have been impossible to produce exactly
      the failure details that real hardware did without a crazy amount
      of side by side testing.
   b) What good would be having a broken device like this connected to a
      simulated system?