### PR TITLE
I7000: Fix i701 cpu/sys for half-word...

### DIFF
--- a/I7000/i701_cpu.c
+++ b/I7000/i701_cpu.c
@@ -21,15 +21,15 @@
 
    cpu          701 central processor
 
-   The IBM 701 also know as "Defense Calculator" was introduced by IBM
-   on April 7, 1953. This computer was start of IBM 700 and 7000 line.
+   The IBM 701 also known as "Defense Calculator" was introduced by IBM
+   on April 7, 1953. This computer was the start of the IBM 700 and 7000 lines.
    Memory was 2048 36 bit words. Each instruction could be signed plus
-   or minus, plus would access memory as 18 bit words, minus as 36 bit
+   or minus, plus would access memory as 18-bit words, minus as 36-bit
    words. There was a expansion option to add another 2048 words of
    memory, but I can't find documentation on how it worked. Memory cycle
-   time was 12 microseconds. The 701 was withdrawn from the market
-   October 1, 1954 replaced by 704 and 702. A total of 19 machines were
-   installed.
+   time was 12 microseconds. The 701 was withdrawn from the market on
+   October 1, 1954 and replaced by the 704 and 702 models. A total of
+   19 machines were installed.
 
    The system state for the IBM 701 is:
 
@@ -63,7 +63,7 @@
         illegal instruction
         illegal I/O operation for device
         illegal I/O operation for channel
-        breakpoint encountered
+        break point encountered
         nested XEC's exceeding limit
         divide check
         I/O error in I/O simulator
@@ -783,19 +783,23 @@ cpu_reset(DEVICE * dptr)
 t_stat
 cpu_ex(t_value * vptr, t_addr addr, UNIT * uptr, int32 sw)
 {
-    if (addr >= (MEMSIZE * 2))
+    if (addr > 013777)
         return SCPE_NXM;
     if (vptr == NULL)
         return SCPE_OK;
 
-    *vptr = M[(addr & 07777) >> 1];
-    if ((addr & 0400000) == 0) {
-        if ( addr & 1)
-           *vptr <<= 18;
+    if ((addr & 010000) == 0) { /* process for half-words only... */
+        *vptr = M[addr >> 1] & 0777777777777L;
+        if (addr & 1)
+          *vptr &= RMASK;
         else
-           *vptr &= LMASK;
+          *vptr >>= 18;
+    } else { /* swap the half-words in place... */
+        *vptr = M[addr & 03777] & 0777777777777L;
+        *vptr ^= (*vptr << 18) & LMASK;
+        *vptr ^= (*vptr >> 18) & RMASK;
+        *vptr ^= (*vptr << 18) & LMASK;
     }
-    *vptr &= 0777777777777L;
 
     return SCPE_OK;
 }
@@ -803,22 +807,25 @@ cpu_ex(t_value * vptr, t_addr addr, UNIT * uptr, int32 sw)
 /* Memory deposit */
 
 t_stat
-cpu_dep(t_value val, t_addr addr, UNIT * uptr, int32 sw)
-{
-    t_addr      a = (addr >> 1) & 03777;
+cpu_dep(t_value val, t_addr addr, UNIT * uptr, int32 sw){
 
-    if (addr >= (MEMSIZE * 2))
+    if (addr > 013777) /* allow the extra "sign" bit */
         return SCPE_NXM;
-    if ((addr & 0400000) == 0) {
+    if ((addr & 010000) == 0) { /* set by half words... */
+        t_addr a = (addr >> 1) & 03777; /* full word address */
         if (addr & 1) {
-           M[a] &= LMASK;
-           M[a] |= (val >> 18) & RMASK;
+          M[a] &= LMASK;
+          M[a] |= val & RMASK;
         } else {
-           M[a] &= RMASK;
-           M[a] |= val & LMASK;
+          M[a] &= RMASK;
+          M[a] |= (val << 18) & LMASK;
         }
-    } else
-        M[a] = val & 0777777777777L;
+    } else { /* swap the half-words in place... */
+        val ^= (val << 18) & LMASK;
+        val ^= (val >> 18) & RMASK;
+        val ^= (val << 18) & LMASK;
+        M[addr & 03777] = val & 0777777777777L; /* set only full word */
+    }
     return SCPE_OK;
 }
 
@@ -949,7 +956,6 @@ cpu_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr)
     fprintf (st, "The CPU behaves as a IBM 701\n");
     fprintf (st, "These switches are recognized when examining or depositing in CPU memory:\n\n");
     fprintf (st, "      -c      examine/deposit characters, 6 per word\n");
-    fprintf (st, "      -l      examine/deposit half words\n");
     fprintf (st, "      -m      examine/deposit IBM 701 instructions\n\n");
     fprintf (st, "The CPU can maintain a history of the most recently executed instructions.\n");
     fprintf (st, "This is controlled by the SET CPU HISTORY and SHOW CPU HISTORY commands:\n\n");
@@ -962,4 +968,3 @@ cpu_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr)
 
 return SCPE_OK;
 }
-

--- a/I7000/i701_cpu.c
+++ b/I7000/i701_cpu.c
@@ -1,25 +1,31 @@
 /* i701_cpu.c: IBM 701 CPU simulator
 
+
    Copyright (c) 2005-2016, Richard Cornwell
+
 
    Permission is hereby granted, free of charge, to any person obtaining a
    copy of this software and associated documentation files (the "Software"),
    to deal in the Software without restriction, including without limitation
    the rights to use, copy, modify, merge, publish, distribute, sublicense,
    and/or sell copies of the Software, and to permit persons to whom the
+
    Software is furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
 
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
    RICHARD CORNWELL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+
    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
    cpu          701 central processor
+
 
    The IBM 701 also known as "Defense Calculator" was introduced by IBM
    on April 7, 1953. This computer was the start of the IBM 700 and 7000 lines.
@@ -33,24 +39,29 @@
 
    The system state for the IBM 701 is:
 
+
    AC<S,P,Q,1:35>       AC register
    MQ<S,1:35>           MQ register
    IC<0:15>             program counter
    SSW<0:5>             sense switches
    SLT<0:3>             sense lights
+
    ACOVF                AC overflow
    DVC                  divide check
    IOC                  I/O check
+
 
    The 701 had one instruction format: memory reference,
 
        00000 000011111111
      S 12345 678901234567
     +-+-----+------------+
+
     | |opcod|  address   | memory reference
     +-+-----+------------+
 
    This routine is the instruction decode routine for the 701.
+
    It is called from the simulator control program to execute
    instructions in simulated memory, starting at the simulated PC.
    It runs until a stop condition occurs.
@@ -60,10 +71,12 @@
    1. Reasons to stop.  The simulator can be stopped by:
 
         HALT instruction
+
         illegal instruction
         illegal I/O operation for device
         illegal I/O operation for channel
         break point encountered
+
         nested XEC's exceeding limit
         divide check
         I/O error in I/O simulator
@@ -73,6 +86,7 @@
       arithmetic for indexing calculations.
 
    4. Adding I/O devices.  These modules must be modified:
+
 
         i7090_defs.h    add device definitions
         i7090_chan.c    add channel subsystem
@@ -145,10 +159,12 @@ extern UNIT         chan_unit[];
 
 /* CPU data structures
 
+
    cpu_dev      CPU device descriptor
    cpu_unit     CPU unit descriptor
    cpu_reg      CPU register list
    cpu_mod      CPU modifiers list
+
 */
 
 UNIT                cpu_unit =
@@ -794,12 +810,8 @@ cpu_ex(t_value * vptr, t_addr addr, UNIT * uptr, int32 sw)
           *vptr &= RMASK;
         else
           *vptr >>= 18;
-    } else { /* swap the half-words in place... */
+    } else /* no swap necessary... */
         *vptr = M[addr & 03777] & 0777777777777L;
-        *vptr ^= (*vptr << 18) & LMASK;
-        *vptr ^= (*vptr >> 18) & RMASK;
-        *vptr ^= (*vptr << 18) & LMASK;
-    }
 
     return SCPE_OK;
 }
@@ -820,12 +832,8 @@ cpu_dep(t_value val, t_addr addr, UNIT * uptr, int32 sw){
           M[a] &= RMASK;
           M[a] |= (val << 18) & LMASK;
         }
-    } else { /* swap the half-words in place... */
-        val ^= (val << 18) & LMASK;
-        val ^= (val >> 18) & RMASK;
-        val ^= (val << 18) & LMASK;
+    } else /* no swap necessary... */
         M[addr & 03777] = val & 0777777777777L; /* set only full word */
-    }
     return SCPE_OK;
 }
 
@@ -968,3 +976,4 @@ cpu_help (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr)
 
 return SCPE_OK;
 }
+

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -415,6 +415,37 @@ find_opcode(char *op, t_opcode * tab)
     return NULL;
 }
 
+/* extract opcode string that may contain spaces
+
+   Inputs:
+        iptr        =   pointer to input string
+        optr        =   pointer to output string
+
+   Outputs
+        result      =   pointer to next character in input string
+*/
+
+CONST char        *
+get_opcode(CONST char *iptr, char *optr)
+{
+
+while ((*iptr != 0) && (*iptr != ',') &&
+       (*iptr == ' ' || ((*iptr >= 'A') && (*iptr <= 'Z')) ||
+                        ((*iptr >= 'a') && (*iptr <= 'z')))) {
+    if (*iptr >= 'a')                   /* force to be upper case */
+        *optr++ = *iptr++ - 32;
+    else *optr++ = *iptr++;
+    }
+if (*iptr == ',')                       /* skip input terminator */
+    iptr++;
+while (*--optr == ' ');                 /* remove trailing spaces */
+optr++;
+*optr = 0;                              /* terminate result string */
+while (isspace (*iptr))                 /* absorb additional input spaces */
+    iptr++;
+return iptr;
+}
+
 /* Symbolic input
 
    Inputs:
@@ -447,7 +478,7 @@ parse_sym(CONST char *cptr, t_addr addr, UNIT * uptr, t_value * val, int32 sw)
         sign = 0;
         
         /* Grab opcode */
-        cptr = get_glyph(cptr, opcode, ',');
+        cptr = get_opcode(cptr, opcode);
 
         if ((op = find_opcode(opcode, base_ops)) != 0) {
             d |= (t_uint64) op->opbase << 12;

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -509,18 +509,18 @@ parse_sym(CONST char *cptr, t_addr addr, UNIT * uptr, t_value * val, int32 sw)
         if (*arg != opcode[0])
             d += (t_value)tag;
         /* ignore any following characters, which can be any form of comments */
-        *val = d & 0777777; /* safety - exactly one instructions per line! */
+        *val = d & 0777777; /* safety - exactly one instruction per line! */
         return SCPE_OK;
     } else if (sw & SWMASK('C')) { /* character string... */
         i = 0;
-        while (*cptr != '\0' && i < 6) {
+        while (*cptr != '\0' && i < (addr < 010000 ? 3 : 6)) {
             d <<= 6;
             if (sim_ascii_to_six[0177 & *cptr] != (const char)-1)
                 d |= sim_ascii_to_six[0177 & *cptr];
             cptr++;
             i++;
         }
-        while (i < 6) {
+        while (i < (addr < 010000 ? 3 : 6)) {
             d <<= 6;
             d |= 060;
             i++;
@@ -539,7 +539,7 @@ parse_sym(CONST char *cptr, t_addr addr, UNIT * uptr, t_value * val, int32 sw)
             d <<= 3;
             d |= *cptr++ - '0';
         }
-        if (addr & 010000) { /* full word... */
+        if (addr > 07777) { /* full word... */
             d &= 0777777777777; /* if too many digits, take right ones! */
             if (sign)
                 d |= 00400000000000L;

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -317,10 +317,10 @@ parse_addr(DEVICE *dptr, const char *cptr, const char **tptr) {
         v <<= 3;
         v += *cptr++ - '0';
     }
-    if (v >= 8192) /* greater than half-word size of MEMSIZE * 2 with sign  */
+    if (v >= 6144) /* >= half-word size of MEMSIZE * 1.5 (with sign)  */
         return 0; /* indicate error?  */
     if (s)
-        v |= 0400000; /* signin instruction format sign bit! */
+        v |= 0400000; /* sign in instruction format sign bit! */
     /* if valid characters have been processed, *tptr == cptr means success! */
     *tptr = cptr;
     return v;
@@ -476,9 +476,15 @@ parse_sym(CONST char *cptr, t_addr addr, UNIT * uptr, t_value * val, int32 sw)
             d <<= 3;
             d |= *cptr++ - '0';
         }
-        d &= 0377777777777; /* in case of too many digits, take right ones! */
-        if (sign)
-            d |= 00400000000000L;
+        if (addr & 010000) { /* full word... */
+            d &= 0777777777777; /* if too many digits, take right ones! */
+            if (sign)
+                d |= 00400000000000L;
+        } else { /* half word... */
+            d &= 0777777; /* if too many digits, take right ones! */
+            if (sign)
+                d |= 00400000L;
+        }
     }
     *val = d;
     return SCPE_OK;

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -190,7 +190,7 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
             for(; *p == ' ' || *p == '\t'; p++);
             /* any lines containing ';' after a data field
                ignore the rest of the line as a comment */
-            while (*p == ';' || *p == '\n' || *p == '\r' || *p == '\0') {
+            while (*p != ';' && *p != '\n' && *p != '\r' && *p != '\0') {
                 for (wd = 0; *p >= '0' && *p <= '7'; p++)
                     wd = (wd << 3) + *p - '0';
                 if (addr > 07777) {

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -214,9 +214,16 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
                 /* advance past white space... */
                 for(; *p == ' ' || *p == '\t'; p++);
             }
+
+            /* ignore line content longer than 80 characters... */
+            while (strchr((char *)buf, '\n') == 0) { /* loop until newline */ 
+                if (fgets((char *)buf, 80, fileref) == 0) {
+                    break; /* Exit if we hit End-of-File mid-line */
+                }
+            }
         }
     } else if (match_ext(fnam, "sym")) {
-        while (fgets((char *)buf, 80, fileref) != 0) {
+        while (fgets((char *)buf, 80, fileref) != 0) { /* must be whole lines */
             for (p = (char *)buf; *p == ' ' || *p == '\t'; p++);
             /* any lines with first meaningful char of ';' are comment lines */
             if (*p == ';' || *p == '\n' || *p == '\r' || *p == '\0')
@@ -235,16 +242,26 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
             } else {
                 parse_sym(p, addr, &cpu_unit, &wd, SWMASK('M'));
             }
-            /* `addr` is half-word address! */
-            dlen = addr >> 1; /* `dlen` is full-word address! */
-            if (dlen < MAXMEMSIZE)
-                if (addr & 1) {
-                    M[dlen] &= LMASK;
-                    M[dlen] |= wd & RMASK;
-                } else {
-                    M[dlen] &= RMASK;
-                    M[dlen] |= (wd << 18) & LMASK;
+            /* `addr` is half-word or full-word address with BCD/OCT address! */
+            if (addr < 014000)
+                if (addr < 07777) { /* for half-word data */
+                    dlen = addr >> 1; /* `dlen` is full-word address! */
+                    if (addr & 1) {
+                        M[dlen] &= LMASK;
+                        M[dlen] |= wd & RMASK;
+                    } else {
+                        M[dlen] &= RMASK;
+                        M[dlen] |= (wd << 18) & LMASK;
+                    }
+                } else /* for full-word data */
+                    M[addr & 03777] = wd & 0777777;
+
+            /* ignore line content longer than 80 characters... */
+            while (strchr((char *)buf, '\n') == 0) { /* loop until newline */ 
+                if (fgets((char *)buf, 80, fileref) == 0) {
+                    break; /* Exit if we hit End-of-File mid-line */
                 }
+            }
         }
     } else
         return SCPE_ARG;

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -186,8 +186,8 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
             /* Grab address; these are may be half or full word addresses! */
             for (addr = 0; *p >= '0' && *p <= '7'; p++)
                 addr = (addr << 3) + *p - '0';
-            /* advance past white space... */
-            for(; *p == ' ' || *p == '\t'; p++);
+            /* advance past ':' (colon) or white space... */
+            for(; *p == ':' || *p == ' ' || *p == '\t'; p++);
             /* any lines containing ';' after a data field
                ignore the rest of the line as a comment */
             while (*p != ';' && *p != '\n' && *p != '\r' && *p != '\0') {
@@ -231,7 +231,8 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
             /* Grab address; this is a half-word address! */
             for (addr = 0; *p >= '0' && *p <= '7'; p++)
                addr = (addr << 3) + *p - '0';
-            while (*p == ' ' || *p == '\t') p++;
+            /* skip over ':' (colon) or white space... */
+            while (*p == ':' || *p == ' ' || *p == '\t') p++;
             if (sim_strncasecmp(p, "BCD", 3) == 0) {
                 p += 3;
                 parse_sym(++p, addr, &cpu_unit, &wd, SWMASK('C'));
@@ -244,7 +245,7 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
             }
             /* `addr` is half-word or full-word address with BCD/OCT address! */
             if (addr < 014000)
-                if (addr < 07777) { /* for half-word data */
+                if (addr < 010000) { /* for half-word data */
                     dlen = addr >> 1; /* `dlen` is full-word address! */
                     if (addr & 1) {
                         M[dlen] &= LMASK;

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -1,10 +1,13 @@
 /* i701_sys.c: IBM 701 Simulator system interface.
 
+
+
    Copyright (c) 2005-2016, Richard Cornwell
 
    Permission is hereby granted, free of charge, to any person obtaining a
    copy of this software and associated documentation files (the "Software"),
    to deal in the Software without restriction, including without limitation
+
    the rights to use, copy, modify, merge, publish, distribute, sublicense,
    and/or sell copies of the Software, and to permit persons to whom the
    Software is furnished to do so, subject to the following conditions:
@@ -13,6 +16,7 @@
    all copies or substantial portions of the Software.
 
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
    RICHARD CORNWELL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
@@ -167,11 +171,7 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
             for (; i < 24 && dlen > 0; i++) {
                 if (addr >= MAXMEMSIZE) /* safety check! */
                     break;
-                wd = lbuff[i]; /* swap half words!... */
-                wd ^= (wd << 18) & LMASK;
-                wd ^= (wd >> 18) & RMASK;
-                wd ^= (wd << 18) & LMASK;
-                M[addr++] = wd;
+                M[addr++] = lbuff[i]; /* no swap necessary... */
                 dlen--;
             }
         }
@@ -194,15 +194,9 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
                 for (wd = 0; *p >= '0' && *p <= '7'; p++)
                     wd = (wd << 3) + *p - '0';
                 if (addr > 07777) {
-                    /* `addr` & 03777 is full-word address!... */
-                    dlen = addr & 03777;
-                    if (dlen < MAXMEMSIZE) {
-                        wd ^= (wd << 18) & LMASK; /* swap half words!... */
-                        wd ^= (wd >> 18) & RMASK;
-                        wd ^= (wd << 18) & LMASK;
-                        M[dlen] = wd & 0777777777777;
-                        addr++;
-                    }
+                    if (dlen < MAXMEMSIZE)
+                        /* `addr` & 03777 is full-word address!... */
+                        M[addr++ & 03777] = wd & 0777777777777; /* no swap necessary... */
                 } else {
                     /* `addr` is half-word address! */
                     dlen = addr >> 1; /* `dlen` is now a full-word address! */

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -167,38 +167,57 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
             for (; i < 24 && dlen > 0; i++) {
                 if (addr >= MAXMEMSIZE) /* safety check! */
                     break;
-                M[addr++] = lbuff[i];
+                wd = lbuff[i]; /* swap half words!... */
+                wd ^= (wd << 18) & LMASK;
+                wd ^= (wd >> 18) & RMASK;
+                wd ^= (wd << 18) & LMASK;
+                M[addr++] = wd;
                 dlen--;
             }
         }
     } else if (match_ext(fnam, "oct")) {
         while (fgets((char *)buf, 80, fileref) != 0) {
+            /* Grab address; these are may be half or full word addresses! */
+            /* advance past white space... */
             for(p = (char *)buf; *p == ' ' || *p == '\t'; p++);
             /* any lines with first meaningful char of ';' are comment lines */
             if (*p == ';' || *p == '\n' || *p == '\r')
                 continue; /* skip lines with no meaningful content! */
-            /* Grab address; these are half-word addresses! */
+            /* Grab address; these are may be half or full word addresses! */
             for (addr = 0; *p >= '0' && *p <= '7'; p++)
                 addr = (addr << 3) + *p - '0';
-            while (*p != '\n' && *p != '\0') {
-                for(; *p == ' ' || *p == '\t'; p++);
-                /* any lines containing ';' after a data field
-                   ignore the rest of the line as a comment */
-                if (*p == ';' || *p == '\n' || *p == '\r' || *p == '\0')
-                    break; /* advance line when no meaningful content! */
+            /* advance past white space... */
+            for(; *p == ' ' || *p == '\t'; p++);
+            /* any lines containing ';' after a data field
+               ignore the rest of the line as a comment */
+            while (*p == ';' || *p == '\n' || *p == '\r' || *p == '\0') {
                 for (wd = 0; *p >= '0' && *p <= '7'; p++)
                     wd = (wd << 3) + *p - '0';
-                /* `addr` is half-word address! */
-                dlen = addr >> 1; /* `dlen` is full-word address! */
-                if (dlen < MAXMEMSIZE)
-                    if (addr & 1) {
-                        M[dlen] &= LMASK;
-                        M[dlen] |= wd & RMASK;
+                if (addr > 07777) {
+                    /* `addr` & 03777 is full-word address!... */
+                    dlen = addr & 03777;
+                    if (dlen < MAXMEMSIZE) {
+                        wd ^= (wd << 18) & LMASK; /* swap half words!... */
+                        wd ^= (wd >> 18) & RMASK;
+                        wd ^= (wd << 18) & LMASK;
+                        M[dlen] = wd & 0777777777777;
                         addr++;
-                    } else {
-                        M[dlen] &= RMASK;
-                        M[dlen] |= (wd << 18) & LMASK;
                     }
+                } else {
+                    /* `addr` is half-word address! */
+                    dlen = addr >> 1; /* `dlen` is now a full-word address! */
+                    if (dlen < MAXMEMSIZE)
+                        if (addr & 1) {
+                            M[dlen] &= LMASK;
+                            M[dlen] |= wd & RMASK;
+                            addr++;
+                        } else {
+                            M[dlen] &= RMASK;
+                            M[dlen] |= (wd << 18) & LMASK;
+                        }
+                }
+                /* advance past white space... */
+                for(; *p == ' ' || *p == '\t'; p++);
             }
         }
     } else if (match_ext(fnam, "sym")) {

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -138,7 +138,7 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
         t_uint64            lbuff[24];
         int                 i;
 
-        while (sim_fread(cbuf, 2, 80, fileref) == 80) {
+        while (addr < MAXMEMSIZE && sim_fread(cbuf, 2, 80, fileref) == 80) {
 
             /* Bit flip into read buffer */
             for (i = 0; i < 24; i++) {
@@ -165,41 +165,72 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
                 dlen = (int)(lbuff[0] >> 18) & 077777;
             }
             for (; i < 24 && dlen > 0; i++) {
+                if (addr >= MAXMEMSIZE) /* safety check! */
+                    break;
                 M[addr++] = lbuff[i];
                 dlen--;
             }
         }
     } else if (match_ext(fnam, "oct")) {
         while (fgets((char *)buf, 80, fileref) != 0) {
-             for(p = (char *)buf; *p == ' ' || *p == '\t'; p++);
-            /* Grab address */
-             for(addr = 0; *p >= '0' && *p <= '7'; p++)
+            for(p = (char *)buf; *p == ' ' || *p == '\t'; p++);
+            /* any lines with first meaningful char of ';' are comment lines */
+            if (*p == ';' || *p == '\n' || *p == '\r')
+                continue; /* skip lines with no meaningful content! */
+            /* Grab address; these are half-word addresses! */
+            for (addr = 0; *p >= '0' && *p <= '7'; p++)
                 addr = (addr << 3) + *p - '0';
-             while(*p != '\n' && *p != '\0') {
+            while (*p != '\n' && *p != '\0') {
                 for(; *p == ' ' || *p == '\t'; p++);
-                for(wd = 0; *p >= '0' && *p <= '7'; p++)
+                /* any lines containing ';' after a data field
+                   ignore the rest of the line as a comment */
+                if (*p == ';' || *p == '\n' || *p == '\r' || *p == '\0')
+                    break; /* advance line when no meaningful content! */
+                for (wd = 0; *p >= '0' && *p <= '7'; p++)
                     wd = (wd << 3) + *p - '0';
-                if (addr < MAXMEMSIZE)
-                    M[addr++] = wd;
-             }
+                /* `addr` is half-word address! */
+                dlen = addr >> 1; /* `dlen` is full-word address! */
+                if (dlen < MAXMEMSIZE)
+                    if (addr & 1) {
+                        M[dlen] &= LMASK;
+                        M[dlen] |= wd & RMASK;
+                        addr++;
+                    } else {
+                        M[dlen] &= RMASK;
+                        M[dlen] |= (wd << 18) & LMASK;
+                    }
+            }
         }
-    } else if (match_ext(fnam, "txt")) {
+    } else if (match_ext(fnam, "sym")) {
         while (fgets((char *)buf, 80, fileref) != 0) {
-             for(p = (char *)buf; *p == ' ' || *p == '\t'; p++);
-             /* Grab address */
-             for(addr = 0; *p >= '0' && *p <= '7'; p++)
-                addr = (addr << 3) + *p - '0';
-             while(*p == ' ' || *p == '\t') p++;
-             if(sim_strncasecmp(p, "BCD", 3) == 0) {
-                 p += 3;
-                 parse_sym(++p, addr, &cpu_unit, &M[addr], SWMASK('C'));
-             } else if (sim_strncasecmp(p, "OCT", 3) == 0) {
-                 p += 3;
-                 for(; *p == ' ' || *p == '\t'; p++);
-                 parse_sym(p, addr, &cpu_unit, &M[addr], 0);
-             } else {
-                 parse_sym(p, addr, &cpu_unit, &M[addr], SWMASK('M'));
-             }
+            for (p = (char *)buf; *p == ' ' || *p == '\t'; p++);
+            /* any lines with first meaningful char of ';' are comment lines */
+            if (*p == ';' || *p == '\n' || *p == '\r' || *p == '\0')
+                continue; /* skip lines with no meaningful content! */
+            /* Grab address; this is a half-word address! */
+            for (addr = 0; *p >= '0' && *p <= '7'; p++)
+               addr = (addr << 3) + *p - '0';
+            while (*p == ' ' || *p == '\t') p++;
+            if (sim_strncasecmp(p, "BCD", 3) == 0) {
+                p += 3;
+                parse_sym(++p, addr, &cpu_unit, &wd, SWMASK('C'));
+            } else if (sim_strncasecmp(p, "OCT", 3) == 0) {
+                p += 3;
+                for(; *p == ' ' || *p == '\t'; p++);
+                parse_sym(p, addr, &cpu_unit, &wd, 0);
+            } else {
+                parse_sym(p, addr, &cpu_unit, &wd, SWMASK('M'));
+            }
+            /* `addr` is half-word address! */
+            dlen = addr >> 1; /* `dlen` is full-word address! */
+            if (dlen < MAXMEMSIZE)
+                if (addr & 1) {
+                    M[dlen] &= LMASK;
+                    M[dlen] |= wd & RMASK;
+                } else {
+                    M[dlen] &= RMASK;
+                    M[dlen] |= (wd << 18) & LMASK;
+                }
         }
     } else
         return SCPE_ARG;
@@ -260,38 +291,38 @@ const char *chname[] = { "*" };
 
    Inputs:
         *dptr   =       pointer to device.
-        *cptr   =       pointer to string.
-        **tptr  =       pointer to final scaned character.
+        *cptr   =       pointer to string to scan.
+        **tptr  =       pointer past the last scanned character.
    Outputs:
         address with sign.
 */
 
 t_addr
 parse_addr(DEVICE *dptr, const char *cptr, const char **tptr) {
-    t_addr      v;
+    t_addr      v = 0;
     int         s = 0;
-    *tptr = cptr;
     if (dptr != &cpu_dev)
         return 0;
-    v = 0;
+    /* Skip white space */
+    while (isspace(*cptr))
+        cptr++;
     if (*cptr == '-') {
         cptr++;
         s = 1;
-    }
+    } else
+        if (*cptr == '+')
+            cptr++;
+    *tptr = cptr;
     while(*cptr >= '0' && *cptr <= '7') {
         v <<= 3;
         v += *cptr++ - '0';
     }
-    if (v > 4096)
-        return 0;
-    if (s) {
-        if ((cptr - 1) != *tptr)
-            *tptr = cptr;
-        v |= 0400000;
-    } else {
-        if (cptr != *tptr)
-            *tptr = cptr;
-    }
+    if (v >= 8192) /* greater than half-word size of MEMSIZE * 2 with sign  */
+        return 0; /* indicate error?  */
+    if (s)
+        v |= 0400000; /* signin instruction format sign bit! */
+    /* if valid characters have been processed, *tptr == cptr means success! */
+    *tptr = cptr;
     return v;
 }
 
@@ -323,25 +354,13 @@ fprint_sym(FILE * of, t_addr addr, t_value * val, UNIT * uptr, int32 sw)
     fprint_val(of, inst, 8, 36, PV_RZRO);
 
     if (sw & SWMASK('M')) {
-        int     op = (int)(inst >> (12+18));
+        int     op = (int)(inst >> 12);
         int     i;
-        fputs("  rt  ", of);
-        if (op != (040 + 13))
+        if (op != (040 + 13)) /* if EXTR instruction... */
            op &= 037;
-        for(i = 0; base_ops[i].name != NULL; i++) {
-            if (base_ops[i].opbase == op) {
-                fputs(base_ops[i].name, of);
-                break;
-            }
-        }
-        fputc(' ', of);
-        if ((inst >> 18) & 0400000L)
-            fputc('-', of);
-        fprint_val(of, (inst >> 18) & 0000000007777L, 8, 12, PV_RZRO);
-        op = (int)(inst >> 12);
-        fputs(" lt  ", of);
-        if (op != (040 + 13))
-           op &= 037;
+        fputs("      ", of); /* space between octal value and sym value */
+        if (addr > 07777)
+            return SCPE_ARG;
         for(i = 0; base_ops[i].name != NULL; i++) {
             if (base_ops[i].opbase == op) {
                 fputs(base_ops[i].name, of);
@@ -407,15 +426,12 @@ parse_sym(CONST char *cptr, t_addr addr, UNIT * uptr, t_value * val, int32 sw)
     while (isspace(*cptr))
         cptr++;
     d = 0;
-    if (sw & SWMASK('M')) {
+    if (sw & SWMASK('M')) { /* symbolic code... */
         t_opcode           *op;
 
         i = 0;
         sign = 0;
-next:
-        /* Skip blanks */
-        while (isspace(*cptr))
-            cptr++;
+        
         /* Grab opcode */
         cptr = get_glyph(cptr, opcode, ',');
 
@@ -429,16 +445,10 @@ next:
         tag = parse_addr(&cpu_dev, opcode, &arg);
         if (*arg != opcode[0])
             d += (t_value)tag;
-        if (*cptr == ',') {
-            d <<= 18;
-            cptr++;
-            goto next;
-        }
-        if (*cptr != '\0')
-            return STOP_UUO;
-        *val = d;
+        /* ignore any following characters, which can be any form of comments */
+        *val = d & 0777777; /* safety - exactly one instructions per line! */
         return SCPE_OK;
-    } else if (sw & SWMASK('C')) {
+    } else if (sw & SWMASK('C')) { /* character string... */
         i = 0;
         while (*cptr != '\0' && i < 6) {
             d <<= 6;
@@ -452,7 +462,8 @@ next:
             d |= 060;
             i++;
         }
-    } else {
+        d &= 0777777777777; /* in case of too many digits, take right ones! */
+    } else { /* octal... */
         if (*cptr == '-') {
             sign = 1;
             cptr++;
@@ -465,6 +476,7 @@ next:
             d <<= 3;
             d |= *cptr++ - '0';
         }
+        d &= 0377777777777; /* in case of too many digits, take right ones! */
         if (sign)
             d |= 00400000000000L;
     }

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -206,15 +206,16 @@ sim_load(FILE * fileref, CONST char *cptr, CONST char *fnam, int flag)
                 } else {
                     /* `addr` is half-word address! */
                     dlen = addr >> 1; /* `dlen` is now a full-word address! */
-                    if (dlen < MAXMEMSIZE)
+                    if (dlen < MAXMEMSIZE) {
                         if (addr & 1) {
                             M[dlen] &= LMASK;
                             M[dlen] |= wd & RMASK;
-                            addr++;
                         } else {
                             M[dlen] &= RMASK;
                             M[dlen] |= (wd << 18) & LMASK;
                         }
+                        addr++;
+                   }
                 }
                 /* advance past white space... */
                 for(; *p == ' ' || *p == '\t'; p++);

--- a/I7000/i701_sys.c
+++ b/I7000/i701_sys.c
@@ -351,7 +351,7 @@ fprint_sym(FILE * of, t_addr addr, t_value * val, UNIT * uptr, int32 sw)
 
 /* Print value in octal first */
     fputc(' ', of);
-    fprint_val(of, inst, 8, 36, PV_RZRO);
+    fprint_val(of, inst, 8, addr > 07777 ? 36 : 18, PV_RZRO);
 
     if (sw & SWMASK('M')) {
         int     op = (int)(inst >> 12);
@@ -379,7 +379,7 @@ fprint_sym(FILE * of, t_addr addr, t_value * val, UNIT * uptr, int32 sw)
         int                 i;
 
         fputs("   '", of);
-        for (i = 5; i >= 0; i--) {
+        for (i = addr > 07777 ? 5 : 2; i >= 0; i--) {
             int                 ch;
 
             ch = (int)(inst >> (6 * i)) & 077;


### PR DESCRIPTION
The current version of the IBM 701 simulation is quite broken as to dealing with beng a half-word 18-bit processor.

Half-word 18-bit transfers are this computer's default addressing mode, but it has a means of overriding for the instruction referencing to be able to also transfer 36-bit full words at a time.  The similated execution using these execution addressing modes isn't the problem, it's the UI interface with the simulator that isn't consistent in how it converts the two different views (18-bit half word and 36-bit full word) of the memory for the EXAMINE, DEPOSIT, EVAL, and LOAD commands.

The changes are probably too many to list individually, but other than some grammar and typo correction, they fall into the following categories:

1. The EXAMINE and DEPOSIT work and look so much better with the rule that any address up to 4095 (4K) is treated as a half-word address, and any address above that to 6143 (from 4K to 6K) is treated as a full-word address thus actually covering the same memory range.  Thus, the upper 4K bit serves as a marker on when to switch from half-word to full-word addressing.

2. For ease of use, all half-word outputs are right justified six digits with leading zeros.

3. Again, for ease of use, all half-word inputs are treated as right justified with no leading zeros required (although they can be used).

4. With the above scheme, ranges work as expected with a range of full-word addresses only needing to be half as many addresses to cover the same address range as the same count of half-word addresses, although full-word addresses are always forced start at an even half-word addresses.

5. Since it works as described above, any address above 6143 (6K) is a "Address space exeeded" error.

6. Both character mode (-c option) and octal mode (the default option) work as described above, with the addressing depending on the address range with the set upper bit the deciding test on which to use (set is full-word; unset is half-word, so half-word is the easiest to access and use as that is what is required most frequently). 

7. Assembly mode (the -m option) should only be used for half-word addresses as all assembly instructions occupy one half-word of memory space.  if one tries to EXAMINE full-word memory addresses with `-m` mode, the view automatically drops to viewing the full-word octal memory contents twice, once for the usual display of octal data, and once replacing what would normally be the disassembly display.  The DEPOSIT command should never be used with the `-m` mode and full-word addresses as the assembly will be made only to only even numbered half-word addresses.

8. More masks and checks are used  for safety to ensure that the stored and retrieved half-word/full-word data is consistent to each bit range.

9. In order to be consistent to the big-endian memory model of IBM computer and since the words are flipped for half-word use, they are also flipped for full-word use in order to be consistent between the two views.  A perhaps better alternative would have been to do no flipping at all for either mode, but that would have required that the code execution simulator also be changed to be consistent with this non-flipped memory view.

10. The help string line mentioning the `-l` switch to use half-mode view of memory was removed as this switch seems to no longer be used.

11. For the LOAD command for "*.crd" card files, the only change is to add a maximum memory check to stop reading when the memory is full.

12. The main change to reading of "*.oct" files other than correcting the swapping in using the LOAD command is that any line starting with the `;` character (optionally preceeded by white space) or any characters past the one octal data field are treated as comments in the file.  All of these octal files are assumed to use half-word addressing.

13. The same changes as for the octal files is also applied to using the LOAD command on (*.sym) files as to using comments and correcting the half-word flipping; half-word addressing must always be used with these files.

14. Similar changes are also made to the parsing and printing of the various types of allowed symbols (octal and symbolic) as to range checks and safety masking.

In short, the simulator didn't work before; after these changes it does, although there may still be a few bugs.

Further work should be done on formally testing this and the execution engine, but this is far enough for one PR...

EXAMPLES OF BEFORE AND AFTER USE OF THE SIMULATOR:

BEFORE:

```
sim> eval -m tr -42
0:	 000000010042  rt  STOP 0000 lt  TR  -0042
sim> eval 4735
0:	 000000004735
sim> d 0/7 420037
sim> e 0/4
0:	 000000000000
1:	 000000000000
2:	 000000000000
3:	 000000000000
sim> e -c 0/4
0:	 000000000000   '      '
1:	 000000000000   '      '
2:	 000000000000   '      '
3:	 000000000000   '      '
sim> e -m 0/4
0:	 000000000000  rt  STOP 0000 lt  STOP  0000
1:	 000000000000  rt  STOP 0000 lt  STOP  0000
2:	 000000000000  rt  STOP 0000 lt  STOP  0000
3:	 000000000000  rt  STOP 0000 lt  STOP  0000
```

AFTER:

```
sim> eval -m tr -42
0:	 000000410042      TR -0042
sim> eval 4735
0:	 000000004735
sim> d 0/4 420037
sim> e 0/4
0:	 000000420037
1:	 000000420037
2:	 000000420037
3:	 000000420037
sim> e -c 0/4
0:	 000000420037   '   K #'
1:	 000000420037   '   K #'
2:	 000000420037   '   K #'
3:	 000000420037   '   K #'
sim> e -m 0/4
0:	 000000420037      TRO -0037
1:	 000000420037      TRO -0037
2:	 000000420037      TRO -0037
3:	 000000420037      TRO -0037
```

Most importantly, the LOAD command now works for octal and symbolic files:

Given a "test.oct" file containing the following:

```
; a header for the octal test file...

10 000005 ; some random comment
11 000007
12 000000
```

```
sim> d 10003/3 -377777777777
sim> e 6/6
6:	 000000777777
7:	 000000777777
10:	 000000777777
11:	 000000777777
12:	 000000777777
13:	 000000777777
sim> load test.oct
sim> e 6/6
6:	 000000777777
7:	 000000777777
10:	 000000000005
11:	 000000000007
12:	 000000000000
13:	 000000777777
```

and accepts the following "test.sym" file containing the following, assemblying and storing the proper binary machine instructions and the data into the proper locations while ignoring the comment fields:

```
; LOAD test file of IBM 701 assembly code...

0 ADD 10     ; dummy program comment!
1 ADD, +11
2 STORE,+12
3 STOP,+0

10 OCT 5     ; comments in the data section!
11 OCT 7
12 OCT 0
13 BCD ab c de ; another comment here!

; blank line preceeding the end of file!
```

```
sim> d 0/5 777777
sim> e 0/5
0:	 000000777777
1:	 000000777777
2:	 000000777777
3:	 000000777777
4:	 000000777777
sim> load test.sym
sim> e -m 0/5
0:	 000000110010      ADD  0010
1:	 000000110011      ADD  0011
2:	 000000140012      STORE  0012
3:	 000000000000      STOP  0000
4:	 000000777777      COPY -7777
```

The additional second commit corrects a deficiency in handling symbol parsing of negative signed octal half-word data (addresses up to 07777 octal) and non-negative octal full-word data (addresses above 010000 octal).

PREVIOuS TO CHANGE:

```
sim> d all 777777
sim> e 0/4
0:	 000000777777
1:	 000000777777
2:	 000000777777
3:	 000000777777
sim> d 1/2 -20037
sim> e 0/4
0:	 000000777777
1:	 000000020037
2:	 000000020037
3:	 000000777777
sim> d all 777777
sim> e 0/10
0:	 000000777777
1:	 000000777777
2:	 000000777777
3:	 000000777777
4:	 000000777777
5:	 000000777777
6:	 000000777777
7:	 000000777777
sim> d 10001/2 424242373737
sim> e 0/10
0:	 000000777777
1:	 000000777777
2:	 000000373737
3:	 000000024242
4:	 000000373737
5:	 000000024242
6:	 000000777777
7:	 000000777777
```

AFTER CHANGE:

```
sim> d all 777777
sim> e 0/4
0:	 000000777777
1:	 000000777777
2:	 000000777777
3:	 000000777777
sim> d 1/2 -20037
sim> e 0/4
0:	 000000777777
1:	 000000420037
2:	 000000420037
3:	 000000777777
sim> d all 777777
sim> e 0/10
0:	 000000777777
1:	 000000777777
2:	 000000777777
3:	 000000777777
4:	 000000777777
5:	 000000777777
6:	 000000777777
7:	 000000777777
sim> d 10001/2 424242373737
sim> e 0/10
0:	 000000777777
1:	 000000777777
2:	 000000373737
3:	 000000424242
4:	 000000373737
5:	 000000424242
6:	 000000777777
7:	 000000777777
```

Also, the third commit makes changes so rather than print all octal data values as 12 octal digits, it now prints half-word octal numbers with 6 octal digits, and instead of always printing  half-word BCD values as 6 BCD characters with the leading three charactars as spaces, it now prints half-word BCD values with just three BCD characters.

Another change was made as the fourth commit to correct the use of the LOAD command of "*.crd" files in that the full-word data needs to be swapped into big-endian just as in all the other occurences, and improves the use with "*.oct" files in that now full-word addresses marked by being between octal addresses of 010000 and 013777 along with full-word data are now handled.  **THE SWAPPING OF FULL-WORD ACCESSES HAS NOW BEEN REVERTED AS THAT IS NOT THE WAY THE IBM 701 IS SPECIFIED**, although the addressing fixes from this commit were kept.

Next, the IBM 701 is the only computer in the i7000 series that is specified with internal spaces in its assembly instruction mnemonics such as "R ADD", etc.; these mnemonics with spaces could not be parsed correctly by the mini-assembler built into the simulator as the general `get_glyph` function can only get glyph's that do not contain spaces.

A commit fixes that by replacing the use of `get_glyph` for the fetching of the instruction opcode from the input text stream with a simple `get_opcode` function that does all the things that `get_glyph` does as in converting to upper case and optionally stopping at a ',' character but also allowing internal space characters, which may result in  trailing space characters so these are stripped off by the function.

As originally written, the LOAD programming does not handle file lines greater than 80 characters and the extra characters read for what is assumed to be the next line cause erratic text stream interpretation behaviour.

A commit fixes that by doing repeated reads on the characters following the beginning of each line until a line feed character is reached; this is implemented both for "*.oct" files and "*.sym" files where it was considered that "*.crd" (Card Reader Data) files will have to be the correct length due to cards being exactly 80 characters long by specification and by implementation.

A minor commit makes having a colon (':') after the address field acceptable when using the LOAD command for "*.oct" or "*.sym" files in order to be consistent with the way the address field is displayed by the EXAMINE and EVAL commands, which show a colon immediately after the octal address.

Finally, a minor commit was made to ignore colon (':') characters after the first octal address field in "*.oct" and "*.sym" files when the LOAD command is used on them; this makes the LOAD command accept formats that look like as printed by the EVAL and EXAMINE commands, which include a colon immediately after the octal address field to make it more human readable.