### PR TITLE
KA10: Fix DDC device bugs.

### DIFF
--- a/PDP10/kx10_ddc.c
+++ b/PDP10/kx10_ddc.c
@@ -184,7 +184,9 @@ t_stat ddc_devio(uint32 dev, uint64 *data) {
         if (*data & DDC_EXF) {  /* Execute FR */
         }
         if (*data & DDC_EXQ) {  /* Execute Queue */
-           if (!sim_is_active(uptr)) {
+           if ((uptr->flags & UNIT_ATT) == 0)
+              uptr->STATUS |= DDC_HUD;
+           else if (!sim_is_active(uptr)) {
                sim_activate(uptr, 100);
                uptr->POS = 0;
            }

--- a/PDP10/kx10_ddc.c
+++ b/PDP10/kx10_ddc.c
@@ -74,8 +74,8 @@
 #define DDC_SEQ         0003700000000LL    /* Sequence number */
 #define DDC_PIA         0000070000000LL    /* PIA */
 #define DDC_FUNC        0000006000000LL    /* Function */
-#define DDC_READ        0000002000000LL
-#define DDC_WRITE       0000004000000LL
+#define DDC_WRITE       1
+#define DDC_READ        2
 #define DDC_DISK        0000001400000LL    /* Logical Disc */
 #define DDC_TRK         0000000377600LL    /* Track */
 #define DDC_SEC         0000000000177LL    /* Sector */
@@ -286,12 +286,12 @@ t_stat ddc_svc (UNIT *uptr)
             ddc_buf[wc] = 0;
    }
 
-   if (func == 2) {
+   if (func == DDC_READ) {
        if (Mem_write_word(adr, &ddc_buf[uptr->POS], 0)) {
            uptr->STATUS |= DDC_NXM;
            goto done;
        }
-   } else if (func == 1) {
+   } else if (func == DDC_WRITE) {
        if (Mem_read_word(adr, &ddc_buf[uptr->POS], 0)) {
           uptr->STATUS |= DDC_NXM;
           goto done;
@@ -304,7 +304,7 @@ t_stat ddc_svc (UNIT *uptr)
 
    if (uptr->POS == DDC10_WDS) {
 done:
-       if (func == 2) {
+       if (func == DDC_WRITE) {
           int da;
           da = ((trk * 13) + sec) * DDC10_WDS;
           (void)sim_fseek(duptr->fileref, da * sizeof(uint64), SEEK_SET);


### PR DESCRIPTION
- Fix crash when no file is attached.  Change CONO bit to execute the command queue to raise error instead of activating the interrupt service if there is no file attached.  Fixes #340.
- Fix device function codes.  Per TENEX monitor sources, the DDC codes are 1B16 for write and 2B16 for read.  Fixes #342.

Thanks to @ajfa for finding the bugs.